### PR TITLE
Feature/load map cells from arealist

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,8 +1,3 @@
->* Modified 5/13/2019: Added the deadreckoner node from the AutonomouStuff fork of Autoware
->  - Michael McConnell
->* Creation 5/10/2019: Added document to describe fork status and record modifications to repository
->  - Kyle Rush
-
 ## Note
 This is a fork of Autoware containing modifications to support usage with the [CARMAPlatform](https://github.com/usdot-fhwa-stol/CARMAPlatform). This repository will contain changes to the Autoware source code and configuration which may not be supported by the Autoware Foundation and may not be consistent the original design intent of Autoware. All modifications in this repository are licensed under the same Apache License 2.0 as Autoware and all modifications of the source code made will be marked as such in accordance with the terms of the Apache License 2.0. For a list of modifications and their descriptions please see [NOTICE.md](NOTICE.md).
 
@@ -15,6 +10,12 @@ For any modified file please follow these steps to ensure proper documentation o
 - Addition of notice about fork status to the README.md and creation of this NOTICE.md file
   - 5/10/2019
   - Kyle Rush
+- Added the deadreckoner node from the AutonomouStuff fork of Autoware
+  - 5/13/2019
+  - Michael McConnell
 - Modified points_map_loader package to publish the tf from map to ECEF frame using tf2 library
-  - 5/7/2019
+  - 6/7/2019
   - Shuwei Qiang
+- Modified points_map_loader package to have option for loading map cells from arealist.txt file directly instead of using redundant file paths as well as improved launch file
+  - 6/25/2019
+  - Michael McConnell

--- a/ros/src/data/packages/map_file/CMakeLists.txt
+++ b/ros/src/data/packages/map_file/CMakeLists.txt
@@ -1,4 +1,9 @@
 cmake_minimum_required(VERSION 2.8.3)
+#
+#- Modified to install new config folder at install time
+#    - 6/25/2019
+#    - Michael McConnell
+#
 project(map_file)
 
 include(FindPkgConfig)
@@ -91,4 +96,7 @@ install(DIRECTORY include/${PROJECT_NAME}/
 
 install(DIRECTORY launch/
         DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/launch
+        PATTERN ".svn" EXCLUDE)
+install(DIRECTORY config/
+        DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/config
         PATTERN ".svn" EXCLUDE)

--- a/ros/src/data/packages/map_file/config/params.yaml
+++ b/ros/src/data/packages/map_file/config/params.yaml
@@ -1,3 +1,4 @@
 # Double List: Transform describing the map frame in the ECEF frame as a translation and quaternion rotation
+# Translation followed by rotation quaternion [x,y,z,rx,ry,rz,rw]
 # Units: [m, m, m, rad, rad, rad, rad]
-map_1_origin: [1104880.0, -4842200.0, 3988270.0, 0.848612, -0.0638497, 0.525148, 0.863712]
+map_1_origin: [1104880.0, -4842200.0, 3988270.0, 0.6422251, -0.0483211, 0.3974293, 0.6536527]

--- a/ros/src/data/packages/map_file/config/params.yaml
+++ b/ros/src/data/packages/map_file/config/params.yaml
@@ -1,1 +1,3 @@
+# Double List: Transform describing the map frame in the ECEF frame as a translation and quaternion rotation
+# Units: [m, m, m, rad, rad, rad, rad]
 map_1_origin: [1104880.0, -4842200.0, 3988270.0, 0.848612, -0.0638497, 0.525148, 0.863712]

--- a/ros/src/data/packages/map_file/launch/map_loader.launch
+++ b/ros/src/data/packages/map_file/launch/map_loader.launch
@@ -1,6 +1,17 @@
 <launch>
-  <arg name="area" default="1x1" />
+  <!-- Primary launch file for the points map loader. Allows the user to load maps using three different methods defined by the arg load_type -->
+  <arg name="load_type" default="noupdate" doc="Enum of the map loading approach to use. Can be 'download', 'noupdate', or 'arealist'"/> 
+  <arg name="single_pcd_path" default="pcd_map.pcd" doc="Path to the map pcd file if using the noupdate load type"/>
+  <arg name="area" default="1x1" doc="Dimensions of the square of cells loaded at runtime using the download and arealist load types"/>
+  <arg name="arealist_path" default="arealist.txt" doc="Path to the arealist.txt file which contains the paths and dimensions of each map cell to load with the arealist load_type"/>
+  <arg name="area_paths" default="" doc="List of cell paths to load when using the arealist load type. If this is not filled all the cells will be loaded based on the arealist.txt file"/>
+
+  <arg name="pml_args" if="$(eval 'noupdate' == arg('load_type'))" value="noupdate $(arg single_pcd_path)"/>
+  <arg name="pml_args" if="$(eval 'download' == arg('load_type'))" value="$(arg area) download"/>
+  <arg name="pml_args" if="$(eval 'arealist' == arg('load_type'))" value="$(arg area) $(arg arealist_path) $(arg area_paths)"/>
+
   <rosparam command="load" file="$(find map_file)/config/params.yaml"/>
-  <node name="points_map_loader" pkg="map_file" type="points_map_loader" args="$(arg area) download" />
+
+  <node name="points_map_loader" pkg="map_file" type="points_map_loader" args="$(arg pml_args)" />
 
 </launch>

--- a/ros/src/data/packages/map_file/nodes/points_map_loader/points_map_loader.cpp
+++ b/ros/src/data/packages/map_file/nodes/points_map_loader/points_map_loader.cpp
@@ -17,8 +17,11 @@
 /*
  * Modifications:
  *  - Modified points_map_loader package to publish the tf from map to ECEF frame using tf2 library
- *    - 5/7/2019
+ *    - 6/7/2019
  *    - Shuwei Qiang
+ *  - Modified points_map_loader package to have option for loading map cells from arealist.txt file directly instead of using redundant file paths
+ *    - 6/25/2019
+ *    - Michael McConnell
  */
 
 
@@ -533,15 +536,15 @@ int main(int argc, char **argv)
 		}
 	}
 
