### PR TITLE
Feature/search llt ref

### DIFF
--- a/common/lanelet2_extension/include/lanelet2_extension/utility/impl/query.h
+++ b/common/lanelet2_extension/include/lanelet2_extension/utility/impl/query.h
@@ -7,13 +7,21 @@ namespace lanelet
 {
 namespace utils
 {
+// Declaration of recurse func. Following recurse functions are helper functions for each primitives
+void recurse (lanelet::Point3d prim,const lanelet::LaneletMapPtr ll_Map, query::direction check_dir, query::References& rfs);
+void recurse (lanelet::LineString3d prim, const lanelet::LaneletMapPtr ll_Map, query::direction check_dir, query::References& rfs);
+void recurse (lanelet::Lanelet prim,const lanelet::LaneletMapPtr ll_Map, query::direction check_dir, query::References& rfs);
+void recurse (lanelet::Area prim,const lanelet::LaneletMapPtr ll_Map, query::direction check_dir, query::References& rfs);
+void recurse (lanelet::RegulatoryElementPtr prim_ptr,const lanelet::LaneletMapPtr ll_Map, query::direction check_dir, query::References& rfs);
+
 // Depending on the type of input, different recurse functions will be called
 // primT: Point, LS, llt, regem, polygon
-
 template <class primT>
-void query::referenceFinder::run(primT prim, const lanelet::LaneletMapPtr ll_Map)
+query::References query::findReferences(primT prim, const lanelet::LaneletMapPtr ll_Map)
 {
-  recurse(prim, ll_Map, query::direction::CHECK_CHILD);
+  query::References references;
+  recurse(prim, ll_Map, query::direction::CHECK_CHILD, references);
+  return references;
 } 
 } // namespace utils
 } // namespace lanelet

--- a/common/lanelet2_extension/include/lanelet2_extension/utility/impl/query.h
+++ b/common/lanelet2_extension/include/lanelet2_extension/utility/impl/query.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <ros/ros.h>
+#include <lanelet2_extension/utility/query.h>
+
+namespace lanelet
+{
+namespace utils
+{
+// Depending on the type of input, different recurse functions will be called
+// primT: Point, LS, llt, regem, polygon
+
+template <class primT>
+void query::referenceFinder::run(primT prim, const lanelet::LaneletMapPtr ll_Map)
+{
+  recurse(prim, ll_Map, query::direction::CHECK_CHILD);
+} 
+} // namespace utils
+} // namespace lanelet

--- a/common/lanelet2_extension/include/lanelet2_extension/utility/query.h
+++ b/common/lanelet2_extension/include/lanelet2_extension/utility/query.h
@@ -151,6 +151,8 @@ std::vector<lanelet::ConstLineString3d> stopSignStopLines(const lanelet::ConstLa
 }  // namespace utils
 }  // namespace lanelet
 
-#include <lanelet2_extension/utility/impl/query.h>
+// Template functions cannot be linked unless the implementation is provided
+// Therefore include implementation to allow for template functions
+#include "../../../lib/query.tpp"
 
 #endif  // LANELET2_EXTENSION_UTILITY_QUERY_H

--- a/common/lanelet2_extension/include/lanelet2_extension/utility/query.h
+++ b/common/lanelet2_extension/include/lanelet2_extension/utility/query.h
@@ -49,10 +49,9 @@ namespace utils
 namespace query
 {
 enum direction {CHECK_CHILD,CHECK_PARENT};
-class referenceFinder
+struct References
 {
-    public:
-    referenceFinder() {};
+    References() {};
     struct comparator
     {
         template <typename PrimT>
@@ -64,36 +63,19 @@ class referenceFinder
             return prim1->id() == prim2->id();
         }
     };
-    
-    /**
-     * [TODO]
-     * @param  ll_Map [TODO]
-     * @return        [TODO]
-     */
-    template <class primT>
-    void run (primT prim, const lanelet::LaneletMapPtr ll_Map);
-    // following recurse functions are helper functions for each primitives
-
-    // Point
-    void recurse (lanelet::Point3d prim,const lanelet::LaneletMapPtr ll_Map, direction check_dir);
-    // LS
-    void recurse (lanelet::LineString3d prim, const lanelet::LaneletMapPtr ll_Map, direction check_dir);
-    // Lanelet
-    void recurse (lanelet::Lanelet prim,const lanelet::LaneletMapPtr ll_Map, direction check_dir);
-    // Area
-    void recurse (lanelet::Area prim,const lanelet::LaneletMapPtr ll_Map, direction check_dir);
-    // Regem
-    void recurse (lanelet::RegulatoryElementPtr prim_ptr,const lanelet::LaneletMapPtr ll_Map, direction check_dir);
-    // Comparator
     std::unordered_set<lanelet::Point3d, std::hash<lanelet::Point3d>, comparator> pts;
     std::unordered_set<lanelet::LineString3d, std::hash<lanelet::LineString3d>, comparator> lss;
     std::unordered_set<lanelet::Lanelet, std::hash<lanelet::Lanelet>, comparator> llts;
     std::unordered_set<lanelet::Area, std::hash<lanelet::Area>, comparator> areas;
     std::unordered_set<lanelet::RegulatoryElementPtr, std::hash<lanelet::RegulatoryElementPtr>, comparator> regems;
-    private:
-    // will put sets here once finished
 };
