### PR TITLE
Update ssc to match as autoware fork which is hardware agnostic

### DIFF
--- a/ros/src/actuation/vehicles/packages/as/interface.yaml
+++ b/ros/src/actuation/vehicles/packages/as/interface.yaml
@@ -1,4 +1,4 @@
-- name: /pacmod_interface
+- name: /ssc_interface
   publish: [/as/arbitrated_steering_commands, /as/arbitrated_speed_commands,
-    /as_current_twist]
-  subscribe: [/twist_cmd, /as/control_mode, /vehicle/steering_report]
+    /vehicle/twist]
+  subscribe: [/vehicle_cmd, /vehicle/engage, /as/steering_feedback]

--- a/ros/src/actuation/vehicles/packages/as/launch/ssc_interface.launch
+++ b/ros/src/actuation/vehicles/packages/as/launch/ssc_interface.launch
@@ -1,7 +1,6 @@
 <!-- -->
 <launch>
 
-	<arg name="use_rear_wheel_speed" default="true"/>
 	<arg name="use_adaptive_gear_ratio" default="true"/>
 	<arg name="command_timeout" default="1000"/>
 	<arg name="loop_rate" default="30.0"/>
@@ -12,7 +11,6 @@
 	<arg name="max_curvature_rate" default="0.75"/>
 
 	<node pkg="as" type="ssc_interface" name="ssc_interface" output="screen">
-		<param name="use_rear_wheel_speed" value="$(arg use_rear_wheel_speed)" />
 		<param name="use_adaptive_gear_ratio" value="$(arg use_adaptive_gear_ratio)" />
 		<param name="command_timeout" value="$(arg command_timeout)" />
 		<param name="loop_rate" value="$(arg loop_rate)" />

--- a/ros/src/actuation/vehicles/packages/as/nodes/ssc_interface/ssc_interface.cpp
+++ b/ros/src/actuation/vehicles/packages/as/nodes/ssc_interface/ssc_interface.cpp
@@ -19,7 +19,6 @@
 SSCInterface::SSCInterface() : nh_(), private_nh_("~"), engage_(false), command_initialized_(false)
 {
   // setup parameters
-  private_nh_.param<bool>("use_rear_wheel_speed", use_rear_wheel_speed_, true);
   private_nh_.param<bool>("use_adaptive_gear_ratio", use_adaptive_gear_ratio_, true);
   private_nh_.param<int>("command_timeout", command_timeout_, 1000);
   private_nh_.param<double>("loop_rate", loop_rate_, 30.0);
@@ -50,17 +49,14 @@ SSCInterface::SSCInterface() : nh_(), private_nh_("~"), engage_(false), command_
   gear_feedback_sub_ =
       new message_filters::Subscriber<automotive_platform_msgs::GearFeedback>(nh_, "as/gear_feedback", 10);
   velocity_accel_sub_ =
-      new message_filters::Subscriber<automotive_platform_msgs::VelocityAccel>(nh_, "as/velocity_accel", 10);
-  // subscribers from PACMod
-  wheel_speed_sub_ =
-      new message_filters::Subscriber<pacmod_msgs::WheelSpeedRpt>(nh_, "pacmod/parsed_tx/wheel_speed_rpt", 10);
+      new message_filters::Subscriber<automotive_platform_msgs::VelocityAccelCov>(nh_, "as/velocity_accel_cov", 10); 
   steering_wheel_sub_ =
-      new message_filters::Subscriber<pacmod_msgs::SystemRptFloat>(nh_, "pacmod/parsed_tx/steer_rpt", 10);
+      new message_filters::Subscriber<automotive_platform_msgs::SteeringFeedback>(nh_, "as/steering_feedback", 10);
   ssc_feedbacks_sync_ = new message_filters::Synchronizer<SSCFeedbacksSyncPolicy>(
       SSCFeedbacksSyncPolicy(10), *velocity_accel_sub_, *curvature_feedback_sub_, *throttle_feedback_sub_,
-      *brake_feedback_sub_, *gear_feedback_sub_, *wheel_speed_sub_, *steering_wheel_sub_);
+      *brake_feedback_sub_, *gear_feedback_sub_, *steering_wheel_sub_);
   ssc_feedbacks_sync_->registerCallback(
-      boost::bind(&SSCInterface::callbackFromSSCFeedbacks, this, _1, _2, _3, _4, _5, _6, _7));
+      boost::bind(&SSCInterface::callbackFromSSCFeedbacks, this, _1, _2, _3, _4, _5, _6));
 
   // publishers to autoware
   vehicle_status_pub_ = nh_.advertise<autoware_msgs::VehicleStatus>("vehicle_status", 10);
@@ -107,36 +103,29 @@ void SSCInterface::callbackFromSSCModuleStates(const automotive_navigation_msgs:
   }
 }
 