-        // Load origin of the map
-        std::vector<double> ecef_map_tf_params;
-        n.getParam("map_1_origin", ecef_map_tf_params);
-        if(ecef_map_tf_params.size() != 7) {
-            ROS_ERROR_STREAM("Could not load the origin of the point cloud. TF between earth and map will not be published.");
-            ROS_ERROR_STREAM(ecef_map_tf_params.size());
-        } else {
-            update_map_ecef_tf(ecef_map_tf_params);
-        }
+	// Load origin of the map
+	std::vector<double> ecef_map_tf_params;
+	n.getParam("map_1_origin", ecef_map_tf_params);
+	if(ecef_map_tf_params.size() != 7) {
+			ROS_ERROR_STREAM("Could not load the origin of the point cloud. TF between earth and map will not be published.");
+			ROS_ERROR_STREAM(ecef_map_tf_params.size());
+	} else {
+			update_map_ecef_tf(ecef_map_tf_params);
+	}
 
 	pcd_pub = n.advertise<sensor_msgs::PointCloud2>("points_map", 1, true);
 	stat_pub = n.advertise<std_msgs::Bool>("pmap_stat", 1, true);
@@ -575,9 +578,16 @@ int main(int argc, char **argv)
 		} else {
 			AreaList areas = read_arealist(arealist_path);
 			for (const Area& area : areas) {
-				for (const std::string& path : pcd_paths) {
-					if (path == area.path)
-						cache_arealist(area, downloaded_areas);
+				// Check if the user entered pcd paths in addition to the arealist.txt file
+				if (pcd_paths.size() > 0) {
+					// Only load cells which the user specified
+					for (const std::string& path : pcd_paths) {
+						if (path == area.path)
+							cache_arealist(area, downloaded_areas);
+					}
+				} else {
+					// The user did not specify any cells to load all the cells contained in the arealist.txt file
+					cache_arealist(area, downloaded_areas);
 				}
 			}
 		}


### PR DESCRIPTION
This PR updates the points map loader to load map cells directly from arealist.txt file when no additional pcd paths are provided. If additional paths are provided only the specified cells will be loaded as is the existing default behavior. 

In addition the map_loader.launch file was updated to support launching the points map loader with different arguments. Users can now say things like
```
roslaunch map_file map_loader.launch load_type:=noupdate single_pcd_path:=pcd_map.pcd
roslaunch map_file map_loader.launch load_type:=download area:=1x1
roslaunch map_file map_loader.launch load_type:=arealist arealist_path:=arealist.txt
```

This PR also normalizes the quaternion provided in the params file. 