### PR TITLE
Fix/find ref query

### DIFF
--- a/common/lanelet2_extension/lib/query.cpp
+++ b/common/lanelet2_extension/lib/query.cpp
@@ -82,7 +82,15 @@ void recurse (const lanelet::ConstLineString3d& prim, const lanelet::LaneletMapP
     recurse(area, ll_Map, query::CHECK_PARENT, rfs);
   }
 
-  if (area_list_owning_ls.size() ==0 && llt_list_owning_ls.size() == 0)
+  // similarly, process areas owning this ls
+  auto regem_list_owning_ls = ll_Map->regulatoryElementLayer.findUsages(prim);
+  for (auto regem : regem_list_owning_ls)
+  {
+    // recurse up on this area
+    recurse(regem, ll_Map, query::CHECK_PARENT, rfs);
+  }
+
+  if (area_list_owning_ls.size() ==0 && llt_list_owning_ls.size() == 0 && regem_list_owning_ls.size() == 0)
     rfs.lss.insert(prim);
 }
 
@@ -136,13 +144,16 @@ void recurse (const lanelet::ConstArea& prim, const lanelet::LaneletMapPtr ll_Ma
 }
 
 // RegulatoryElement
-
 void recurse (const lanelet::RegulatoryElementConstPtr& prim_ptr, const lanelet::LaneletMapPtr ll_Map, query::direction check_dir, query::References& rfs)
 {
   // go down, query::CHECK_CHILD
-  RecurseVisitor recurse_visitor(ll_Map, check_dir, rfs);
-  prim_ptr->applyVisitor(recurse_visitor);
-  
+  if (check_dir == query::CHECK_CHILD)
+  {
+    RecurseVisitor recurse_visitor(ll_Map, check_dir, rfs);
+    prim_ptr->applyVisitor(recurse_visitor);
+    return;
+  }
+
   // go up, query::CHECK_PARENT
   // process lanelets owning this regem
   auto llt_list_owning_regem = ll_Map->laneletLayer.findUsages(prim_ptr);
@@ -153,7 +164,7 @@ void recurse (const lanelet::RegulatoryElementConstPtr& prim_ptr, const lanelet:
     recurse(llt, ll_Map, query::CHECK_PARENT, rfs);
   }
   
-  // similarly, process areas owning this ls
+  // similarly, process areas owning this regem
   auto area_list_owning_regem = ll_Map->areaLayer.findUsages(prim_ptr);
   for (auto area : area_list_owning_regem)
   {

--- a/common/lanelet2_extension/lib/query.cpp
+++ b/common/lanelet2_extension/lib/query.cpp
@@ -70,7 +70,7 @@ void recurse (const lanelet::ConstLineString3d& prim, const lanelet::LaneletMapP
 
   for (auto llt : llt_list_owning_ls)
   {
-    // recurse up on this lanelet
+    // recurse up to this lanelet
     recurse(llt, ll_Map, query::CHECK_PARENT, rfs);
   }
   
@@ -78,15 +78,15 @@ void recurse (const lanelet::ConstLineString3d& prim, const lanelet::LaneletMapP
   auto area_list_owning_ls = ll_Map->areaLayer.findUsages(prim);
   for (auto area : area_list_owning_ls)
   {
-    // recurse up on this area
+    // recurse up to this area
     recurse(area, ll_Map, query::CHECK_PARENT, rfs);
   }
 
-  // similarly, process areas owning this ls
+  // similarly, process regems owning this ls
   auto regem_list_owning_ls = ll_Map->regulatoryElementLayer.findUsages(prim);
   for (auto regem : regem_list_owning_ls)
   {
-    // recurse up on this area
+    // recurse up to this regem
     recurse(regem, ll_Map, query::CHECK_PARENT, rfs);
   }
 
@@ -164,7 +164,7 @@ void recurse (const lanelet::RegulatoryElementConstPtr& prim_ptr, const lanelet:
     recurse(llt, ll_Map, query::CHECK_PARENT, rfs);
   }
   
-  // similarly, process areas owning this regem
+  // similarly, process regems owning this regem
   auto area_list_owning_regem = ll_Map->areaLayer.findUsages(prim_ptr);
   for (auto area : area_list_owning_regem)
   {

--- a/common/lanelet2_extension/test/src/test_query.cpp
+++ b/common/lanelet2_extension/test/src/test_query.cpp
@@ -152,7 +152,7 @@ TEST_F(TestSuite, QueryReferences)
   // Test references to regulatory elements
   rf = lanelet::utils::query::findReferences(tl, sample_map_ptr);
   ASSERT_EQ(rf.regems.size(), 0);
-  ASSERT_EQ(rf.lss.size(), 3);
+  ASSERT_EQ(rf.lss.size(), 0); // tl has 3 unregistered lss, but it is part of llt itself which is registered
   ASSERT_EQ(rf.llts.size(), 1);
   ASSERT_EQ(rf.areas.size(), 0);
   rf = lanelet::utils::query::findReferences(pcl, sample_map_ptr);
@@ -181,7 +181,7 @@ TEST_F(TestSuite, QueryReferences)
   // Test references to Lanelet
   rf = lanelet::utils::query::findReferences(road_lanelet, sample_map_ptr);
   ASSERT_EQ(rf.regems.size(), 0); //tl and pcl both are accounted for inside road_lanelet
-  ASSERT_EQ(rf.lss.size(), 3); //it has tl, which has stop_line,traffic_light_base,traffic_light_bulbs linestrings
+  ASSERT_EQ(rf.lss.size(), 0); //it has tl, which has stop_line,traffic_light_base,traffic_light_bulbs linestrings
                                 // which are not in the map, although tl itself is in the lanelet
   ASSERT_EQ(rf.llts.size(), 3); //itself + llt that overlays but different type + and llt that shares border, 
   ASSERT_EQ(rf.areas.size(), 1); // due to having a same regem pcl

--- a/common/lanelet2_extension/test/src/test_query.cpp
+++ b/common/lanelet2_extension/test/src/test_query.cpp
@@ -31,14 +31,14 @@ using lanelet::utils::getId;
 class TestSuite : public ::testing::Test
 {
 public:
-  Point3d p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15;
+  Point3d p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p_unreg1, p_unreg2;
   LineString3d ls_left, ls_right, ls_right_right, traffic_light_base, 
-    traffic_light_bulbs, stop_line, ls_area_right, ls_area_top, ls_area_bottom;
+    traffic_light_bulbs, stop_line, ls_area_right, ls_area_top, ls_area_bottom, pcl_unreg_ls, ls_unreg;
   lanelet::ConstLineString3d centerline;
   Lanelet road_lanelet, road_lanelet1, crosswalk_lanelet;
   Area side_area;
   lanelet::autoware::AutowareTrafficLight::Ptr tl;
-  std::shared_ptr<lanelet::PassingControlLine> pcl;
+  std::shared_ptr<lanelet::PassingControlLine> pcl, pcl_unreg;
 
   TestSuite() : sample_map_ptr(new lanelet::LaneletMap())
   {  // NOLINT
@@ -46,6 +46,8 @@ public:
     // create sample lanelets
     p1 = Point3d(getId(), 0., 0., 0.);
     p2 = Point3d(getId(), 0., 1., 0.);
+    p_unreg1 = Point3d(getId(), 0., 11., 0.);
+    p_unreg2 = Point3d(getId(), 0., 12., 0.);
 
     p3 = Point3d(getId(), 1., 0., 0.);
     p4 = Point3d(getId(), 1., 1., 0.);
@@ -63,6 +65,7 @@ public:
     ls_area_right = LineString3d(getId(), { p14, p15 });  // NOLINT
     ls_area_top = LineString3d(getId(), { p15, p6 });
     ls_area_bottom = LineString3d(getId(), { p14, p5 });
+    ls_unreg = LineString3d(getId(), { p_unreg1, p_unreg2 });
     
     road_lanelet = Lanelet(getId(), ls_left, ls_right);
     road_lanelet.attributes()[lanelet::AttributeName::Subtype] = lanelet::AttributeValueString::Road;
@@ -87,12 +90,16 @@ public:
     traffic_light_base = LineString3d(getId(), Points3d{ p7, p8 });        // NOLINT
     traffic_light_bulbs = LineString3d(getId(), Points3d{ p9, p10, p11 });  // NOLINT
     stop_line = LineString3d(getId(), Points3d{ p12, p13 });               // NOLINT
+    pcl_unreg_ls = LineString3d(getId(), { p16, p17 });
 
     tl = lanelet::autoware::AutowareTrafficLight::make(getId(), lanelet::AttributeMap(), { traffic_light_base },
                                                             stop_line, { traffic_light_bulbs });  // NOLINT
 
     pcl = std::make_shared<lanelet::PassingControlLine>(lanelet::PassingControlLine::buildData(
       lanelet::utils::getId(), {road_lanelet1.leftBound() }, {}, { lanelet::Participants::Vehicle }));
+
+    pcl_unreg = std::make_shared<lanelet::PassingControlLine>(lanelet::PassingControlLine::buildData(
+      lanelet::utils::getId(), {pcl_unreg_ls}, {}, { lanelet::Participants::Vehicle }));
 
     road_lanelet.addRegulatoryElement(tl);
     road_lanelet.addRegulatoryElement(pcl);
@@ -102,6 +109,7 @@ public:
     sample_map_ptr->add(road_lanelet1);
     sample_map_ptr->add(crosswalk_lanelet);
     sample_map_ptr->add(side_area);
+    sample_map_ptr->add(pcl_unreg);
   }
   ~TestSuite(){}
 
@@ -139,6 +147,12 @@ TEST_F(TestSuite, QueryReferences)
   ASSERT_EQ(rf.lss.size(), 0);
   ASSERT_EQ(rf.llts.size(), 0);
   ASSERT_EQ(rf.regems.size(), 0);
+  // linestring that exist individually (not part of any other primitive)
+  sample_map_ptr->add(ls_unreg);
+  rf = lanelet::utils::query::findReferences(ls_unreg, sample_map_ptr);
+  ASSERT_EQ(rf.lss.size(), 1);
+  ASSERT_EQ(rf.llts.size(), 0);
+  ASSERT_EQ(rf.regems.size(), 0);
   // linestrings that half exist, sharing a point
   LineString3d ls_halfexist  = LineString3d(getId(), { p1, pne2 });
   rf = lanelet::utils::query::findReferences(ls_halfexist, sample_map_ptr);
@@ -160,6 +174,12 @@ TEST_F(TestSuite, QueryReferences)
   ASSERT_EQ(rf.lss.size(), 0);
   ASSERT_EQ(rf.llts.size(), 3); //road_lanelet(directly added), road_lanelet1(leftBound is pcl), crosswalk_lanelet(rightBound is pcl)
   ASSERT_EQ(rf.areas.size(), 1);
+  // regem that exists by itself, not referenced by any other primitive
+  rf = lanelet::utils::query::findReferences(pcl_unreg, sample_map_ptr);
+  ASSERT_EQ(rf.regems.size(), 1); //itself
+  ASSERT_EQ(rf.lss.size(), 0); //not part of any other primitives
+  ASSERT_EQ(rf.llts.size(), 0); 
+  ASSERT_EQ(rf.areas.size(), 0);
 
   // Test references to Area
   rf = lanelet::utils::query::findReferences(side_area, sample_map_ptr);

--- a/common/lanelet2_extension/test/src/test_utilities.cpp
+++ b/common/lanelet2_extension/test/src/test_utilities.cpp
@@ -26,10 +26,10 @@ using lanelet::LineString3d;
 using lanelet::Point3d;
 using lanelet::utils::getId;
 
-class TestSuite : public ::testing::Test
+class TestSuite1 : public ::testing::Test
 {
 public:
-  TestSuite() : sample_map_ptr(new lanelet::LaneletMap())
+  TestSuite1() : sample_map_ptr(new lanelet::LaneletMap())
   {  // NOLINT
     // create sample lanelets
     Point3d p1, p2, p3, p4, p5, p6, p7, p8, p9, p10;
@@ -77,7 +77,7 @@ public:
     sample_map_ptr->add(next_lanelet2);
     sample_map_ptr->add(merging_lanelet);
   }
-  ~TestSuite()
+  ~TestSuite1()
   {
   }
 
@@ -90,7 +90,7 @@ public:
 private:
 };
 
-TEST_F(TestSuite, MatchWaypointAndLanelet)
+TEST_F(TestSuite1, MatchWaypointAndLanelet)
 {
   std::map<int, lanelet::Id> waypointid2laneletid;
   autoware_msgs::LaneArray lane_array;
@@ -127,7 +127,7 @@ TEST_F(TestSuite, MatchWaypointAndLanelet)
   ASSERT_EQ(next_lanelet2.id(), waypointid2laneletid.at(3)) << "failed to match waypoints with lanelet";
 }
 
-TEST_F(TestSuite, OverwriteLaneletsCenterline)
+TEST_F(TestSuite1, OverwriteLaneletsCenterline)
 {
   lanelet::utils::overwriteLaneletsCenterline(sample_map_ptr);
 


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
Accounted for an edge case where a linestring needs to check its parent regulatory element by recursing upwards. 

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/usdot-fhwa-stol/carma-platform/issues/700
## Motivation and Context

Recent merge of findReference function did not account for the fact that linestrings can be owned by regulatoryElements. This won't be a problem if the linestring is part of a lanelet or area that owns that regulatory element. However, often times regulatory elements can have linestrings that are not registered in the map (which means they are not part of any higher primitives like area or lanelet). And if that linestring was the input to that function, the function was not returning the parent regulatory element that is actually registered in the map. 

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit Tested

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.