### PR TITLE
Add ekf localizer to build and make compatable with carma

### DIFF
--- a/autoware/ros/carma_autoware_build
+++ b/autoware/ros/carma_autoware_build
@@ -33,7 +33,7 @@ autoware_src="$(realpath .)"
 autoware_build_args=""
 use_catkin=false
 # The list of packages which are required by carma from autoware
-AUTOWARE_PACKAGE_SELECTION="map_tools lidar_localizer map_file deadreckoner points_downsampler points_preprocessor lane_planner waypoint_maker autoware_msgs autoware_config_msgs as waypoint_planner pure_pursuit twist_filter twist_gate lanelet2_extension"
+AUTOWARE_PACKAGE_SELECTION="map_tools lidar_localizer map_file deadreckoner points_downsampler points_preprocessor lane_planner waypoint_maker autoware_msgs autoware_config_msgs as waypoint_planner pure_pursuit twist_filter twist_gate lanelet2_extension ekf_localizer"
 
 # The list of message packages used by autoware which will need to have thier rosjava artifacts generated for carma
 # Note: The order of this list is the order of compilation and therefore must account for dependancies

--- a/core_perception/ekf_localizer/launch/ekf_localizer.launch
+++ b/core_perception/ekf_localizer/launch/ekf_localizer.launch
@@ -48,8 +48,6 @@
     <remap if="$(arg use_twist_with_covariance)" from="in_twist" to="input_twist_UNUSED"/>
     <remap if="$(arg use_twist_with_covariance)" from="in_twist_with_covariance" to="$(arg input_twist_with_cov_name)"/>
 
-    <remap from="initialpose" to="/initialpose"/>
-
     <param name="pose_frame_id" value="map"/>
 
     <param name="show_debug_info" value="$(arg show_debug_info)"/>


### PR DESCRIPTION
This PR adds the ekf_localizer to the autoware.ai repo build and exposes it's initialpose topic so it can be remapped by carma. 

This PR helps address usdot-fhwa-stol/CARMAPlatform#527