### PR TITLE
Disable genjava in docker build as it causes instability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM usdotfhwastol/carma-base:3.0.0 as build
+FROM usdotfhwastol/carma-base:3.1.0 as build
 
 COPY --chown=carma . /home/carma/autoware.ai
 RUN /home/carma/autoware.ai/docker/checkout.sh
 RUN ./home/carma/autoware.ai/docker/install.sh
 
-FROM usdotfhwastol/carma-base:3.0.0 
+FROM usdotfhwastol/carma-base:3.1.0 
 
 ARG BUILD_DATE="NULL"
 ARG VCS_REF="NULL"

--- a/docker/install.sh
+++ b/docker/install.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 source /home/carma/.base-image/init-env.sh
+export ROS_LANG_DISABLE=genjava # Disable genjava as it is not needed in this image and makes build inconsistent 
 autoware_src="/home/carma/autoware.ai"
 cd ${autoware_src}/ros 
 ./carma_autoware_build -a ${autoware_src}


### PR DESCRIPTION
As noted in the title. Genjava causes build instability for autoware. It can be disabled safely as the java messages are generated using the command line interface in a later step of the build process. 