### PR TITLE
Feature/add deadreckoner node

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,3 +1,5 @@
+>* Modified 5/13/2019: Added the deadreckoner node from the AutonomouStuff fork of Autoware
+>  - Michael McConnell
 >* Creation 5/10/2019: Added document to describe fork status and record modifications to repository
 >  - Kyle Rush
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
->* Modified 5/13/2019: Added the deadreckoner node from the AutonomouStuff fork of Autoware
->  - Michael McConnell
 >* Modified 5/10/2019: Added notice section describing fork status and providing instructions for developers
 >  - Kyle Rush
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+>* Modified 5/13/2019: Added the deadreckoner node from the AutonomouStuff fork of Autoware
+>  - Michael McConnell
 >* Modified 5/10/2019: Added notice section describing fork status and providing instructions for developers
 >  - Kyle Rush
 

--- a/ros/src/computing/perception/localization/packages/deadreckoner/CMakeLists.txt
+++ b/ros/src/computing/perception/localization/packages/deadreckoner/CMakeLists.txt
@@ -1,0 +1,42 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(deadreckoner)
+
+add_compile_options(-std=c++11)
+
+find_package(catkin REQUIRED COMPONENTS
+  roscpp
+  std_msgs
+  nav_msgs
+  geometry_msgs
+)
+
+catkin_package(
+#  INCLUDE_DIRS include
+#  LIBRARIES deadreckoner
+#  CATKIN_DEPENDS other_catkin_pkg
+#  DEPENDS system_lib
+)
+
+include_directories(
+  ${catkin_INCLUDE_DIRS}
+)
+
+add_executable(deadreckoner
+  nodes/deadreckoner_node.cpp
+  nodes/deadreckoner.cpp
+)
+
+target_link_libraries(deadreckoner
+  ${catkin_LIBRARIES}
+)
+
+install(TARGETS
+  deadreckoner
+  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+
+install(DIRECTORY launch/
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/launch
+)

--- a/ros/src/computing/perception/localization/packages/deadreckoner/README.md
+++ b/ros/src/computing/perception/localization/packages/deadreckoner/README.md
@@ -1,0 +1,3 @@
+## Deadreckoner Package
+This package is responsible for providing odometry to NDT Matching. Currently only the Twist field of the nav_msgs::Odometry message is populated. 
+This node was originally developed by AutonomouStuff and the git history can be found in their fork of the Autoware repo (https://github.com/astuff/autoware). 

--- a/ros/src/computing/perception/localization/packages/deadreckoner/launch/deadreckoner.launch
+++ b/ros/src/computing/perception/localization/packages/deadreckoner/launch/deadreckoner.launch
@@ -1,0 +1,12 @@
+<!-- -->
+<launch>
+
+  <arg name="current_twist" default="/vehicle/twist" />
+  <arg name="current_odom" default="/vehicle/odom" />
+
+  <node pkg="deadreckoner" type="deadreckoner" name="deadreckoner" output="screen">
+    <remap from="current_twist" to="$(arg current_twist)" />
+    <remap from="current_odom" to="$(arg current_odom)" />
+  </node>
+
+</launch>

--- a/ros/src/computing/perception/localization/packages/deadreckoner/nodes/deadreckoner.cpp
+++ b/ros/src/computing/perception/localization/packages/deadreckoner/nodes/deadreckoner.cpp
@@ -1,0 +1,50 @@
+/*
+ *  Copyright (c) 2017, Nagoya University
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither the name of Autoware nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ *  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ *  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ *  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include "deadreckoner.h"
+
+DeadRecokner::DeadRecokner() : nh_(), private_nh_("~")
+{
+  twist_sub_ = nh_.subscribe("current_twist", 10, &DeadRecokner::callbackFromCurrentTwist, this);
+  odom_pub_ = nh_.advertise<nav_msgs::Odometry>("current_odom", 10);
+}
+
+DeadRecokner::~DeadRecokner()
+{
+}
+
+void DeadRecokner::callbackFromCurrentTwist(const geometry_msgs::TwistStampedConstPtr& msg)
+{
+  // TODO: calurate odom.pose.pose by accumulating
+  nav_msgs::Odometry odom;
+  odom.header = msg->header;
+  odom.twist.twist = msg->twist;
+  odom_pub_ .publish(odom);
+}

--- a/ros/src/computing/perception/localization/packages/deadreckoner/nodes/deadreckoner.h
+++ b/ros/src/computing/perception/localization/packages/deadreckoner/nodes/deadreckoner.h
@@ -1,0 +1,50 @@
+/*
+ *  Copyright (c) 2017, Nagoya University
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither the name of Autoware nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"geometry
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ *  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ *  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ *  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef DEADRECKONER_H
+#define DEADRECKONER_H
+
+#include <ros/ros.h>
+#include <nav_msgs/Odometry.h>
+#include <geometry_msgs/TwistStamped.h>
+
+class DeadRecokner
+{
+public:
+  DeadRecokner();
+  ~DeadRecokner();
+private:
+  ros::NodeHandle nh_, private_nh_;
+  ros::Subscriber twist_sub_;
+  ros::Publisher odom_pub_;
+  
+  void callbackFromCurrentTwist(const geometry_msgs::TwistStampedConstPtr& msg);
+};
+#endif  // DEADRECKONER_H

--- a/ros/src/computing/perception/localization/packages/deadreckoner/nodes/deadreckoner_node.cpp
+++ b/ros/src/computing/perception/localization/packages/deadreckoner/nodes/deadreckoner_node.cpp
@@ -1,0 +1,41 @@
+/*
+ *  Copyright (c) 2017, Nagoya University
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither the name of Autoware nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ *  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ *  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ *  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include <ros/ros.h>
+
+#include "deadreckoner.h"
+
+int main(int argc, char** argv)
+{
+  ros::init(argc, argv, "deadreckoner");
+  DeadRecokner node;
+  ros::spin();
+  return 0;
+}

--- a/ros/src/computing/perception/localization/packages/deadreckoner/package.xml
+++ b/ros/src/computing/perception/localization/packages/deadreckoner/package.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<package>
+  <name>deadreckoner</name>
+  <version>0.0.0</version>
+  <description>The deadreckoner package</description>
+
+  <maintainer email="aohsato@gmail.com">Akihito Ohsato</maintainer>
+
+  <license>TODO</license>
+
+  <author email="aohsato@gmail.com">Akihito Ohsato</author>
+
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <export>
+  </export>
+
+</package>


### PR DESCRIPTION
This PR adds the deadreckoner node from the AStuff fork of autoware. Node was added via copy and paste. 