### PR TITLE
Fix/sync with lanelet2 master

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Lanelet2
 
-![build](https://www.mrt.kit.edu/z/gitlab/lanelet2/pipeline.svg) ![coverage](https://www.mrt.kit.edu/z/gitlab/lanelet2/coverage.svg)
+| [Travis CI](https://travis-ci.org/fzi-forschungszentrum-informatik/Lanelet2) | Gitlab CI | Coverage |
+| --------- | --------- | -------- |
+| [![](https://travis-ci.org/fzi-forschungszentrum-informatik/Lanelet2.svg?branch=master)](https://travis-ci.org/fzi-forschungszentrum-informatik/Lanelet2) | ![build](https://www.mrt.kit.edu/z/gitlab/lanelet2/pipeline.svg) | ![coverage](https://www.mrt.kit.edu/z/gitlab/lanelet2/coverage.svg) |
 
 ## Overview
 

--- a/lanelet2/lanelet2_routing/CMakeLists.txt
+++ b/lanelet2/lanelet2_routing/CMakeLists.txt
@@ -93,6 +93,6 @@ mrt_install(PROGRAMS scripts FILES res data)
 #############
 # Add test targets for cpp and python tests
 if (CATKIN_ENABLE_TESTING)
-    #mrt_add_tests(test) # TODO Figure out why this can't build on kinetic
-    #mrt_add_nosetests(test) # TODO Figure out why this can't build on kinetic
+    mrt_add_tests(test) # TODO Figure out why this can't build on kinetic
+    mrt_add_nosetests(test) # TODO Figure out why this can't build on kinetic
 endif()

--- a/lanelet2_routing/test/test_route.cpp
+++ b/lanelet2_routing/test/test_route.cpp
@@ -10,8 +10,6 @@ using namespace lanelet::routing::tests;
 template <Id FromId, Id ToId, Id... ViaIds>
 class TestRoute : public GermanVehicleGraph {
  public:
-  static constexpr Id From = FromId;
-  static constexpr Id To = ToId;
   explicit TestRoute(uint16_t routingCostId = 0, bool withLaneChanges = true) {
     Ids viaIds{ViaIds...};
     start = lanelets.at(From);
@@ -26,6 +24,9 @@ class TestRoute : public GermanVehicleGraph {
   ConstLanelet end;
   ConstLanelets via;
   Route route;
+  // these would better be defined as static constexpr, but c++14 doesnt support it well
+  const Id From{FromId};  // NOLINT
+  const Id To{ToId};      // NOLINT
 };
 
 class Route1 : public TestRoute<2001, 2014> {};

--- a/lanelet2_routing/test/test_routing_visualization.cpp
+++ b/lanelet2_routing/test/test_routing_visualization.cpp
@@ -12,17 +12,19 @@ namespace fs = boost::filesystem;
 class Tempfile {
  public:
   Tempfile() {
-    auto res = mkdtemp(path_.data());
+    char path[] = {"/tmp/lanelet2_unittest.XXXXXX"};
+    auto res = mkdtemp(path);
     if (res == nullptr) {
       throw lanelet::LaneletError("Failed to crate temporary directory");
     }
+    path_ = path;
   }
   ~Tempfile() { fs::remove_all(fs::path(path_)); }
 
   auto operator()(const std::string& str) const noexcept -> std::string { return (fs::path(path_) / str).string(); }
 
  private:
-  std::string path_{"/tmp/lanelet2_unittest.XXXXXX"};
+  std::string path_;
 };
 
 static Tempfile tempfile;


### PR DESCRIPTION
Pull in fix to fzi-forschungszentrum-informatik/Lanelet2#71

This allows the unit test disable from #48 to be rolled back in this PR. 