### PR TITLE
EKF and NDT updates to support gps failover

### DIFF
--- a/core_perception/ekf_localizer/README.md
+++ b/core_perception/ekf_localizer/README.md
@@ -124,6 +124,8 @@ The parameters are set in `launch/ekf_localizer.launch` .
 |tf_rate|double|Frqcuency for tf broadcasting [Hz]|10.0|
 |extend_state_step|int|Max delay step which can be dealt with in EKF. Large number increases computational cost. |50|
 |enable_yaw_bias_estimation| bool |Flag to enable yaw bias estimation|true|
+|pose_frame_id| string |TF base frame name|map|
+|child_frame_id| string |TF child frame name|base_link|
 
 ## For pose measurement
 

--- a/core_perception/ekf_localizer/include/ekf_localizer/ekf_localizer.h
+++ b/core_perception/ekf_localizer/include/ekf_localizer/ekf_localizer.h
@@ -68,7 +68,8 @@ private:
   double ekf_dt_;                    //!< @brief  = 1 / ekf_rate_
   double tf_rate_;                   //!< @brief  tf publish rate
   bool enable_yaw_bias_estimation_;  //!< @brief  for LiDAR mount error. if true, publish /estimate_yaw_bias
-  std::string pose_frame_id_;
+  std::string pose_frame_id_;        //!< @brief  Base frame for pose and tf output
+  std::string child_frame_id_;       //!< @brief Child frame for pose and tf output
 
   int dim_x_;              //!< @brief  dimension of EKF state
   int extend_state_step_;  //!< @brief  for time delay compensation

--- a/core_perception/ekf_localizer/include/ekf_localizer/ekf_localizer.h
+++ b/core_perception/ekf_localizer/include/ekf_localizer/ekf_localizer.h
@@ -68,8 +68,8 @@ private:
   double ekf_dt_;                    //!< @brief  = 1 / ekf_rate_
   double tf_rate_;                   //!< @brief  tf publish rate
   bool enable_yaw_bias_estimation_;  //!< @brief  for LiDAR mount error. if true, publish /estimate_yaw_bias
-  std::string pose_frame_id_;        //!< @brief  Base frame for pose and tf output
-  std::string child_frame_id_;       //!< @brief Child frame for pose and tf output
+  std::string pose_frame_id_;        //!< @brief  Parent frame for pose and tf output
+  std::string child_frame_id_;       //!< @brief  Child frame for pose and tf output
 
   int dim_x_;              //!< @brief  dimension of EKF state
   int extend_state_step_;  //!< @brief  for time delay compensation

--- a/core_perception/ekf_localizer/launch/ekf_localizer.launch
+++ b/core_perception/ekf_localizer/launch/ekf_localizer.launch
@@ -5,7 +5,8 @@
   <arg name="predict_frequency" default="50.0"/>
   <arg name="tf_rate" default="10.0"/>
   <arg name="extend_state_step" default="50"/>
-
+  <arg name="pose_frame_id" default="map"/>
+  <arg name="child_frame_id" default="base_link"/>
 
   <!-- for Pose measurement -->
   <arg name="use_pose_with_covariance" default="false"/>
@@ -48,7 +49,8 @@
     <remap if="$(arg use_twist_with_covariance)" from="in_twist" to="input_twist_UNUSED"/>
     <remap if="$(arg use_twist_with_covariance)" from="in_twist_with_covariance" to="$(arg input_twist_with_cov_name)"/>
 
-    <param name="pose_frame_id" value="map"/>
+    <param name="pose_frame_id" value="$(arg pose_frame_id)"/>
+    <param name="child_frame_id" value="$(arg child_frame_id)"/>
 
     <param name="show_debug_info" value="$(arg show_debug_info)"/>
     <param name="enable_yaw_bias_estimation" value="$(arg enable_yaw_bias_estimation)"/>

