### PR TITLE
Add calibration file for ray_ground_filter node

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -25,4 +25,10 @@ For any modified file please follow these steps to ensure proper documentation o
 - Removed exisitng Docker configuration files for replacement with the new CARMA3 docker config files.
   - 8/1/2019
   - Kyle Rush
+- Updated as package (ssc_interface) to version found in the AutonomouStuff fork of Autoware
+  - 8/6/2019
+  - Michael McConnell
+- Add carma_autoware_build bash script which builds the portions of autoware needed by carma
+  - 8/13/2019
+  - Michael McConnell
 

--- a/ros/src/sensing/filters/packages/points_preprocessor/CMakeLists.txt
+++ b/ros/src/sensing/filters/packages/points_preprocessor/CMakeLists.txt
@@ -207,6 +207,6 @@ install(DIRECTORY include/
         DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION}
         PATTERN ".svn" EXCLUDE
         )
-install(DIRECTORY launch/
+install(DIRECTORY launch/ config/
         DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/launch
         PATTERN ".svn" EXCLUDE)

--- a/ros/src/sensing/filters/packages/points_preprocessor/config/calibration.yaml
+++ b/ros/src/sensing/filters/packages/points_preprocessor/config/calibration.yaml
@@ -1,0 +1,4 @@
+# File containing ray_ground_filter parameters that are vehicle specific
+# Double: Height of the lidar sensor from the ground
+# Units: m
+sensor_height: 1.8

--- a/ros/src/sensing/filters/packages/points_preprocessor/launch/ray_ground_filter_file_config.launch
+++ b/ros/src/sensing/filters/packages/points_preprocessor/launch/ray_ground_filter_file_config.launch
@@ -1,0 +1,32 @@
+<!-- Launch file for Ray Ground Filter -->
+<launch>
+
+        <arg name="vehicle_clibration_params_file" default="$(find points_preprocessor)/config/calibration.yaml"/> /><!--  File containing vehicle specific calibration parameters -->
+        <arg name="input_point_topic" default="/points_raw" /> <!-- input_point_topic, ground filtering will be performed over the pointcloud in this topic. -->
+        <arg name="clipping_height" default="0.2" /><!-- Remove Points above this height value (default 0.2 meters) -->
+        <arg name="min_point_distance" default="1.85" /><!-- Removes Points closer than this distance from the sensor origin (default 1.85 meters) -->
+        <arg name="radial_divider_angle" default="0.08" /><!-- Angle of each Radial division on the XY Plane (default 0.08 degrees)-->
+        <arg name="concentric_divider_distance" default="0.01" /><!-- Distance of each concentric division on the XY Plane (default 0.01 meters) -->
+        <arg name="local_max_slope" default="8" /><!-- Max Slope of the ground between Points (default 8 degrees) -->
+        <arg name="general_max_slope" default="5" /><!-- Max Slope of the ground in the entire PointCloud, used when reclassification occurs (default 5 degrees)-->
+        <arg name="min_height_threshold" default="0.5" /><!-- Minimum height threshold between points (default 0.05 meters)-->
+        <arg name="reclass_distance_threshold" default="0.2" /><!-- Distance between points at which re classification will occur (default 0.2 meters)-->
+        <arg name="no_ground_point_topic" default="/points_no_ground" />
+        <arg name="ground_point_topic" default="/points_ground" />
+
+        <!-- rosrun points_preprocessor ray_ground_filter -->
+        <node pkg="points_preprocessor" type="ray_ground_filter" name="ray_ground_filter" output="screen">
+                <rosparam command="load" file="$(arg vehicle_clibration_params_file)" />
+                <param name="input_point_topic" value="$(arg input_point_topic)" />
+                <param name="clipping_height" value="$(arg clipping_height)" />
+                <param name="min_point_distance" value="$(arg min_point_distance)" />
+                <param name="radial_divider_angle" value="$(arg radial_divider_angle)" />
+                <param name="concentric_divider_distance" value="$(arg concentric_divider_distance)" />
+                <param name="local_max_slope" value="$(arg local_max_slope)" />
+                <param name="general_max_slope" value="$(arg general_max_slope)" />
+                <param name="min_height_threshold" value="$(arg min_height_threshold)" />
+                <param name="reclass_distance_threshold" value="$(arg reclass_distance_threshold)" />
+                <param name="no_ground_point_topic" value="$(arg no_ground_point_topic)" />
+                <param name="ground_point_topic" value="$(arg ground_point_topic)" />
+        </node>
+</launch>


### PR DESCRIPTION
Adds a calibration file for the ray_ground_filter node so that the sensor_height parameter can be stored as a calibration in the vehicle calibration repo. 