-void SSCInterface::callbackFromSSCFeedbacks(const automotive_platform_msgs::VelocityAccelConstPtr& msg_velocity,
+void SSCInterface::callbackFromSSCFeedbacks(const automotive_platform_msgs::VelocityAccelCovConstPtr& msg_velocity,
                                             const automotive_platform_msgs::CurvatureFeedbackConstPtr& msg_curvature,
                                             const automotive_platform_msgs::ThrottleFeedbackConstPtr& msg_throttle,
                                             const automotive_platform_msgs::BrakeFeedbackConstPtr& msg_brake,
                                             const automotive_platform_msgs::GearFeedbackConstPtr& msg_gear,
-                                            const pacmod_msgs::WheelSpeedRptConstPtr& msg_wheel_speed,
-                                            const pacmod_msgs::SystemRptFloatConstPtr& msg_steering_wheel)
+                                            const automotive_platform_msgs::SteeringFeedbackConstPtr& msg_steering_wheel)
 {
   ros::Time stamp = msg_velocity->header.stamp;
-
-  // current speed
-  double speed =
-      !use_rear_wheel_speed_ ?
-          (msg_velocity->velocity) :
-          (msg_wheel_speed->rear_left_wheel_speed + msg_wheel_speed->rear_right_wheel_speed) * tire_radius_ / 2.;
-
+  
   // update adaptive gear ratio (avoiding zero divizion)
   adaptive_gear_ratio_ =
-    std::max(1e-5, agr_coef_a_ + agr_coef_b_ * speed * speed - agr_coef_c_ * msg_steering_wheel->output);
+    std::max(1e-5, agr_coef_a_ + agr_coef_b_ * msg_velocity->velocity * msg_velocity->velocity - agr_coef_c_ * msg_steering_wheel->steering_wheel_angle);
   // current steering curvature
   double curvature = !use_adaptive_gear_ratio_ ?
                          (msg_curvature->curvature) :
-                         std::tan(msg_steering_wheel->output / adaptive_gear_ratio_) / wheel_base_;
+                         std::tan(msg_steering_wheel->steering_wheel_angle/ adaptive_gear_ratio_) / wheel_base_;
 
   // as_current_velocity (geometry_msgs::TwistStamped)
   geometry_msgs::TwistStamped twist;
   twist.header.frame_id = BASE_FRAME_ID;
   twist.header.stamp = stamp;
-  twist.twist.linear.x = speed;               // [m/s]
-  twist.twist.angular.z = curvature * speed;  // [rad/s]
+  twist.twist.linear.x = msg_velocity->velocity;               // [m/s]
+  twist.twist.angular.z = curvature * msg_velocity->velocity;  // [rad/s]
   current_twist_pub_.publish(twist);
 
   // vehicle_status (autoware_msgs::VehicleStatus)
@@ -150,7 +139,7 @@ void SSCInterface::callbackFromSSCFeedbacks(const automotive_platform_msgs::Velo
   vehicle_status.steeringmode = vehicle_status.drivemode;
 
   // speed [km/h]
-  vehicle_status.speed = speed * 3.6;
+  vehicle_status.speed = msg_velocity->velocity * 3.6;
 
   // drive/brake pedal [0,1000] (TODO: Scaling)
   vehicle_status.drivepedal = (int)(1000 * msg_throttle->throttle_pedal);

--- a/ros/src/actuation/vehicles/packages/as/nodes/ssc_interface/ssc_interface.h
+++ b/ros/src/actuation/vehicles/packages/as/nodes/ssc_interface/ssc_interface.h
@@ -30,14 +30,14 @@
 #include <automotive_platform_msgs/SpeedMode.h>
 #include <automotive_platform_msgs/GearCommand.h>
 #include <automotive_platform_msgs/TurnSignalCommand.h>
-#include <automotive_platform_msgs/VelocityAccel.h>
+#include <automotive_platform_msgs/VelocityAccelCov.h>
 #include <automotive_platform_msgs/CurvatureFeedback.h>
 #include <automotive_platform_msgs/ThrottleFeedback.h>
 #include <automotive_platform_msgs/BrakeFeedback.h>
 #include <automotive_platform_msgs/GearFeedback.h>
 #include <automotive_navigation_msgs/ModuleState.h>
-#include <pacmod_msgs/WheelSpeedRpt.h>
-#include <pacmod_msgs/SystemRptFloat.h>
+#include <automotive_platform_msgs/SteeringFeedback.h>
+
 
 #include <autoware_msgs/VehicleCmd.h>
 #include <autoware_msgs/VehicleStatus.h>
@@ -54,9 +54,9 @@ public:
 
 private:
   typedef message_filters::sync_policies::ApproximateTime<
-      automotive_platform_msgs::VelocityAccel, automotive_platform_msgs::CurvatureFeedback,
+      automotive_platform_msgs::VelocityAccelCov, automotive_platform_msgs::CurvatureFeedback,
       automotive_platform_msgs::ThrottleFeedback, automotive_platform_msgs::BrakeFeedback,
-      automotive_platform_msgs::GearFeedback, pacmod_msgs::WheelSpeedRpt, pacmod_msgs::SystemRptFloat>
+      automotive_platform_msgs::GearFeedback, automotive_platform_msgs::SteeringFeedback>
       SSCFeedbacksSyncPolicy;
 
   // handle
@@ -67,13 +67,12 @@ private:
   ros::Subscriber vehicle_cmd_sub_;
   ros::Subscriber engage_sub_;
   ros::Subscriber module_states_sub_;
-  message_filters::Subscriber<automotive_platform_msgs::VelocityAccel>* velocity_accel_sub_;
+  message_filters::Subscriber<automotive_platform_msgs::VelocityAccelCov>* velocity_accel_sub_;
   message_filters::Subscriber<automotive_platform_msgs::CurvatureFeedback>* curvature_feedback_sub_;
   message_filters::Subscriber<automotive_platform_msgs::ThrottleFeedback>* throttle_feedback_sub_;
   message_filters::Subscriber<automotive_platform_msgs::BrakeFeedback>* brake_feedback_sub_;
   message_filters::Subscriber<automotive_platform_msgs::GearFeedback>* gear_feedback_sub_;
-  message_filters::Subscriber<pacmod_msgs::WheelSpeedRpt>* wheel_speed_sub_;
-  message_filters::Subscriber<pacmod_msgs::SystemRptFloat>* steering_wheel_sub_;
+  message_filters::Subscriber<automotive_platform_msgs::SteeringFeedback>* steering_wheel_sub_;
   message_filters::Synchronizer<SSCFeedbacksSyncPolicy>* ssc_feedbacks_sync_;
 
   // publishers
@@ -92,7 +91,7 @@ private:
   double deceleration_limit_;  // [m/s^2]
   double max_curvature_rate_;  // [rad/m/s]
 
-  bool use_rear_wheel_speed_;     // instead of 'as/velocity_accel'
+  //bool use_rear_wheel_speed_;     // instead of 'as/velocity_accel'
   bool use_adaptive_gear_ratio_;  // for more accurate steering angle (gr = theta_sw / theta_s)
   double tire_radius_;            // [m] (NOTE: used by 'use_rear_wheel_speed' mode)
   double ssc_gear_ratio_;         // gr = const (NOTE: used by 'use_adaptive_gear_ratio' mode)
@@ -118,13 +117,12 @@ private:
   void callbackFromVehicleCmd(const autoware_msgs::VehicleCmdConstPtr& msg);
   void callbackFromEngage(const std_msgs::BoolConstPtr& msg);
   void callbackFromSSCModuleStates(const automotive_navigation_msgs::ModuleStateConstPtr& msg);
-  void callbackFromSSCFeedbacks(const automotive_platform_msgs::VelocityAccelConstPtr& msg_velocity,
+  void callbackFromSSCFeedbacks(const automotive_platform_msgs::VelocityAccelCovConstPtr& msg_velocity,
                                 const automotive_platform_msgs::CurvatureFeedbackConstPtr& msg_curvature,
                                 const automotive_platform_msgs::ThrottleFeedbackConstPtr& msg_throttle,
                                 const automotive_platform_msgs::BrakeFeedbackConstPtr& msg_brake,
                                 const automotive_platform_msgs::GearFeedbackConstPtr& msg_gear,
-                                const pacmod_msgs::WheelSpeedRptConstPtr& msg_wheel_speed,
-                                const pacmod_msgs::SystemRptFloatConstPtr& msg_steering_wheel);
+                                const automotive_platform_msgs::SteeringFeedbackConstPtr& msg_steering_wheel);
   // functions
   void publishCommand();
 };

--- a/ros/src/actuation/vehicles/packages/as/package.xml
+++ b/ros/src/actuation/vehicles/packages/as/package.xml
@@ -4,6 +4,7 @@
   <version>1.11.0</version>
   <description>The pacmod interface package</description>
   <maintainer email="aohsato@gmail.com">Akihito Ohsato</maintainer>
+  <maintainer email="sganesh@autonomoustuff.com">Sneha Ganesh</maintainer>
   <license>Apache 2</license>
   <author email="aohsato@gmail.com">Akihito Ohsato</author>
   <author email="antm678@ertl.jp">T.Ando</author>


### PR DESCRIPTION
The SSC/SSC interface has changed to be hardware agnostic. This PR updates the interface to match what is in the AStuff autoware fork. 