### PR TITLE
fix edge case of vector_map loading incorrectly 

### DIFF
--- a/common/lanelet2_extension/lib/autoware_osm_parser.cpp
+++ b/common/lanelet2_extension/lib/autoware_osm_parser.cpp
@@ -77,7 +77,9 @@ void AutowareOsmParser::parseVersions(const std::string& filename, std::string* 
   auto result = doc.load_file(filename.c_str());
   if (!result)
   {
-    throw lanelet::ParseError(std::string("Errors occured while parsing osm file: ") + result.description());
+    throw lanelet::ParseError(std::string("In function ") + __FUNCTION__ + 
+    std::string(":\nErrors occured while parsing osm file: ") + result.description());
+    return;
   }
 
   auto osmNode = doc.child("osm");
@@ -93,7 +95,7 @@ void AutowareOsmParser::parseMapParams (const std::string& filename, int* projec
   if (target_frame == nullptr)
   {
     throw lanelet::ParseError(std::string("In function ") + __FUNCTION__ + 
-    std::string(": Errors occured while parsing .osm file - target frame is a null pointer!"));
+    std::string(":\nErrors occured while parsing .osm file - target frame is a null pointer!"));
     return;
   }
 
@@ -101,16 +103,17 @@ void AutowareOsmParser::parseMapParams (const std::string& filename, int* projec
   auto result = doc.load_file(filename.c_str());
   if (!result)
   {
-    throw lanelet::ParseError(std::string("Errors occured while parsing .osm file: ") + result.description());
+    throw lanelet::ParseError(std::string("In function ") + __FUNCTION__ + 
+    std::string(":\nErrors occured while parsing .osm file: ") + result.description());
+    return;
   }
 
   auto osmNode = doc.child("osm");
   auto geoRef = osmNode.child("geoReference");
 
-  if (geoRef)
+  if (geoRef && std::string(geoRef.child_value()) != "")
   {
     std::string raw_geo_ref = geoRef.child_value();
-
     // Filter unnecessary part out of georeference.
     std::vector<std::string> buffer;
     boost::split(buffer,  raw_geo_ref, boost::is_any_of(" "));
@@ -126,7 +129,9 @@ void AutowareOsmParser::parseMapParams (const std::string& filename, int* projec
   }
   else
   {
-    throw lanelet::ParseError(std::string("While parsing .osm file, geoReference was not found!"));
+    throw lanelet::ParseError(std::string("In function ") + __FUNCTION__ + 
+    std::string(":\nWhile parsing .osm file, geoReference was not found! Please check geoReference syntax in vector_map.osm"));
+    return;
   }
 
   // Default values


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

Added extra case check where geoReference tag is present, but with wrong syntax which results in the vector_map not loading.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/usdot-fhwa-stol/CARMAPlatform/issues/608
## Motivation and Context

Vector_map.osm was not loading correctly even though the geoReference was inside the map file.

<!--- Why is this change required? What problem does it solve? -->
## How Has This Been Tested?

Tested using CARMAConfig: development locally with TFHRC map.
/tf_static correctly publishes transform and raises exception when `geoReference` is encoded wrongly in `vector_map.osm`
correct:
`<geoReference>+proj=tmerc +lat_0=38.95197911150576 +lon_0=-77.14835128349988 +k=1 +x_0=0 +y_0=0 +datum=WGS84 +geoidgrids=egm96_15.gtx +units=m +vunits=m +no_defs</geoReference>`
wrong:
`<geoReference v="+proj=tmerc +lat_0=38.95197911150576 +lon_0=-77.14835128349988 +k=1 +x_0=0 +y_0=0 +datum=WGS84 +geoidgrids=egm96_15.gtx +units=m +vunits=m +no_defs"/>`
And now it additionally checks if the tag is empty or not.
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](Contributing.md) 
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.