### PR TITLE
Fix/lanelet2 projection

### DIFF
--- a/common/lanelet2_extension/CMakeLists.txt
+++ b/common/lanelet2_extension/CMakeLists.txt
@@ -138,6 +138,7 @@ if(CATKIN_ENABLE_TESTING)
   test/src/DigitalSpeedLimitTest.cpp
   test/src/CarmaUSTrafficRulesTest.cpp
   test/src/MapLoadingTest.cpp
+  test/src/test_local_projector.cpp
   WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/test # Add test directory as working directory for unit tests
  )
 

--- a/common/lanelet2_extension/include/lanelet2_extension/io/autoware_osm_parser.h
+++ b/common/lanelet2_extension/include/lanelet2_extension/io/autoware_osm_parser.h
@@ -52,14 +52,14 @@ public:
 
   /**
    * [parseMapParams parses GeoReference (i.e. map parameters) info from osm file and loads default ECEF proj strings]
+   * NOTE: projector_type = 0 is currently not supported by CARMA
+   *       +geoidgrids is also currently not a supported georeference field by the parser
    * @param filename            [path to osm file]
    * @param projector_type      [parsed information about map projector_type: Currently it supposes 0 as Autoware default MGRSProjector and 1 as CARMA LocalFrameProjector]
-   * @param base_frame          [parsed information about map geo reference: base_frame ]
    * @param target_frame        [parsed information about map geo reference: target_frame]
    * @throw lanelet::ParseError [throws if either frame is nullptr or if geoReference tag cannot be found in .osm file]
-
    */
