### PR TITLE
added more flexibility in encoding georeference inside map.osm

### DIFF
--- a/common/lanelet2_extension/include/lanelet2_extension/io/autoware_osm_parser.h
+++ b/common/lanelet2_extension/include/lanelet2_extension/io/autoware_osm_parser.h
@@ -52,7 +52,9 @@ public:
 
   /**
    * [parseMapParams parses GeoReference (i.e. map parameters) info from osm file and loads default ECEF proj strings]
-   * NOTE: projector_type = 0 is currently not supported by CARMA
+   * NOTE: geoReference is expected to be encoded inside bracket:<geoReference>string</geoReference>, or as "v" or "value"
+   *       attributes: <geoReference v="string"/> or <geoReference value="string"/>
+   *       projector_type = 0 is currently not supported by CARMA
    *       +geoidgrids is also currently not a supported georeference field by the parser
    * @param filename            [path to osm file]
    * @param projector_type      [parsed information about map projector_type: Currently it supposes 0 as Autoware default MGRSProjector and 1 as CARMA LocalFrameProjector]

--- a/common/lanelet2_extension/lib/autoware_osm_parser.cpp
+++ b/common/lanelet2_extension/lib/autoware_osm_parser.cpp
@@ -110,10 +110,33 @@ void AutowareOsmParser::parseMapParams (const std::string& filename, int* projec
 
   auto osmNode = doc.child("osm");
   auto geoRef = osmNode.child("geoReference");
-
-  if (geoRef && std::string(geoRef.child_value()) != "")
+  std::string raw_geo_ref = "";
+  
+  if (geoRef)
   {
-    std::string raw_geo_ref = geoRef.child_value();
+    // check common ways the geoReference might have been encoded in the map
+    if (std::string(geoRef.child_value()) != "")
+    {
+      raw_geo_ref = geoRef.child_value();
+    }
+    else if(geoRef.attribute("v"))
+    {
+      raw_geo_ref = geoRef.attribute("v").value();
+    }
+    else if (geoRef.attribute("value"))
+    {
+      raw_geo_ref = geoRef.attribute("value").value();
+    }
+  }
+  // parser was not able to find a valid geoReference from the map
+  if (raw_geo_ref == "")
+  {
+    throw lanelet::ParseError(std::string("In function ") + __FUNCTION__ + 
+    std::string(":\nWhile parsing .osm file, geoReference was not found! Please check geoReference syntax in vector_map.osm"));
+    return;
+  }
+  else
+  {
     // Filter unnecessary part out of georeference.
     std::vector<std::string> buffer;
     boost::split(buffer,  raw_geo_ref, boost::is_any_of(" "));
@@ -126,12 +149,6 @@ void AutowareOsmParser::parseMapParams (const std::string& filename, int* projec
         std::cerr << "Removing +geoidgrids from input projection as this is not currently supported by AutowareOsmParser" << std::endl;
       }
     }
-  }
-  else
-  {
-    throw lanelet::ParseError(std::string("In function ") + __FUNCTION__ + 
-    std::string(":\nWhile parsing .osm file, geoReference was not found! Please check geoReference syntax in vector_map.osm"));
-    return;
   }
 
   // Default values

--- a/common/lanelet2_extension/test/resources/test_map_nogeoreference.osm
+++ b/common/lanelet2_extension/test/resources/test_map_nogeoreference.osm
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <osm version="0.6" generator="lanelet2">
-  <geoReference>+proj=tmerc +lat_0=39.46636844371259 +lon_0=-76.16919523566943 +k=1 +x_0=0 +y_0=0 +datum=WGS84 +units=m +geoidgrids=egm96_15.gtx +vunits=m +no_defs</geoReference>
+  <!-- Same map as test_map, but geoReference is missing. This is to test parseMapParams-->
   <node id="1339" visible="true" version="1" lat="0.00000898315" lon="0" />
   <node id="1340" visible="true" version="1" lat="0.00001796631" lon="0" />
   <node id="1342" visible="true" version="1" lat="0.00000898315" lon="0.00000898315" />

--- a/common/lanelet2_extension/test/resources/test_map_v.osm
+++ b/common/lanelet2_extension/test/resources/test_map_v.osm
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <osm version="0.6" generator="lanelet2">
-  <geoReference>+proj=tmerc +lat_0=39.46636844371259 +lon_0=-76.16919523566943 +k=1 +x_0=0 +y_0=0 +datum=WGS84 +units=m +geoidgrids=egm96_15.gtx +vunits=m +no_defs</geoReference>
+  <geoReference v= "+proj=tmerc +lat_0=39.46636844371259 +lon_0=-76.16919523566943 +k=1 +x_0=0 +y_0=0 +datum=WGS84 +units=m +geoidgrids=egm96_15.gtx +vunits=m +no_defs"/>
   <node id="1339" visible="true" version="1" lat="0.00000898315" lon="0" />
   <node id="1340" visible="true" version="1" lat="0.00001796631" lon="0" />
   <node id="1342" visible="true" version="1" lat="0.00000898315" lon="0.00000898315" />

--- a/common/lanelet2_extension/test/resources/test_map_value.osm
+++ b/common/lanelet2_extension/test/resources/test_map_value.osm
@@ -1,6 +1,7 @@
 <?xml version="1.0"?>
 <osm version="0.6" generator="lanelet2">
-  <geoReference>+proj=tmerc +lat_0=39.46636844371259 +lon_0=-76.16919523566943 +k=1 +x_0=0 +y_0=0 +datum=WGS84 +units=m +geoidgrids=egm96_15.gtx +vunits=m +no_defs</geoReference>
+  <!-- Same map as test_map, but geoReference is encoded in a different way. This is to test parseMapParams-->
+  <geoReference value= "+proj=tmerc +lat_0=39.46636844371259 +lon_0=-76.16919523566943 +k=1 +x_0=0 +y_0=0 +datum=WGS84 +units=m +geoidgrids=egm96_15.gtx +vunits=m +no_defs"/>
   <node id="1339" visible="true" version="1" lat="0.00000898315" lon="0" />
   <node id="1340" visible="true" version="1" lat="0.00001796631" lon="0" />
   <node id="1342" visible="true" version="1" lat="0.00000898315" lon="0.00000898315" />

--- a/common/lanelet2_extension/test/src/MapLoadingTest.cpp
+++ b/common/lanelet2_extension/test/src/MapLoadingTest.cpp
@@ -19,6 +19,7 @@
 #include <lanelet2_io/Io.h>
 #include <lanelet2_io/io_handlers/Factory.h>
 #include <lanelet2_io/io_handlers/Writer.h>
+#include <lanelet2_extension/io/autoware_osm_parser.h>
 
 #include <lanelet2_extension/regulatory_elements/RegionAccessRule.h>
 #include <lanelet2_extension/regulatory_elements/DigitalSpeedLimit.h>
@@ -41,6 +42,32 @@ using ::testing::ReturnArg;
 namespace lanelet
 {
 using namespace lanelet::units::literals;
+TEST(MapLoadingTest, parseMapParams)
+{
+  int projector_type = 1; // default value
+  std::string target_frame, lanelet2_filename;
+  std::string correct_georeference = "+proj=tmerc +lat_0=39.46636844371259 +lon_0=-76.16919523566943 +k=1 +x_0=0 +y_0=0 +datum=WGS84 +units=m +vunits=m +no_defs ";
+  // Test regular way
+  lanelet2_filename = "resources/test_map.osm";
+  lanelet::io_handlers::AutowareOsmParser::parseMapParams(lanelet2_filename, &projector_type, &target_frame);
+  EXPECT_EQ(correct_georeference, target_frame);
+  // Test v="string" way
+  target_frame = "";
+  lanelet2_filename = "resources/test_map_v.osm";
+  lanelet::io_handlers::AutowareOsmParser::parseMapParams(lanelet2_filename, &projector_type, &target_frame);
+  EXPECT_EQ(correct_georeference, target_frame);
+  // Test v="string" way
+  target_frame = "";
+  lanelet2_filename = "resources/test_map_value.osm";
+  lanelet::io_handlers::AutowareOsmParser::parseMapParams(lanelet2_filename, &projector_type, &target_frame);
+  EXPECT_EQ(correct_georeference, target_frame);
+  // Test unsupported way
+  target_frame = "";
+  lanelet2_filename = "resources/test_map_nogeoreference.osm";
+  EXPECT_THROW(lanelet::io_handlers::AutowareOsmParser::parseMapParams(lanelet2_filename, &projector_type, &target_frame), lanelet::ParseError);
+}
+
+
 
 TEST(MapLoadingTest, mapLoadingTest)
 {


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
Added more flexibility in encoding geoReference string inside vector_map.osm. 
Autoware_osm_parsert now supports following geoReference tags in the map, e.g.:
- `<geoReference>+proj=tmerc +lat_0=39.46636844371259 +lon_0=-76.16919523566943 +k=1 +x_0=0 +y_0=0 +datum=WGS84</geoReference>`
- `<geoReference  v="+proj=tmerc +lat_0=39.46636844371259 +lon_0=-76.16919523566943 +k=1 +x_0=0 +y_0=0 +datum=WGS84"/>`

- `<geoReference value="+proj=tmerc +lat_0=39.46636844371259 +lon_0=-76.16919523566943 +k=1 +x_0=0 +y_0=0 +datum=WGS84"/>`

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Initial issue is [here](https://github.com/usdot-fhwa-stol/carma-platform/issues/608)
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Initial way of encoding, which is to use inside-brackets approach, was not as common, and created confusion for developers when they used more common practices without being successfully loading the map. Particularly, this creates discrepancy when scripts like osm converter is used.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit Tested using sample maps
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.