### PR TITLE
Create autoware build script to work with carma_build script

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -25,4 +25,6 @@ For any modified file please follow these steps to ensure proper documentation o
 - Removed exisitng Docker configuration files for replacement with the new CARMA3 docker config files.
   - 8/1/2019
   - Kyle Rush
-
+- Add carma_autoware_build bash script which builds the portions of autoware needed by carma
+  - 8/13/2019
+  - Michael McConnell

--- a/docker/install.sh
+++ b/docker/install.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+source /home/carma/.base-image/init-env.sh
 autoware_src="/home/carma/autoware.ai"
 cd ${autoware_src}/ros 
 ./carma_autoware_build -a ${autoware_src}

--- a/docker/install.sh
+++ b/docker/install.sh
@@ -1,43 +1,4 @@
 #!/bin/bash
-
 autoware_src="/home/carma/autoware.ai"
-AUTOWARE_PACKAGE_SELECTION="map_tools lidar_localizer map_file deadreckoner points_downsampler points_preprocessor lane_planner waypoint_maker autoware_msgs autoware_config_msgs as"
-MSGS_TO_GENERATE="jsk_footstep_msgs jsk_recognition_msgs autoware_msgs radar_msgs derived_object_msgs autoware_config_msgs"
-
-echo "Building Autoware required packages ${AUTOWARE_PACKAGE_SELECTION}"
-cd ${autoware_src}/ros
-
-source /opt/ros/kinetic/setup.sh
-./colcon_release --executor sequential --packages-up-to "${AUTOWARE_PACKAGE_SELECTION}"
-source ./install/setup.bash
-echo "Autoware built successfuly. Binaries sourced from $(realpath ./install/setup.bash)"
-
-
-###
-# Generate rosjava message artifacts for autoware
-###
-
-# Set environment variables required by genjava_message_artifacts 
-# The default values do not resolve correctly with autoware's colon build
-export ROS_MAVEN_DEPLOYMENT_REPOSITORY_PREV=$ROS_MAVEN_DEPLOYMENT_REPOSITORY
-export ROS_MAVEN_DEPLOYMENT_REPOSITORY="${autoware_src}/ros/install/share/maven"
-export ROS_MAVEN_PATH_PREV=${ROS_MAVEN_PATH}
-export ROS_MAVEN_PATH="${ROS_MAVEN_PATH}:${autoware_src}/ros/install/share/maven"
-
-# Generate message artifacts
-echo "Trying to generate rosjava message artifacts for ${MSGS_TO_GENERATE}"
-genjava_message_artifacts -p ${MSGS_TO_GENERATE}
-
-# Copy jar and pom files to the directories where gradle will search for them during the carma build
-JAR_DIR="${ROS_MAVEN_DEPLOYMENT_REPOSITORY}"
-
-for message in ${MSGS_TO_GENERATE}
-do
-  JAR_DEST=${autoware_src}/ros/install/${message}/share/maven
-  mkdir -p ${JAR_DEST}
-  cp -R ${JAR_DIR}/* ${JAR_DEST}
-done
-
-# Reset maven deployment environment variable to ensure carma builds its java messages correctly
-export ROS_MAVEN_DEPLOYMENT_REPOSITORY=$ROS_MAVEN_DEPLOYMENT_REPOSITORY_PREV
-export ROS_MAVEN_PATH=$ROS_MAVEN_PATH_PREV
+cd ${autoware_src}/ros 
+./carma_autoware_build -a ${autoware_src}

--- a/ros/carma_autoware_build
+++ b/ros/carma_autoware_build
@@ -1,0 +1,98 @@
+#!/bin/bash
+
+#  Copyright (C) 2018-2019 LEIDOS.
+# 
+#  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+#  use this file except in compliance with the License. You may obtain a copy of
+#  the License at
+# 
+#  http://www.apache.org/licenses/LICENSE-2.0
+# 
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations under
+#  the License.
+
+# This scipt builds the CARMA platform and its Autoware.ai dependancies. 
+
+usage() { 
+  echo "USAGE carma_build [OPTION]
+  carma_build will build the CARMA Platform including any drivers in the same workspace as well as any required Autoware.ai components
+  
+  -a Path to Autoware.ai workspace. If this is not specified it is assumed CARMA and Autoware.ai share a workspace 
+  -b Additional build arguments to pass to Autoware.ai's colcon build
+  -h Print help
+  ";
+}
+
+
+# Default environment variables
+autoware_src="$(realpath .)"
+autoware_build_args=""
+# The list of packages which are required by carma from autoware
+AUTOWARE_PACKAGE_SELECTION="map_tools lidar_localizer map_file deadreckoner points_downsampler points_preprocessor lane_planner waypoint_maker autoware_msgs autoware_config_msgs as waypoint_planner"
+
+# The list of message packages used by autoware which will need to have thier rosjava artifacts generated for carma
+# Note: The order of this list is the order of compilation and therefore must account for dependancies
+MSGS_TO_GENERATE="jsk_footstep_msgs jsk_recognition_msgs autoware_msgs radar_msgs derived_object_msgs autoware_config_msgs"
+
+# Read Options
+while getopts a:c:xrhm:b: option
+do
+	case "${option}"
+	in
+		a) autoware_src="$(realpath ${OPTARG})";;
+    b) autoware_build_args=${OPTARG};;
+    h) usage; exit 0;;
+		\?) echo "Unknown option: -$OPTARG" >&2; exit 1;;
+		:) echo "Missing option argument for -$OPTARG" >&2; exit 1;;
+		*) echo "Unimplemented option: -$OPTARG" >&2; exit 1;;
+
+	esac
+done
+
+echo "
+Attempting to build Autoware
+Autoware Source Dir: ${autoware_src}
+"
+
+
+echo "Building Autoware required packages ${AUTOWARE_PACKAGE_SELECTION}"
+
+cd ${autoware_src}/ros
+
+./colcon_release "${autoware_build_args}" --executor sequential --packages-up-to "${AUTOWARE_PACKAGE_SELECTION}"
+source ./install/setup.bash
+echo "Autoware built successfuly. Binaries sourced from $(realpath ./install/setup.bash)"
+
+###
+# Generate rosjava message artifacts for autoware
+###
+
+# Set environment variables required by genjava_message_artifacts 
+# The default values do not resolve correctly with autoware's colon build
+export ROS_MAVEN_DEPLOYMENT_REPOSITORY_PREV=$ROS_MAVEN_DEPLOYMENT_REPOSITORY
+export ROS_MAVEN_DEPLOYMENT_REPOSITORY="${autoware_src}/ros/install/share/maven"
+export ROS_MAVEN_PATH_PREV=${ROS_MAVEN_PATH}
+export ROS_MAVEN_PATH="${ROS_MAVEN_PATH}:${autoware_src}/ros/install/share/maven"
+
+# Generate message artifacts
+echo "Trying to generate rosjava message artifacts for ${MSGS_TO_GENERATE}"
+genjava_message_artifacts -p ${MSGS_TO_GENERATE}
+
+# Copy jar and pom files to the directories where gradle will search for them during the carma build
+JAR_DIR="${ROS_MAVEN_DEPLOYMENT_REPOSITORY}"
+
+for message in ${MSGS_TO_GENERATE}
+do
+  JAR_DEST=${autoware_src}/ros/install/${message}/share/maven
+  mkdir -p ${JAR_DEST}
+  cp -R ${JAR_DIR}/* ${JAR_DEST}
+done
+
+# Reset maven deployment environment variable to ensure carma builds its java messages correctly
+export ROS_MAVEN_DEPLOYMENT_REPOSITORY=$ROS_MAVEN_DEPLOYMENT_REPOSITORY_PREV
+export ROS_MAVEN_PATH=$ROS_MAVEN_PATH_PREV
+
+echo "Autoware Build Complete"

--- a/ros/carma_autoware_build
+++ b/ros/carma_autoware_build
@@ -14,13 +14,13 @@
 #  License for the specific language governing permissions and limitations under
 #  the License.
 
-# This scipt builds the CARMA platform and its Autoware.ai dependancies. 
+# This scipt builds the Autoware.ai components used by the CARMA Platform
 
 usage() { 
-  echo "USAGE carma_build [OPTION]
-  carma_build will build the CARMA Platform including any drivers in the same workspace as well as any required Autoware.ai components
+  echo "USAGE carma_autoware_build [OPTION]
+  carma_autoware_build will build the Autoware.ai components used by the CARMA Platform
   
-  -a Path to Autoware.ai workspace. If this is not specified it is assumed CARMA and Autoware.ai share a workspace 
+  -a Path to Autoware.ai workspace. If this is not specified it is assumed the current workspace will work
   -b Additional build arguments to pass to Autoware.ai's colcon build
   -h Print help
   ";


### PR DESCRIPTION
Port autoware build logic from carma_build in carma_autoware_build script so that it can be used in the install.sh script. 