-  static void parseMapParams(const std::string& filename, int* projector_type, std::string* base_frame, std::string* target_frame);
+  static void parseMapParams(const std::string& filename, int* projector_type, std::string* target_frame);
 
   static constexpr const char* extension()
   {

--- a/common/lanelet2_extension/include/lanelet2_extension/projection/local_frame_projector.h
+++ b/common/lanelet2_extension/include/lanelet2_extension/projection/local_frame_projector.h
@@ -34,7 +34,7 @@ class LocalFrameProjector : public Projector
 
 public:
 
-  explicit LocalFrameProjector(const char* base_frame, const char* target_frame, Origin origin = Origin({ 0.0, 0.0 }));
+  explicit LocalFrameProjector(const char* target_frame, Origin origin = Origin({ 0.0, 0.0 }));
 
   /**
    * [LocalFrameProjector::forward projects gps lat/lon to local map frame]
@@ -44,7 +44,7 @@ public:
   BasicPoint3d forward(const GPSPoint& p) const override;
 
   /**
-   * [LocalFrameProjector::forward projects between ECEF and local map/ from base to target]
+   * [LocalFrameProjector::projectECEF projects between WGS-84 ECEF and local map]
    * @param  ecef_point             [point with x,y,z in ecef information]
    * @param  proj_dir               [1 for forward -1 for reverse]
    * @return                        [projected point in local map coordinate]
@@ -61,7 +61,12 @@ public:
 
 private:
   
-  PJ *P;
+  PJ *P_;
+
+  const std::string map_proj_string_;
+
+  // The PROJ string used to define a WGS-84 ECEF frame
+  static constexpr char ECEF_PROJ_STR[] = "+proj=geocent +ellps=WGS84 +datum=WGS84 +units=m +no_defs";
 };
 
 }  // namespace projection

--- a/common/lanelet2_extension/lib/autoware_osm_parser.cpp
+++ b/common/lanelet2_extension/lib/autoware_osm_parser.cpp
@@ -88,13 +88,12 @@ void AutowareOsmParser::parseVersions(const std::string& filename, std::string* 
     *map_version = metainfo.attribute("map_version").value();
 }
 
-void AutowareOsmParser::parseMapParams (const std::string& filename, int* projector_type, std::string* base_frame, 
-                                      std::string* target_frame)
+void AutowareOsmParser::parseMapParams (const std::string& filename, int* projector_type, std::string* target_frame)
 {
-  if (base_frame == nullptr || target_frame == nullptr)
+  if (target_frame == nullptr)
   {
     throw lanelet::ParseError(std::string("In function ") + __FUNCTION__ + 
-    std::string(": Errors occured while parsing .osm file - either frame is a null pointer!"));
+    std::string(": Errors occured while parsing .osm file - target frame is a null pointer!"));
     return;
   }
 
@@ -111,14 +110,18 @@ void AutowareOsmParser::parseMapParams (const std::string& filename, int* projec
   if (geoRef)
   {
     std::string raw_geo_ref = geoRef.child_value();
+
     // Filter unnecessary part out of georeference.
     std::vector<std::string> buffer;
     boost::split(buffer,  raw_geo_ref, boost::is_any_of(" "));
 
     for (int i = 0; i < buffer.size(); i++)
     {
-      if (!boost::algorithm::contains(buffer[i], "+geoidgrids"))
+      if (!boost::algorithm::contains(buffer[i], "+geoidgrids")) {
         target_frame->append(buffer[i] + " "); //geo reference value
+      } else {
+        std::cerr << "Removing +geoidgrids from input projection as this is not currently supported by AutowareOsmParser" << std::endl;
+      }
     }
   }
   else
@@ -128,7 +131,6 @@ void AutowareOsmParser::parseMapParams (const std::string& filename, int* projec
 
   // Default values
   *projector_type = 1; // default value for autoware.ai projector type for CARMA purposes
-  *base_frame = std::string("+proj=geocent +ellps=WGS84 +datum=WGS84 +units=m +no_defs"); //default value for ECEF proj string
 }
 } // namespace io_handlers
 } // namespace lanelet

--- a/common/lanelet2_extension/lib/local_frame_projector.cpp
+++ b/common/lanelet2_extension/lib/local_frame_projector.cpp
@@ -18,6 +18,7 @@
 
 #include <lanelet2_extension/projection/local_frame_projector.h>
 #include <iostream>
+#include <math.h>
 
 namespace lanelet
 {
@@ -37,9 +38,10 @@ LocalFrameProjector::LocalFrameProjector(const char* projection_string, Origin o
 
 BasicPoint3d LocalFrameProjector::forward(const GPSPoint& p) const
 {
-  PJ_COORD c{{p.lat, p.lon, p.ele, 0}};
+  static constexpr double DEG2RAD =  M_PI/180.0; 
+  PJ_COORD c{{p.lon * DEG2RAD, p.lat * DEG2RAD, p.ele}};
   PJ_COORD c_out = proj_trans(P_, PJ_FWD, c);
-  return BasicPoint3d{c_out.xy.x, c_out.xy.y, 0};
+  return BasicPoint3d{c_out.xyz.x, c_out.xyz.y, c_out.xyz.z};
 }
 
 BasicPoint3d LocalFrameProjector::projectECEF(const BasicPoint3d& p, const int& proj_dir) const
@@ -64,10 +66,11 @@ BasicPoint3d LocalFrameProjector::projectECEF(const BasicPoint3d& p, const int& 
 
 GPSPoint LocalFrameProjector::reverse(const BasicPoint3d& p) const
 {
+  static constexpr double RAD2DEG = 180.0/M_PI;
   PJ_COORD c{{p[0], p[1], p[2], 0}};
   PJ_COORD c_out = proj_trans(P_, PJ_INV, c);
 
-  return GPSPoint{c_out.lp.lam, c_out.lp.phi};
+  return GPSPoint{c_out.lpz.phi * RAD2DEG, c_out.lpz.lam * RAD2DEG, c_out.lpz.z};
 }
 
 

--- a/common/lanelet2_extension/lib/local_frame_projector.cpp
+++ b/common/lanelet2_extension/lib/local_frame_projector.cpp
@@ -24,26 +24,35 @@ namespace lanelet
 namespace projection
 {
 
-LocalFrameProjector::LocalFrameProjector(const char* base_frame, const char* target_frame, Origin origin) : Projector(origin)
+// C++ 14 vs 17 constant defintion
+#if __cplusplus < 201703L
+// Forward declare static constexpr
+constexpr char LocalFrameProjector::ECEF_PROJ_STR[];  // instantiate string in cpp file
+#endif
+
+LocalFrameProjector::LocalFrameProjector(const char* projection_string, Origin origin) : Projector(origin), map_proj_string_(projection_string)
 {
-  P = proj_create_crs_to_crs(PJ_DEFAULT_CTX, base_frame, target_frame, NULL);
+  P_ = proj_create(PJ_DEFAULT_CTX, map_proj_string_.c_str());
 }
 
 BasicPoint3d LocalFrameProjector::forward(const GPSPoint& p) const
 {
   PJ_COORD c{{p.lat, p.lon, p.ele, 0}};
-  PJ_COORD c_out = proj_trans(P, PJ_FWD, c);
+  PJ_COORD c_out = proj_trans(P_, PJ_FWD, c);
   return BasicPoint3d{c_out.xy.x, c_out.xy.y, 0};
 }
 
 BasicPoint3d LocalFrameProjector::projectECEF(const BasicPoint3d& p, const int& proj_dir) const
 {
+  static PJ* ecef_in_map_proj = proj_create_crs_to_crs(PJ_DEFAULT_CTX, map_proj_string_.c_str(), ECEF_PROJ_STR, NULL);
+  
   PJ_COORD c{{p[0], p[1], p[2], 0}};
   PJ_COORD c_out;
+
   if (proj_dir == 1)
-    c_out = proj_trans(P, PJ_FWD, c);
+    c_out = proj_trans(ecef_in_map_proj, PJ_FWD, c);
   else if (proj_dir == -1)
-    c_out = proj_trans(P, PJ_INV, c);
+    c_out = proj_trans(ecef_in_map_proj, PJ_INV, c);
   else
   {
     throw std::invalid_argument(std::string("In function ") + __FUNCTION__ + std::string(": Error:  invalid projection direction: ") + 
@@ -56,7 +65,8 @@ BasicPoint3d LocalFrameProjector::projectECEF(const BasicPoint3d& p, const int& 
 GPSPoint LocalFrameProjector::reverse(const BasicPoint3d& p) const
 {
   PJ_COORD c{{p[0], p[1], p[2], 0}};
-  PJ_COORD c_out = proj_trans(P, PJ_INV, c);
+  PJ_COORD c_out = proj_trans(P_, PJ_INV, c);
+
   return GPSPoint{c_out.lp.lam, c_out.lp.phi};
 }
 

--- a/common/lanelet2_extension/test/src/test_local_projector.cpp
+++ b/common/lanelet2_extension/test/src/test_local_projector.cpp
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2015-2019 Autoware Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <ros/ros.h>
+
+#include <gtest/gtest.h>
+#include <math.h>
+
+#include <lanelet2_extension/projection/local_frame_projector.h>
+// TODO
+
+TEST(LocalProjector, ForwardProjection)
+{
+  std::string map_frame = "+proj=tmerc +lat_0=38.95197911150576 +lon_0=-77.14835128349988 +k=1 +x_0=0 +y_0=0 +datum=WGS84 +units=m +vunits=m +no_defs";
+  lanelet::projection::LocalFrameProjector projector(map_frame.c_str());
+
+  lanelet::GPSPoint gps_point;
+  gps_point.lat = 38.95197911150576;
+  gps_point.lon = -77.14835128349988;
+  gps_point.ele = 51.6;
+  lanelet::BasicPoint3d local_point = projector.forward(gps_point);
+
+  ASSERT_DOUBLE_EQ(local_point.x(), 0.0);
+  ASSERT_DOUBLE_EQ(local_point.y(), 0.0);
+  ASSERT_DOUBLE_EQ(local_point.z(), gps_point.ele);
+}
+
+TEST(LocalProjector, ReverseProjection)
+{
+  std::string map_frame = "+proj=tmerc +lat_0=38.95197911150576 +lon_0=-77.14835128349988 +k=1 +x_0=0 +y_0=0 +datum=WGS84 +units=m +vunits=m +no_defs";
+  lanelet::projection::LocalFrameProjector projector(map_frame.c_str());
+
+  lanelet::BasicPoint3d local_point;
+  local_point.x() = 0.0;
+  local_point.y() = 0.0;
+  local_point.z() = 51.6;
+
+  lanelet::GPSPoint gps_point = projector.reverse(local_point);
+
+  ASSERT_DOUBLE_EQ(gps_point.lat, 38.95197911150576);
+  ASSERT_DOUBLE_EQ(gps_point.lon, -77.14835128349988);
+  ASSERT_DOUBLE_EQ(gps_point.ele, local_point.z());
+}
+
+// TEST(LocalProjector, ReverseProjection)
+// {
+//   lanelet::projection::MGRSProjector projector;
+//   lanelet::BasicPoint3d mgrs_point;
+//   mgrs_point.x() = 94946.0;
+//   mgrs_point.y() = 46063.0;
+//   mgrs_point.z() = 12.3456789;
+
+//   projector.setMGRSCode("54SUE");
+//   lanelet::GPSPoint gps_point = projector.reverse(mgrs_point);
+
+//   // projected z value should not change
+//   ASSERT_DOUBLE_EQ(gps_point.ele, mgrs_point.z()) << "Reverse projected z value should be " << mgrs_point.z();
+
+//   // https://www.movable-type.co.uk/scripts/latlong-utm-mgrs.html
+//   // round the projected value since the above reference only gives value up to
+//   // precision of 1e-8
+//   double rounded_lat = round(gps_point.lat * 1e8) / 1e8;
+//   ASSERT_DOUBLE_EQ(rounded_lat, 35.65282525) << "Reverse projected latitude value should be " << 35.65282525;
+//   double rounded_lon = round(gps_point.lon * 1e8) / 1e8;
+//   ASSERT_DOUBLE_EQ(rounded_lon, 139.83947721) << "Reverse projected longitude value should be " << 139.83947721;
+// }

--- a/common/lanelet2_extension/test/src/test_local_projector.cpp
+++ b/common/lanelet2_extension/test/src/test_local_projector.cpp
@@ -20,7 +20,6 @@
 #include <math.h>
 
 #include <lanelet2_extension/projection/local_frame_projector.h>
-// TODO
 
 TEST(LocalProjector, ForwardProjection)
 {
@@ -54,26 +53,3 @@ TEST(LocalProjector, ReverseProjection)
   ASSERT_DOUBLE_EQ(gps_point.lon, -77.14835128349988);
   ASSERT_DOUBLE_EQ(gps_point.ele, local_point.z());
 }
-
-// TEST(LocalProjector, ReverseProjection)
-// {
-//   lanelet::projection::MGRSProjector projector;
-//   lanelet::BasicPoint3d mgrs_point;
-//   mgrs_point.x() = 94946.0;
-//   mgrs_point.y() = 46063.0;
-//   mgrs_point.z() = 12.3456789;
-
-//   projector.setMGRSCode("54SUE");
-//   lanelet::GPSPoint gps_point = projector.reverse(mgrs_point);
-
-//   // projected z value should not change
-//   ASSERT_DOUBLE_EQ(gps_point.ele, mgrs_point.z()) << "Reverse projected z value should be " << mgrs_point.z();
-
-//   // https://www.movable-type.co.uk/scripts/latlong-utm-mgrs.html
-//   // round the projected value since the above reference only gives value up to
-//   // precision of 1e-8
-//   double rounded_lat = round(gps_point.lat * 1e8) / 1e8;
-//   ASSERT_DOUBLE_EQ(rounded_lat, 35.65282525) << "Reverse projected latitude value should be " << 35.65282525;
-//   double rounded_lon = round(gps_point.lon * 1e8) / 1e8;
-//   ASSERT_DOUBLE_EQ(rounded_lon, 139.83947721) << "Reverse projected longitude value should be " << 139.83947721;
-// }

--- a/common/map_file/include/map_file/map_param_loader.h
+++ b/common/map_file/include/map_file/map_param_loader.h
@@ -27,8 +27,8 @@
 
 namespace map_param_loader
 {
-// Get transform from map_frame coord to ecef_frame coord using respective proj strings.
-tf2::Transform getTransform(const std::string& map_frame, const std::string& ecef_frame);
+// Get transform from map_frame to ecef_frame using respective proj strings.
+tf2::Transform getTransform(const std::string& map_frame);
 
 // Broadcast the input transform to tf_static.
 void broadcastTransform(const tf2::Transform& transform);

--- a/common/map_file/nodes/lanelet2_map_loader/lanelet2_map_loader.cpp
+++ b/common/map_file/nodes/lanelet2_map_loader/lanelet2_map_loader.cpp
@@ -70,9 +70,9 @@ int main(int argc, char** argv)
   lanelet::LaneletMapPtr map;
   
   int projector_type = 0;
-  std::string base_frame , target_frame;
+  std::string target_frame;
   // Parse geo reference info from the lanelet map (.osm)
-  lanelet::io_handlers::AutowareOsmParser::parseMapParams(lanelet2_filename, &projector_type, &base_frame, &target_frame);
+  lanelet::io_handlers::AutowareOsmParser::parseMapParams(lanelet2_filename, &projector_type, &target_frame);
 
   if(projector_type == 0)
   {
@@ -80,7 +80,7 @@ int main(int argc, char** argv)
     map = lanelet::load(lanelet2_filename, projector, &errors);
   } else if(projector_type == 1)
   {
-    lanelet::projection::LocalFrameProjector local_projector(base_frame.c_str(), target_frame.c_str());
+    lanelet::projection::LocalFrameProjector local_projector(target_frame.c_str());
     map = lanelet::load(lanelet2_filename, local_projector, &errors);
   }
 

--- a/common/map_file/nodes/map_param_loader/map_param_loader.cpp
+++ b/common/map_file/nodes/map_param_loader/map_param_loader.cpp
@@ -19,10 +19,10 @@
 namespace map_param_loader
 {
 // Get transform from map_frame coord to ecef_frame coord using respective proj strings
-tf2::Transform getTransform(const std::string& map_frame, const std::string& ecef_frame)
+tf2::Transform getTransform(const std::string& map_frame)
 {
 
-  lanelet::projection::LocalFrameProjector local_projector(map_frame.c_str(), ecef_frame.c_str());
+  lanelet::projection::LocalFrameProjector local_projector(map_frame.c_str());
   
   tf2::Matrix3x3 rot_mat, id = tf2::Matrix3x3::getIdentity();
   lanelet::BasicPoint3d origin_in_map{0,0,0}, origin_in_ecef;
@@ -76,14 +76,14 @@ int main(int argc, char **argv)
   ros::NodeHandle private_nh("~");
 
   int projector_type = 1; // default value
-  std::string base_frame , target_frame, lanelet2_filename;
+  std::string target_frame, lanelet2_filename;
   private_nh.param<std::string>("file_name", lanelet2_filename, "");
   
   // Parse geo reference info from the lanelet map (.osm)
-  lanelet::io_handlers::AutowareOsmParser::parseMapParams(lanelet2_filename, &projector_type, &base_frame, &target_frame);
+  lanelet::io_handlers::AutowareOsmParser::parseMapParams(lanelet2_filename, &projector_type, &target_frame);
 
-  // Get the transform (when parsed target_frame is map_frame, and base_frame is ECEF)
-  tf2::Transform tf = map_param_loader::getTransform(target_frame, base_frame);
+  // Get the transform to ecef (when parsed target_frame is map_frame)
+  tf2::Transform tf = map_param_loader::getTransform(target_frame);
 
   // Broadcast the transform
   map_param_loader::broadcastTransform(tf);

--- a/common/map_file/test/test_get_transform.cpp
+++ b/common/map_file/test/test_get_transform.cpp
@@ -17,17 +17,15 @@
 
 #include <gtest/gtest.h>
 #include <map_file/map_param_loader.h>
-//#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 
 
 TEST(GetTransformTest, testECEFPoints)
 {
     //Example frames
-    std::string map_frame = "+proj=tmerc +lat_0=38.95197911150576 +lon_0=-77.14835128349988 +k=1 +x_0=0 +y_0=0 +units=m +vunits=m";
-    std::string ecef_frame = "+proj=geocent +ellps=WGS84 +datum=WGS84 +units=m +no_defs";
+    std::string map_frame = "+proj=tmerc +lat_0=38.95197911150576 +lon_0=-77.14835128349988 +k=1 +x_0=0 +y_0=0 +datum=WGS84 +units=m +vunits=m +no_defs";
 
     //Points are calculated using cs2cs command line function of proj library.
-    tf2::Transform tf = map_param_loader::getTransform(map_frame, ecef_frame);
+    tf2::Transform tf = map_param_loader::getTransform(map_frame);
     tf2::Vector3 origin = tf(tf2::Vector3{0,0,0});
     ASSERT_FLOAT_EQ (origin[0],1104726.07);
     ASSERT_FLOAT_EQ (origin[1],-4842261.44);


### PR DESCRIPTION
This PR resolves issue usdot-fhwa-stol/CARMAPlatform#574 by updating the projectECEF function to store the ECEF projection internally rather than requiring it to be passed in as the base frame. In addition, the structure of the projector is simplified so that it only needs the georeference and not a base frame to be specified for basic projections to be performed. A new unit test was also added to cover the projection logic. In addition some errors in the projection logic were fixed (deg vs rad). The unit tests still pass. 