-
+/**
+ * [TODO]
+ * @param  ll_Map [TODO]
+ * @return        [TODO]
+ */
+template <class primT>
+References findReferences (primT prim, const lanelet::LaneletMapPtr ll_Map);
 
 /**
  * [laneletLayer converts laneletLayer into lanelet vector]

--- a/common/lanelet2_extension/include/lanelet2_extension/utility/query.h
+++ b/common/lanelet2_extension/include/lanelet2_extension/utility/query.h
@@ -49,13 +49,51 @@ namespace utils
 namespace query
 {
 enum direction {CHECK_CHILD,CHECK_PARENT};
-/**
- * [TODO]
- * @param  ll_Map [TODO]
- * @return        [TODO]
- */
-template <typename T, typename primT>
-std::vector<Primitive<T>> findReferences (const primT prim, const lanelet::LaneletMapPtr ll_Map);
+class referenceFinder
+{
+    public:
+    referenceFinder() {};
+    struct comparator
+    {
+        template <typename PrimT>
+        bool operator()(const PrimT& prim1, const PrimT& prim2) const {
+            return prim1.id() == prim2.id();
+        }
+        bool operator()(const lanelet::RegulatoryElementPtr& prim1, 
+        const lanelet::RegulatoryElementPtr& prim2) const {
+            return prim1->id() == prim2->id();
+        }
+    };
+    
+    /**
+     * [TODO]
+     * @param  ll_Map [TODO]
+     * @return        [TODO]
+     */
+    template <class primT>
+    void run (primT prim, const lanelet::LaneletMapPtr ll_Map);
+    // following recurse functions are helper functions for each primitives
+
+    // Point
+    void recurse (lanelet::Point3d prim,const lanelet::LaneletMapPtr ll_Map, direction check_dir);
+    // LS
+    void recurse (lanelet::LineString3d prim, const lanelet::LaneletMapPtr ll_Map, direction check_dir);
+    // Lanelet
+    void recurse (lanelet::Lanelet prim,const lanelet::LaneletMapPtr ll_Map, direction check_dir);
+    // Area
+    void recurse (lanelet::Area prim,const lanelet::LaneletMapPtr ll_Map, direction check_dir);
+    // Regem
+    void recurse (lanelet::RegulatoryElementPtr prim_ptr,const lanelet::LaneletMapPtr ll_Map, direction check_dir);
+    // Comparator
+    std::unordered_set<lanelet::Point3d, std::hash<lanelet::Point3d>, comparator> pts;
+    std::unordered_set<lanelet::LineString3d, std::hash<lanelet::LineString3d>, comparator> lss;
+    std::unordered_set<lanelet::Lanelet, std::hash<lanelet::Lanelet>, comparator> llts;
+    std::unordered_set<lanelet::Area, std::hash<lanelet::Area>, comparator> areas;
+    std::unordered_set<lanelet::RegulatoryElementPtr, std::hash<lanelet::RegulatoryElementPtr>, comparator> regems;
+    private:
+    // will put sets here once finished
+};
+
 
 /**
  * [laneletLayer converts laneletLayer into lanelet vector]
@@ -130,5 +168,7 @@ std::vector<lanelet::ConstLineString3d> stopSignStopLines(const lanelet::ConstLa
 }  // namespace query
 }  // namespace utils
 }  // namespace lanelet
+
+#include <lanelet2_extension/utility/impl/query.h>
 
 #endif  // LANELET2_EXTENSION_UTILITY_QUERY_H

--- a/common/lanelet2_extension/include/lanelet2_extension/utility/query.h
+++ b/common/lanelet2_extension/include/lanelet2_extension/utility/query.h
@@ -58,24 +58,23 @@ struct References
         bool operator()(const PrimT& prim1, const PrimT& prim2) const {
             return prim1.id() == prim2.id();
         }
-        bool operator()(const lanelet::RegulatoryElementPtr& prim1, 
-        const lanelet::RegulatoryElementPtr& prim2) const {
+        bool operator()(const lanelet::RegulatoryElementConstPtr& prim1, 
+        const lanelet::RegulatoryElementConstPtr& prim2) const {
             return prim1->id() == prim2->id();
         }
     };
-    std::unordered_set<lanelet::Point3d, std::hash<lanelet::Point3d>, comparator> pts;
-    std::unordered_set<lanelet::LineString3d, std::hash<lanelet::LineString3d>, comparator> lss;
-    std::unordered_set<lanelet::Lanelet, std::hash<lanelet::Lanelet>, comparator> llts;
-    std::unordered_set<lanelet::Area, std::hash<lanelet::Area>, comparator> areas;
-    std::unordered_set<lanelet::RegulatoryElementPtr, std::hash<lanelet::RegulatoryElementPtr>, comparator> regems;
+    std::unordered_set<lanelet::ConstLineString3d, std::hash<lanelet::ConstLineString3d>, comparator> lss;
+    std::unordered_set<lanelet::ConstLanelet, std::hash<lanelet::ConstLanelet>, comparator> llts;
+    std::unordered_set<lanelet::ConstArea, std::hash<lanelet::ConstArea>, comparator> areas;
+    std::unordered_set<lanelet::RegulatoryElementConstPtr, std::hash<lanelet::RegulatoryElementConstPtr>, comparator> regems;
 };
 /**
- * [TODO]
- * @param  ll_Map [TODO]
- * @return        [TODO]
+ * [findReferences finds all primitives that reference the given primitive in a given map]
+ * @param  ll_Map [input lanelet map]
+ * @return        [References object with referenced element sets for each primitive layers]
  */
 template <class primT>
-References findReferences (primT prim, const lanelet::LaneletMapPtr ll_Map);
+References findReferences (const primT& prim, const lanelet::LaneletMapPtr ll_Map);
 
 /**
  * [laneletLayer converts laneletLayer into lanelet vector]

--- a/common/lanelet2_extension/include/lanelet2_extension/utility/query.h
+++ b/common/lanelet2_extension/include/lanelet2_extension/utility/query.h
@@ -72,6 +72,7 @@ struct References
  * [findReferences finds all primitives that reference the given primitive in a given map]
  * @param  ll_Map [input lanelet map]
  * @return        [References object with referenced element sets for each primitive layers]
+ * NOTE: Polygons and Compound primitives such as LaneletOrArea are not currently supported
  */
 template <class primT>
 References findReferences (const primT& prim, const lanelet::LaneletMapPtr ll_Map);