--- a/core_perception/ekf_localizer/src/ekf_localizer.cpp
+++ b/core_perception/ekf_localizer/src/ekf_localizer.cpp
@@ -562,7 +562,7 @@ void EKFLocalizer::measurementUpdateTwist(const geometry_msgs::TwistStamped& twi
 {
   if (twist.header.frame_id != child_frame_id_)
   {
-    ROS_WARN_DELAYED_THROTTLE(2.0, "twist frame_id must be " + child_frame_id_);
+    ROS_WARN_DELAYED_THROTTLE(2.0, "twist frame_id must be " + child_frame_id_.c_str());
   }
 
   Eigen::MatrixXd X_curr(dim_x_, 1);  // curent state

--- a/core_perception/ekf_localizer/src/ekf_localizer.cpp
+++ b/core_perception/ekf_localizer/src/ekf_localizer.cpp
@@ -177,7 +177,7 @@ void EKFLocalizer::setCurrentResult()
   q_tf.setRPY(roll, pitch, yaw);
   tf2::convert(q_tf, current_ekf_pose_.pose.orientation);
 
-  current_ekf_twist_.header.frame_id = "base_link";
+  current_ekf_twist_.header.frame_id = child_frame_id_;
   current_ekf_twist_.header.stamp = ros::Time::now();
   current_ekf_twist_.twist.linear.x = ekf_.getXelement(IDX::VX);
   current_ekf_twist_.twist.angular.z = ekf_.getXelement(IDX::WZ);
@@ -560,9 +560,9 @@ void EKFLocalizer::measurementUpdatePose(const geometry_msgs::PoseStamped& pose)
  */
 void EKFLocalizer::measurementUpdateTwist(const geometry_msgs::TwistStamped& twist)
 {
-  if (twist.header.frame_id != "base_link")
+  if (twist.header.frame_id != child_frame_id_)
   {
-    ROS_WARN_DELAYED_THROTTLE(2.0, "twist frame_id must be base_link");
+    ROS_WARN_DELAYED_THROTTLE(2.0, "twist frame_id must be " + child_frame_id_);
   }
 
   Eigen::MatrixXd X_curr(dim_x_, 1);  // curent state

--- a/core_perception/ekf_localizer/src/ekf_localizer.cpp
+++ b/core_perception/ekf_localizer/src/ekf_localizer.cpp
@@ -562,7 +562,7 @@ void EKFLocalizer::measurementUpdateTwist(const geometry_msgs::TwistStamped& twi
 {
   if (twist.header.frame_id != child_frame_id_)
   {
-    ROS_WARN_DELAYED_THROTTLE(2.0, "twist frame_id must be " + child_frame_id_.c_str());
+    ROS_WARN_STREAM_DELAYED_THROTTLE(2.0, "twist frame_id must be " << child_frame_id_);
   }
 
   Eigen::MatrixXd X_curr(dim_x_, 1);  // curent state

--- a/core_perception/ekf_localizer/src/ekf_localizer.cpp
+++ b/core_perception/ekf_localizer/src/ekf_localizer.cpp
@@ -31,6 +31,7 @@ EKFLocalizer::EKFLocalizer() : nh_(""), pnh_("~"), dim_x_(6 /* x, y, yaw, yaw_bi
   pnh_.param("enable_yaw_bias_estimation", enable_yaw_bias_estimation_, bool(true));
   pnh_.param("extend_state_step", extend_state_step_, int(50));
   pnh_.param("pose_frame_id", pose_frame_id_, std::string("/map"));
+  pnh_.param("child_frame_id", child_frame_id_, std::string("base_link"));
 
   /* pose measurement */
   pnh_.param("pose_additional_delay", pose_additional_delay_, double(0.0));
@@ -193,7 +194,7 @@ void EKFLocalizer::timerTFCallback(const ros::TimerEvent& e)
   geometry_msgs::TransformStamped transformStamped;
   transformStamped.header.stamp = ros::Time::now();
   transformStamped.header.frame_id = current_ekf_pose_.header.frame_id;
-  transformStamped.child_frame_id = "ekf_pose";
+  transformStamped.child_frame_id = child_frame_id_;
   transformStamped.transform.translation.x = current_ekf_pose_.pose.position.x;
   transformStamped.transform.translation.y = current_ekf_pose_.pose.position.y;
   transformStamped.transform.translation.z = current_ekf_pose_.pose.position.z;

--- a/core_perception/lidar_localizer/launch/ndt_matching.launch
+++ b/core_perception/lidar_localizer/launch/ndt_matching.launch
@@ -10,7 +10,7 @@
   <arg name="queue_size" default="1" />
   <arg name="offset" default="linear" />
   <arg name="get_height" default="false" />
-  <arg name="use_local_transform" default="false" doc="This parameter is deprecated"/>/>
+  <arg name="use_local_transform" default="false" doc="This parameter is deprecated"/>
   <arg name="sync" default="false" />
   <arg name="output_log_data" default="false" />
   <arg name="gnss_reinit_fitness" default="500.0" />

--- a/core_perception/lidar_localizer/launch/ndt_matching.launch
+++ b/core_perception/lidar_localizer/launch/ndt_matching.launch
@@ -10,10 +10,11 @@
   <arg name="queue_size" default="1" />
   <arg name="offset" default="linear" />
   <arg name="get_height" default="false" />
-  <arg name="use_local_transform" default="false" />
+  <arg name="use_local_transform" default="false" doc="This parameter is deprecated"/>/>
   <arg name="sync" default="false" />
   <arg name="output_log_data" default="false" />
   <arg name="gnss_reinit_fitness" default="500.0" />
+  <arg name="base_frame" default="base_link" />
 
   <node pkg="lidar_localizer" type="ndt_matching" name="ndt_matching" output="log">
     <param name="method_type" value="$(arg method_type)" />
@@ -28,6 +29,7 @@
     <param name="use_local_transform" value="$(arg use_local_transform)" />
     <param name="output_log_data" value="$(arg output_log_data)" />
     <param name="gnss_reinit_fitness" value="$(arg gnss_reinit_fitness)" />
+    <param name="base_frame" value="$(arg base_frame)" />
     <remap from="/points_raw" to="/sync_drivers/points_raw" if="$(arg sync)" />
   </node>
 


### PR DESCRIPTION
This PR updates the EKF and NDT nodes such that the parent and child frames expected/used by each can be specified by a parameter or read from the incoming message. This will allow for the EKF to be placed after the gnss_ndt_selector to support the Lidar failover to GPS demonstration with the trucks. 

One additional change is that the all the subscriptions, except the config topic for NDT matching, had their queue size set to 1 by default. There was no need to be processing multiple instances of the odometry or imu data before an execution of ndt matching. Additionally, the call to ros::spin() in ndt_matching.cpp was replaced with a 10 hz ros::spinOnce() call as ros::spin() does not actually operate at 10hz.

Supports issue usdot-fhwa-stol/CARMAPlatform#600