--- a/common/lanelet2_extension/include/lanelet2_extension/utility/query.h
+++ b/common/lanelet2_extension/include/lanelet2_extension/utility/query.h
@@ -21,6 +21,12 @@
 
 #include <lanelet2_core/LaneletMap.h>
 #include <lanelet2_core/primitives/Lanelet.h>
+#include <lanelet2_core/primitives/Area.h>
+#include <lanelet2_core/primitives/LineString.h>
+#include <lanelet2_core/primitives/Point.h>
+#include <lanelet2_core/primitives/RegulatoryElement.h>
+#include <lanelet2_core/primitives/BasicRegulatoryElements.h>
+#include <lanelet2_core/primitives/Primitive.h>
 
 #include <geometry_msgs/PolygonStamped.h>
 
@@ -28,6 +34,7 @@
 
 #include <vector>
 #include <string>
+#include <unordered_set>
 
 namespace lanelet
 {
@@ -41,6 +48,15 @@ namespace utils
 {
 namespace query
 {
+enum direction {CHECK_CHILD,CHECK_PARENT};
+/**
+ * [TODO]
+ * @param  ll_Map [TODO]
+ * @return        [TODO]
+ */
+template <typename T, typename primT>
+std::vector<Primitive<T>> findReferences (const primT prim, const lanelet::LaneletMapPtr ll_Map);
+
 /**
  * [laneletLayer converts laneletLayer into lanelet vector]
  * @param  ll_Map [input lanelet map]

--- a/common/lanelet2_extension/lib/query.cpp
+++ b/common/lanelet2_extension/lib/query.cpp
@@ -31,6 +31,7 @@ namespace lanelet
 {
 namespace utils
 {
+
 // Point
 void recurse (const lanelet::ConstPoint3d& prim, const lanelet::LaneletMapPtr ll_Map, query::direction check_dir, query::References& rfs)
 {
@@ -38,7 +39,7 @@ void recurse (const lanelet::ConstPoint3d& prim, const lanelet::LaneletMapPtr ll
   // get LineStrings that own this point
   auto ls_list_owning_point = ll_Map->lineStringLayer.findUsages(prim);
 
-  // if it's not owned by anyone, do not record it since points are no meaningful objects in Lanelet
+  // if it's not owned by anyone, do not record it since points are not meaningful objects in Lanelet
   if (ls_list_owning_point.size() == 0)
       return;
 
@@ -129,14 +130,19 @@ void recurse (const lanelet::ConstArea& prim, const lanelet::LaneletMapPtr ll_Ma
   }
 
   // go up, query::CHECK_PARENT
-  // no one 'owns' lanelet, so just add it
+  // no one 'owns' area, so just add it
   rfs.areas.insert(prim);
   return;
 }
 
 // RegulatoryElement
+
 void recurse (const lanelet::RegulatoryElementConstPtr& prim_ptr, const lanelet::LaneletMapPtr ll_Map, query::direction check_dir, query::References& rfs)
 {
+  // go down, query::CHECK_CHILD
+  RecurseVisitor recurse_visitor(ll_Map, check_dir, rfs);
+  prim_ptr->applyVisitor(recurse_visitor);
+  
   // go up, query::CHECK_PARENT
   // process lanelets owning this regem
   auto llt_list_owning_regem = ll_Map->laneletLayer.findUsages(prim_ptr);

--- a/common/lanelet2_extension/lib/query.cpp
+++ b/common/lanelet2_extension/lib/query.cpp
@@ -32,7 +32,6 @@ namespace lanelet
 namespace utils
 {
 //====================================================================================================> DEVELOP START
-
 // Point
 void recurse (lanelet::Point3d prim, const lanelet::LaneletMapPtr ll_Map, query::direction check_dir, query::References& rfs)
 {

--- a/common/lanelet2_extension/lib/query.cpp
+++ b/common/lanelet2_extension/lib/query.cpp
@@ -94,7 +94,6 @@ void recurse (const lanelet::ConstLanelet& prim, const lanelet::LaneletMapPtr ll
     // loop through its child and call recurse down on it
     recurse(prim.leftBound(), ll_Map, check_dir, rfs);
     recurse(prim.rightBound(), ll_Map, check_dir, rfs);
-    recurse(prim.centerline(), ll_Map, check_dir, rfs);
     for (auto regem: prim.regulatoryElements())
       recurse(regem, ll_Map, check_dir, rfs);
     // go back up once finished

--- a/common/lanelet2_extension/lib/query.tpp
+++ b/common/lanelet2_extension/lib/query.tpp
@@ -1,12 +1,5 @@
 #pragma once
 
-#include <ros/ros.h>
-#include <lanelet2_extension/utility/query.h>
-
-/**
- * CPP File containing CARMANodeHandle method definitions
- */
-
 namespace lanelet
 {
 namespace utils

--- a/common/lanelet2_extension/lib/query.tpp
+++ b/common/lanelet2_extension/lib/query.tpp
@@ -5,16 +5,19 @@ namespace lanelet
 namespace utils
 {
 // Declaration of recurse func. Following recurse functions are helper functions for each primitives
-void recurse (lanelet::Point3d prim,const lanelet::LaneletMapPtr ll_Map, query::direction check_dir, query::References& rfs);
-void recurse (lanelet::LineString3d prim, const lanelet::LaneletMapPtr ll_Map, query::direction check_dir, query::References& rfs);
-void recurse (lanelet::Lanelet prim,const lanelet::LaneletMapPtr ll_Map, query::direction check_dir, query::References& rfs);
-void recurse (lanelet::Area prim,const lanelet::LaneletMapPtr ll_Map, query::direction check_dir, query::References& rfs);
-void recurse (lanelet::RegulatoryElementPtr prim_ptr,const lanelet::LaneletMapPtr ll_Map, query::direction check_dir, query::References& rfs);
+void recurse (const lanelet::ConstPoint3d& prim,const lanelet::LaneletMapPtr ll_Map, query::direction check_dir, query::References& rfs);
+void recurse (const lanelet::ConstLineString3d& prim, const lanelet::LaneletMapPtr ll_Map, query::direction check_dir, query::References& rfs);
+void recurse (const lanelet::ConstLanelet& prim,const lanelet::LaneletMapPtr ll_Map, query::direction check_dir, query::References& rfs);
+void recurse (const lanelet::ConstArea& prim,const lanelet::LaneletMapPtr ll_Map, query::direction check_dir, query::References& rfs);
+void recurse (const lanelet::RegulatoryElementConstPtr& prim_ptr,const lanelet::LaneletMapPtr ll_Map, query::direction check_dir, query::References& rfs);
 
-// Depending on the type of input, different recurse functions will be called
-// primT: Point, LS, llt, regem, polygon
+/**
+ * [findReferences finds all primitives that reference the given primitive in a given map]
+ * @param  ll_Map [input lanelet map]
+ * @return        [References object with referenced element sets (including the input if applicable) for each primitive layers]
+ */
 template <class primT>
-query::References query::findReferences(primT prim, const lanelet::LaneletMapPtr ll_Map)
+query::References query::findReferences(const primT& prim, const lanelet::LaneletMapPtr ll_Map)
 {
   query::References references;
   recurse(prim, ll_Map, query::direction::CHECK_CHILD, references);

--- a/common/lanelet2_extension/lib/query.tpp
+++ b/common/lanelet2_extension/lib/query.tpp
@@ -11,11 +11,7 @@ void recurse (const lanelet::ConstLanelet& prim,const lanelet::LaneletMapPtr ll_
 void recurse (const lanelet::ConstArea& prim,const lanelet::LaneletMapPtr ll_Map, query::direction check_dir, query::References& rfs);
 void recurse (const lanelet::RegulatoryElementConstPtr& prim_ptr,const lanelet::LaneletMapPtr ll_Map, query::direction check_dir, query::References& rfs);
 
-/**
- * [findReferences finds all primitives that reference the given primitive in a given map]
- * @param  ll_Map [input lanelet map]
- * @return        [References object with referenced element sets (including the input if applicable) for each primitive layers]
- */
+// Helper visitor class for finding all references in other primities for a given RuleParameter, which is boost::variant
 struct RecurseVisitor : public RuleParameterVisitor {
   explicit RecurseVisitor (const lanelet::LaneletMapPtr ll_Map, query::direction check_dir, query::References& rfs) :
                   ll_Map_(ll_Map), check_dir_(check_dir), rfs_(rfs){}
@@ -38,6 +34,11 @@ struct RecurseVisitor : public RuleParameterVisitor {
   query::References &rfs_;
 };
 
+/**
+ * [findReferences finds all primitives that reference the given primitive in a given map]
+ * @param  ll_Map [input lanelet map]
+ * @return        [References object with referenced element sets (including the input if applicable) for each primitive layers]
+ */
 template <class primT>
 query::References query::findReferences(const primT& prim, const lanelet::LaneletMapPtr ll_Map)
 {

--- a/common/lanelet2_extension/lib/query.tpp
+++ b/common/lanelet2_extension/lib/query.tpp
@@ -3,6 +3,10 @@
 #include <ros/ros.h>
 #include <lanelet2_extension/utility/query.h>
 
+/**
+ * CPP File containing CARMANodeHandle method definitions
+ */
+
 namespace lanelet
 {
 namespace utils

--- a/common/lanelet2_extension/test/src/test_query.cpp
+++ b/common/lanelet2_extension/test/src/test_query.cpp
@@ -16,6 +16,7 @@
 
 #include <gtest/gtest.h>
 #include <lanelet2_extension/utility/query.h>
+#include <lanelet2_extension/regulatory_elements/PassingControlLine.h>
 #include <math.h>
 #include <ros/ros.h>
 
@@ -24,90 +25,178 @@ using lanelet::LineString3d;
 using lanelet::LineStringOrPolygon3d;
 using lanelet::Point3d;
 using lanelet::Points3d;
+using lanelet::Area;
 using lanelet::utils::getId;
 
 class TestSuite : public ::testing::Test
 {
 public:
-  Point3d p1, p2, p3, p4;
-  LineString3d ls_left, ls_right;
-  Point3d p5, p6, p7, p8, p9, p10, p11, p12;
-  LineString3d traffic_light_base, traffic_light_bulbs, stop_line;
-  Lanelet road_lanelet, crosswalk_lanelet;
+  Point3d p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15;
+  LineString3d ls_left, ls_right, ls_right_right, traffic_light_base, 
+    traffic_light_bulbs, stop_line, ls_area_right, ls_area_top, ls_area_bottom;
+  lanelet::ConstLineString3d centerline;
+  Lanelet road_lanelet, road_lanelet1, crosswalk_lanelet;
+  Area side_area;
   lanelet::autoware::AutowareTrafficLight::Ptr tl;
+  std::shared_ptr<lanelet::PassingControlLine> pcl;
 
   TestSuite() : sample_map_ptr(new lanelet::LaneletMap())
   {  // NOLINT
-    // create sample lanelets
 
+    // create sample lanelets
     p1 = Point3d(getId(), 0., 0., 0.);
     p2 = Point3d(getId(), 0., 1., 0.);
 
     p3 = Point3d(getId(), 1., 0., 0.);
     p4 = Point3d(getId(), 1., 1., 0.);
 
+    p5 = Point3d(getId(), 2., 0., 0.);
+    p6 = Point3d(getId(), 2., 1., 0.);
+
+    // create a sample area
+    p14 = Point3d(getId(), 3., 0., 0.);
+    p15 = Point3d(getId(), 3., 1., 0.);
+
     ls_left  = LineString3d(getId(), { p1, p2 });   // NOLINT
     ls_right = LineString3d(getId(), { p3, p4 });  // NOLINT
-
+    ls_right_right = LineString3d(getId(), { p5, p6 });  // NOLINT
+    ls_area_right = LineString3d(getId(), { p14, p15 });  // NOLINT
+    ls_area_top = LineString3d(getId(), { p15, p6 });
+    ls_area_bottom = LineString3d(getId(), { p14, p5 });
+    
     road_lanelet = Lanelet(getId(), ls_left, ls_right);
     road_lanelet.attributes()[lanelet::AttributeName::Subtype] = lanelet::AttributeValueString::Road;
+    centerline = road_lanelet.centerline();
+    road_lanelet1 = Lanelet(getId(), ls_right, ls_right_right);
+    road_lanelet1.attributes()[lanelet::AttributeName::Subtype] = lanelet::AttributeValueString::Road;
     crosswalk_lanelet = Lanelet(getId(), ls_left, ls_right);
     crosswalk_lanelet.attributes()[lanelet::AttributeName::Subtype] = lanelet::AttributeValueString::Crosswalk;
+    side_area = Area(getId(), {ls_area_top, ls_area_right, ls_area_bottom, ls_right_right});
 
     // create sample traffic light
-    p6 = Point3d(getId(), 0., 1., 4.);
-    p7 = Point3d(getId(), 1., 1., 4.);
+    p7 = Point3d(getId(), 0., 1., 4.);
+    p8 = Point3d(getId(), 1., 1., 4.);
 
-    p8 = Point3d(getId(), 0., 1., 4.5);
-    p9 = Point3d(getId(), 0.5, 1., 4.5);
-    p10 = Point3d(getId(), 1., 1., 4.5);
+    p9 = Point3d(getId(), 0., 1., 4.5);
+    p10 = Point3d(getId(), 0.5, 1., 4.5);
+    p11 = Point3d(getId(), 1., 1., 4.5);
 
-    p11 = Point3d(getId(), 0., 0., 0.);
-    p12 = Point3d(getId(), 1., 0., 0.);
+    p12 = Point3d(getId(), 0., 0., 0.);
+    p13 = Point3d(getId(), 1., 0., 0.);
 
-    traffic_light_base = LineString3d(getId(), Points3d{ p6, p7 });        // NOLINT
-    traffic_light_bulbs = LineString3d(getId(), Points3d{ p8, p9, p10 });  // NOLINT
-    stop_line = LineString3d(getId(), Points3d{ p11, p12 });               // NOLINT
+    traffic_light_base = LineString3d(getId(), Points3d{ p7, p8 });        // NOLINT
+    traffic_light_bulbs = LineString3d(getId(), Points3d{ p9, p10, p11 });  // NOLINT
+    stop_line = LineString3d(getId(), Points3d{ p12, p13 });               // NOLINT
 
     tl = lanelet::autoware::AutowareTrafficLight::make(getId(), lanelet::AttributeMap(), { traffic_light_base },
                                                             stop_line, { traffic_light_bulbs });  // NOLINT
 
-    road_lanelet.addRegulatoryElement(tl);
+    pcl = std::make_shared<lanelet::PassingControlLine>(lanelet::PassingControlLine::buildData(
+      lanelet::utils::getId(), {road_lanelet1.leftBound() }, {}, { lanelet::Participants::Vehicle }));
 
+    road_lanelet.addRegulatoryElement(tl);
+    road_lanelet.addRegulatoryElement(pcl);
+    side_area.addRegulatoryElement(pcl);
     // add items to map
     sample_map_ptr->add(road_lanelet);
+    sample_map_ptr->add(road_lanelet1);
     sample_map_ptr->add(crosswalk_lanelet);
+    sample_map_ptr->add(side_area);
   }
-  ~TestSuite()
-  {
-  }
+  ~TestSuite(){}
 
   lanelet::LaneletMapPtr sample_map_ptr;
 
 private:
 };
 
-TEST_F(TestSuite, QueryRefs)
+TEST_F(TestSuite, QueryReferences)
 {
-  lanelet::utils::query::References rf = lanelet::utils::query::findReferences(tl, sample_map_ptr);
-  ASSERT_EQ(rf.pts.size(), 0);
+  // Test references to a point
+  lanelet::utils::query::References rf = lanelet::utils::query::findReferences(p1, sample_map_ptr);
+  ASSERT_EQ(rf.lss.size(), 0);
+  ASSERT_EQ(rf.llts.size(), 2);
+  rf = lanelet::utils::query::findReferences(p3, sample_map_ptr);
+  ASSERT_EQ(rf.lss.size(), 0);
+  ASSERT_EQ(rf.llts.size(), 3);
+  Point3d ptest = Point3d(getId(), 2.0, 2.0, 3.0);
+  rf = lanelet::utils::query::findReferences(ptest, sample_map_ptr);
+  ASSERT_EQ(rf.lss.size(), 0);
+  ASSERT_EQ(rf.llts.size(), 0);
+
+  // Test references to a linestring
+  rf = lanelet::utils::query::findReferences(ls_left, sample_map_ptr);
+  ASSERT_EQ(rf.lss.size(), 0);
+  ASSERT_EQ(rf.llts.size(), 2);
+  rf = lanelet::utils::query::findReferences(ls_right, sample_map_ptr);
+  ASSERT_EQ(rf.lss.size(), 0);
+  ASSERT_EQ(rf.llts.size(), 3);
+  // linestrings that don't exist
+  Point3d pne1 = Point3d(getId(), 5., 7., 0.);
+  Point3d pne2 = Point3d(getId(), 5., 8., 0.);
+  LineString3d ls_nonexistent  = LineString3d(getId(), { pne1, pne2 });
+  rf = lanelet::utils::query::findReferences(ls_nonexistent, sample_map_ptr);
+  ASSERT_EQ(rf.lss.size(), 0);
+  ASSERT_EQ(rf.llts.size(), 0);
+  ASSERT_EQ(rf.regems.size(), 0);
+  // linestrings that half exist, sharing a point
+  LineString3d ls_halfexist  = LineString3d(getId(), { p1, pne2 });
+  rf = lanelet::utils::query::findReferences(ls_halfexist, sample_map_ptr);
+  ASSERT_EQ(rf.lss.size(), 0);
+  ASSERT_EQ(rf.llts.size(), 2);
+  ls_halfexist  = LineString3d(getId(), { p3, pne2 });
+  rf = lanelet::utils::query::findReferences(ls_halfexist, sample_map_ptr);
+  ASSERT_EQ(rf.lss.size(), 0);
+  ASSERT_EQ(rf.llts.size(), 3);
+
+  // Test references to regulatory elements
+  rf = lanelet::utils::query::findReferences(tl, sample_map_ptr);
+  ASSERT_EQ(rf.regems.size(), 0);
   ASSERT_EQ(rf.lss.size(), 0);
   ASSERT_EQ(rf.llts.size(), 1);
   ASSERT_EQ(rf.areas.size(), 0);
-  lanelet::utils::recurse(tl,sample_map_ptr, lanelet::utils::query::CHECK_CHILD ,rf);
+  rf = lanelet::utils::query::findReferences(pcl, sample_map_ptr);
+  ASSERT_EQ(rf.regems.size(), 0);
+  ASSERT_EQ(rf.lss.size(), 0);
+  ASSERT_EQ(rf.llts.size(), 1);
+  ASSERT_EQ(rf.areas.size(), 1);
+
+  // Test references to Area
+  rf = lanelet::utils::query::findReferences(side_area, sample_map_ptr);
+  ASSERT_EQ(rf.regems.size(), 0);
+  ASSERT_EQ(rf.lss.size(), 0);
+  ASSERT_EQ(rf.llts.size(), 2);
+  ASSERT_EQ(rf.areas.size(), 1); 
+  ASSERT_EQ(rf.areas.begin()->id(), side_area.id()); //referencing itself
+  // area that half exist (shares borders, but not in the map)
+  LineString3d ls_nonexistent_top  = LineString3d(getId(), { p15, pne2 });
+  LineString3d ls_nonexistent_bottom  = LineString3d(getId(), { p14, pne1 });
+  Area area_halfexist = Area(getId(), {ls_nonexistent_top, ls_nonexistent, ls_nonexistent_bottom, ls_area_right});
+  rf = lanelet::utils::query::findReferences(area_halfexist, sample_map_ptr);
+  ASSERT_EQ(rf.regems.size(), 0);
+  ASSERT_EQ(rf.lss.size(), 0);
+  ASSERT_EQ(rf.llts.size(), 0);
+  ASSERT_EQ(rf.areas.size(), 1); // sharing border with only this area el
+
+  // Test references to Lanelet
+  rf = lanelet::utils::query::findReferences(road_lanelet, sample_map_ptr);
+  ASSERT_EQ(rf.regems.size(), 0);
+  ASSERT_EQ(rf.lss.size(), 0);
+  ASSERT_EQ(rf.llts.size(), 3); //itself, overlays but different type, and one that shares border, 
+  ASSERT_EQ(rf.areas.size(), 1); // due to having a same regem
 }
 
 TEST_F(TestSuite, QueryLanelets)
 {
   lanelet::ConstLanelets all_lanelets = lanelet::utils::query::laneletLayer(sample_map_ptr);
-  ASSERT_EQ(2, all_lanelets.size()) << "failed to retrieve all lanelets";
+  ASSERT_EQ(3, all_lanelets.size()) << "failed to retrieve all lanelets";
 
   lanelet::ConstLanelets subtype_lanelets =
       lanelet::utils::query::subtypeLanelets(all_lanelets, lanelet::AttributeValueString::Road);
-  ASSERT_EQ(1, subtype_lanelets.size()) << "failed to retrieve road lanelet by subtypeLanelets";
+  ASSERT_EQ(2, subtype_lanelets.size()) << "failed to retrieve road lanelet by subtypeLanelets";
 
   lanelet::ConstLanelets road_lanelets = lanelet::utils::query::roadLanelets(all_lanelets);
-  ASSERT_EQ(1, road_lanelets.size()) << "failed to retrieve road lanelets";
+  ASSERT_EQ(2, road_lanelets.size()) << "failed to retrieve road lanelets";
 
   lanelet::ConstLanelets crosswalk_lanelets = lanelet::utils::query::crosswalkLanelets(all_lanelets);
   ASSERT_EQ(1, crosswalk_lanelets.size()) << "failed to retrieve crosswalk lanelets";
@@ -132,7 +221,7 @@ TEST_F(TestSuite, QueryStopLine)
   auto stop_lines = lanelet::utils::query::stopLinesLanelets(all_lanelets);
   ASSERT_EQ(1, stop_lines.size()) << "failed to retrieve stop lines from all lanelets";
 
-  auto stop_lines2 = lanelet::utils::query::stopLinesLanelet(road_lanelets.front());
+  auto stop_lines2 = lanelet::utils::query::stopLinesLanelet(road_lanelets.back());
   ASSERT_EQ(1, stop_lines2.size()) << "failed to retrieve stop lines from a lanelet";
 }
 

--- a/common/lanelet2_extension/test/src/test_query.cpp
+++ b/common/lanelet2_extension/test/src/test_query.cpp
@@ -94,7 +94,7 @@ TEST_F(TestSuite, QueryRefs)
   ASSERT_EQ(rf.lss.size(), 0);
   ASSERT_EQ(rf.llts.size(), 1);
   ASSERT_EQ(rf.areas.size(), 0);
-  //lanelet::utils::recurse(tl,sample_map_ptr, lanelet::utils::query::CHECK_CHILD ,rf);
+  lanelet::utils::recurse(tl,sample_map_ptr, lanelet::utils::query::CHECK_CHILD ,rf);
 }
 
 TEST_F(TestSuite, QueryLanelets)

--- a/common/lanelet2_extension/test/src/test_query.cpp
+++ b/common/lanelet2_extension/test/src/test_query.cpp
@@ -152,20 +152,20 @@ TEST_F(TestSuite, QueryReferences)
   // Test references to regulatory elements
   rf = lanelet::utils::query::findReferences(tl, sample_map_ptr);
   ASSERT_EQ(rf.regems.size(), 0);
-  ASSERT_EQ(rf.lss.size(), 0);
+  ASSERT_EQ(rf.lss.size(), 3);
   ASSERT_EQ(rf.llts.size(), 1);
   ASSERT_EQ(rf.areas.size(), 0);
   rf = lanelet::utils::query::findReferences(pcl, sample_map_ptr);
   ASSERT_EQ(rf.regems.size(), 0);
   ASSERT_EQ(rf.lss.size(), 0);
-  ASSERT_EQ(rf.llts.size(), 1);
+  ASSERT_EQ(rf.llts.size(), 3); //road_lanelet(directly added), road_lanelet1(leftBound is pcl), crosswalk_lanelet(rightBound is pcl)
   ASSERT_EQ(rf.areas.size(), 1);
 
   // Test references to Area
   rf = lanelet::utils::query::findReferences(side_area, sample_map_ptr);
   ASSERT_EQ(rf.regems.size(), 0);
   ASSERT_EQ(rf.lss.size(), 0);
-  ASSERT_EQ(rf.llts.size(), 2);
+  ASSERT_EQ(rf.llts.size(), 3); //it has pcl, which is referenced by 3 llts
   ASSERT_EQ(rf.areas.size(), 1); 
   ASSERT_EQ(rf.areas.begin()->id(), side_area.id()); //referencing itself
   // area that half exist (shares borders, but not in the map)
@@ -180,10 +180,11 @@ TEST_F(TestSuite, QueryReferences)
 
   // Test references to Lanelet
   rf = lanelet::utils::query::findReferences(road_lanelet, sample_map_ptr);
-  ASSERT_EQ(rf.regems.size(), 0);
-  ASSERT_EQ(rf.lss.size(), 0);
-  ASSERT_EQ(rf.llts.size(), 3); //itself, overlays but different type, and one that shares border, 
-  ASSERT_EQ(rf.areas.size(), 1); // due to having a same regem
+  ASSERT_EQ(rf.regems.size(), 0); //tl and pcl both are accounted for inside road_lanelet
+  ASSERT_EQ(rf.lss.size(), 3); //it has tl, which has stop_line,traffic_light_base,traffic_light_bulbs linestrings
+                                // which are not in the map, although tl itself is in the lanelet
+  ASSERT_EQ(rf.llts.size(), 3); //itself + llt that overlays but different type + and llt that shares border, 
+  ASSERT_EQ(rf.areas.size(), 1); // due to having a same regem pcl
 }
 
 TEST_F(TestSuite, QueryLanelets)

--- a/common/lanelet2_extension/test/src/test_query.cpp
+++ b/common/lanelet2_extension/test/src/test_query.cpp
@@ -89,12 +89,12 @@ private:
 
 TEST_F(TestSuite, QueryRefs)
 {
-  lanelet::utils::query::referenceFinder rf;
-  rf.run<lanelet::RegulatoryElementPtr>(tl, sample_map_ptr);
+  lanelet::utils::query::References rf = lanelet::utils::query::findReferences(tl, sample_map_ptr);
   ASSERT_EQ(rf.pts.size(), 0);
   ASSERT_EQ(rf.lss.size(), 0);
   ASSERT_EQ(rf.llts.size(), 1);
   ASSERT_EQ(rf.areas.size(), 0);
+  //lanelet::utils::recurse(tl,sample_map_ptr, lanelet::utils::query::CHECK_CHILD ,rf);
 }
 
 TEST_F(TestSuite, QueryLanelets)

--- a/common/lanelet2_extension/test/src/test_query.cpp
+++ b/common/lanelet2_extension/test/src/test_query.cpp
@@ -29,10 +29,16 @@ using lanelet::utils::getId;
 class TestSuite : public ::testing::Test
 {
 public:
+  Point3d p1, p2, p3, p4;
+  LineString3d ls_left, ls_right;
+  Point3d p5, p6, p7, p8, p9, p10, p11, p12;
+  LineString3d traffic_light_base, traffic_light_bulbs, stop_line;
+  Lanelet road_lanelet, crosswalk_lanelet;
+  lanelet::autoware::AutowareTrafficLight::Ptr tl;
+
   TestSuite() : sample_map_ptr(new lanelet::LaneletMap())
   {  // NOLINT
     // create sample lanelets
-    Point3d p1, p2, p3, p4;
 
     p1 = Point3d(getId(), 0., 0., 0.);
     p2 = Point3d(getId(), 0., 1., 0.);
@@ -40,19 +46,15 @@ public:
     p3 = Point3d(getId(), 1., 0., 0.);
     p4 = Point3d(getId(), 1., 1., 0.);
 
-    LineString3d ls_left(getId(), { p1, p2 });   // NOLINT
-    LineString3d ls_right(getId(), { p3, p4 });  // NOLINT
+    ls_left  = LineString3d(getId(), { p1, p2 });   // NOLINT
+    ls_right = LineString3d(getId(), { p3, p4 });  // NOLINT
 
-    Lanelet road_lanelet(getId(), ls_left, ls_right);
+    road_lanelet = Lanelet(getId(), ls_left, ls_right);
     road_lanelet.attributes()[lanelet::AttributeName::Subtype] = lanelet::AttributeValueString::Road;
-
-    Lanelet crosswalk_lanelet(getId(), ls_left, ls_right);
+    crosswalk_lanelet = Lanelet(getId(), ls_left, ls_right);
     crosswalk_lanelet.attributes()[lanelet::AttributeName::Subtype] = lanelet::AttributeValueString::Crosswalk;
 
     // create sample traffic light
-    Point3d p5, p6, p7, p8, p9, p10, p11, p12;
-    LineString3d traffic_light_base, traffic_light_bulbs, stop_line;
-
     p6 = Point3d(getId(), 0., 1., 4.);
     p7 = Point3d(getId(), 1., 1., 4.);
 
@@ -67,7 +69,7 @@ public:
     traffic_light_bulbs = LineString3d(getId(), Points3d{ p8, p9, p10 });  // NOLINT
     stop_line = LineString3d(getId(), Points3d{ p11, p12 });               // NOLINT
 
-    auto tl = lanelet::autoware::AutowareTrafficLight::make(getId(), lanelet::AttributeMap(), { traffic_light_base },
+    tl = lanelet::autoware::AutowareTrafficLight::make(getId(), lanelet::AttributeMap(), { traffic_light_base },
                                                             stop_line, { traffic_light_bulbs });  // NOLINT
 
     road_lanelet.addRegulatoryElement(tl);
@@ -84,6 +86,16 @@ public:
 
 private:
 };
+
+TEST_F(TestSuite, QueryRefs)
+{
+  lanelet::utils::query::referenceFinder rf;
+  rf.run<lanelet::RegulatoryElementPtr>(tl, sample_map_ptr);
+  ASSERT_EQ(rf.pts.size(), 0);
+  ASSERT_EQ(rf.lss.size(), 0);
+  ASSERT_EQ(rf.llts.size(), 1);
+  ASSERT_EQ(rf.areas.size(), 0);
+}
 
 TEST_F(TestSuite, QueryLanelets)
 {

--- a/lanelet2/lanelet2_core/include/lanelet2_core/primitives/Primitive.h
+++ b/lanelet2/lanelet2_core/include/lanelet2_core/primitives/Primitive.h
@@ -42,6 +42,7 @@ class PrimitiveData {
 
   Id id;                    //!< Id of this primitive (unique across one map)
   AttributeMap attributes;  //!< attributes of this primitive
+  
  protected:
   ~PrimitiveData() = default;
 };  // class PrimitiveData

--- a/lanelet2/lanelet2_core/include/lanelet2_core/primitives/RegulatoryElement.h
+++ b/lanelet2/lanelet2_core/include/lanelet2_core/primitives/RegulatoryElement.h
@@ -514,5 +514,9 @@ template <>
 struct hash<lanelet::RegulatoryElementPtr>{
   size_t operator()(const lanelet::RegulatoryElementPtr& x) const noexcept { return std::hash<lanelet::Id>()(x->id()); }
 };
+template <>
+struct hash<lanelet::RegulatoryElementConstPtr>{
+  size_t operator()(const lanelet::RegulatoryElementConstPtr& x) const noexcept { return std::hash<lanelet::Id>()(x->id()); }
+};
 
 } // namespace lanelet

--- a/lanelet2/lanelet2_core/include/lanelet2_core/primitives/RegulatoryElement.h
+++ b/lanelet2/lanelet2_core/include/lanelet2_core/primitives/RegulatoryElement.h
@@ -507,3 +507,12 @@ template <typename T, typename RetT>
 using IfRE = std::enable_if_t<traits::isRegulatoryElementT<T>(), RetT>;
 
 }  // namespace lanelet
+
+// Hash function for usage in containers
+namespace std {
+template <>
+struct hash<lanelet::RegulatoryElementPtr>{
+  size_t operator()(const lanelet::RegulatoryElementPtr& x) const noexcept { return std::hash<lanelet::Id>()(x->id()); }
+};
+
+} // namespace lanelet

--- a/lanelet2/lanelet2_core/include/lanelet2_core/primitives/RegulatoryElement.h
+++ b/lanelet2/lanelet2_core/include/lanelet2_core/primitives/RegulatoryElement.h
@@ -24,7 +24,7 @@ namespace lanelet {
 //! ## Design
 //! Every regulatoryElement has a number of RuleParameters that are implemented
 //! as boost::variants. A RuleParameter can be any lanelet primitive. For
-//! techical reasons (to avoid cyclic shared_ptr issues), Area and Lanelet is
+//! technical reasons (to avoid cyclic shared_ptr issues), Area and Lanelet is
 //! stored using WeakPtrs. If Lanelets go out of scope, this weak ptr will
 //! become invalid. Usually this will not be an issue because LaneletMap still
 //! holds the Lanelets.
@@ -47,7 +47,7 @@ namespace lanelet {
 //! ## Generic rules
 //! For corner cases, a GenericRegulatoryElement is offered which is mutable and
 //! can be used to model any yet unknown traffic rule.
-//! Traffic rules should be interpreted by extending the lanele2_traffic_rules
+//! Traffic rules should be interpreted by extending the lanelet2_traffic_rules
 //! package, preferably for all countries that have this rule.
 
 //! Typical role names within lanelet (for faster lookup)


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

Added recursive search functionality for lanelet primitives.
The new function `lanelet::utils::query::findReferences(primT prim, const LaneletMapPtr ll_Map)` function returns `lanelet::utils::query::References` object, which has `unordered_set` of each possible primitive (excluding Point) with all the elements that referenced the given element (including this element itself) in the given map. The returned objects are organized in such a way that it returns the element from the highest layer that is associated with the given input object. 

For example, given LineString `A`, we could have returned Points that this LineString owns as well as the Lanelets that own `A`. However, we only return the Lanelets because it is the highest Primitive that includes all other objects anyway. For this reason, the References object doesn't have set for Point because this primitive alone does not have a meaning in lanelet2, and is guaranteed to have a higher Primitive associated with it if it's referenced anywhere in the map.

For the function itself, `findReferences()` uses overloaded recursive helper function, `recurse` for each type of primitives. Each `recurse` generally has two logics inside, one to call `recurse` for lower layers that the object owns, and one to call `recurse` for upper layers that the object corresponds to.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/usdot-fhwa-stol/carma-platform/issues/691
## Motivation and Context

In order to update a lanelet2 map to support geofences we will need to know which primitives are referencing each other. This PR is to develop logic in autoware.ai/lanelet2 to identify all the primitives which directly reference the provided primitive. 

<!--- Why is this change required? What problem does it solve? -->
## How Has This Been Tested?

Unit tested

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](Contributing.md) 
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.