### PR TITLE
Develop logic to remove RegulatoryElements from a Lanelet map

### DIFF
--- a/common/lanelet2_extension/include/lanelet2_extension/utility/utilities.h
+++ b/common/lanelet2_extension/include/lanelet2_extension/utility/utilities.h
@@ -51,6 +51,13 @@ void matchWaypointAndLanelet(const lanelet::LaneletMapPtr lanelet_map,
  */
 void overwriteLaneletsCenterline(lanelet::LaneletMapPtr lanelet_map, const bool force_overite = false);
 
+/**
+ * @brief  [Removes the list of regulatory elements from the given map in 
+ *         such a way that the resulting map is valid and self-contained]
+ * @param  regem_list  [list of regulatory element ptrs to be removed]
+ * @param  lanelet_map [pointer to lanelet2 map]
+ */
+void removeRegulatoryElements(std::vector<lanelet::RegulatoryElementPtr> regem_list, const lanelet::LaneletMapPtr lanelet_map);
 }  // namespace utils
 }  // namespace lanelet
 

--- a/common/lanelet2_extension/lib/utilities.cpp
+++ b/common/lanelet2_extension/lib/utilities.cpp
@@ -290,19 +290,19 @@ std::vector<lanelet::BasicPoint3d> resamplePoints(const lanelet::ConstLineString
   return resampled_points;
 }
 
-  /*!
-   * \brief Return a recomputed centerline for the given input lanelet without 
-   *        modifiying the input lanelet
-   * 
-   * Computes a centerline by averaging each point in the left and right boundary
-   * of the lanelet. Assumes that the points on the left and right bound are 
-   * evenly spaced as well as equally numbered. i.e. average(left[i], right[i])
-   * = center[i].
-   * 
-   * \param lanelet_obj The lanelet to evaluate the centerline for
-   * \return A LineString3d describing the geometry of the center line
-   * \throws std::invalid_argument If the left and right bounds are not the same size
-   */
+/*!
+  * \brief Return a recomputed centerline for the given input lanelet without 
+  *        modifiying the input lanelet
+  * 
+  * Computes a centerline by averaging each point in the left and right boundary
+  * of the lanelet. Assumes that the points on the left and right bound are 
+  * evenly spaced as well as equally numbered. i.e. average(left[i], right[i])
+  * = center[i].
+  * 
+  * \param lanelet_obj The lanelet to evaluate the centerline for
+  * \return A LineString3d describing the geometry of the center line
+  * \throws std::invalid_argument If the left and right bounds are not the same size
+  */
 lanelet::LineString3d generateFineCenterline(const lanelet::ConstLanelet& lanelet_obj)
 {
   if (lanelet_obj.rightBound2d().size() != lanelet_obj.leftBound2d().size()) {
@@ -323,6 +323,8 @@ lanelet::LineString3d generateFineCenterline(const lanelet::ConstLanelet& lanele
 
   return center;
 }
+
+
 
 }  // namespace
 
@@ -406,5 +408,13 @@ void overwriteLaneletsCenterline(lanelet::LaneletMapPtr lanelet_map, const bool 
   }
 }
 
+void removeRegulatoryElements(std::vector<lanelet::RegulatoryElementPtr> regem_list, const lanelet::LaneletMapPtr lanelet_map)
+{
+  for (lanelet::RegulatoryElementPtr regem : regem_list)
+  {
+    lanelet_map->remove(regem);
+  }
+  return;
+}
 }  // namespace utils
 }  // namespace lanelet

--- a/common/lanelet2_extension/test/src/test_query.cpp
+++ b/common/lanelet2_extension/test/src/test_query.cpp
@@ -118,58 +118,6 @@ public:
 
 private:
 };
-TEST_F(TestSuite, DEBUGSTUFF)
-{
-  // check what is the difference between direcly owning and parameterizing
-  // I can remove it from lanelet
-  // can I remove it from linestring
-  std::vector<lanelet::RegulatoryElementPtr> regems = sample_map_ptr->regulatoryElementLayer.findUsages(pcl_unreg_ls);
-  ASSERT_EQ(regems.size(), 1);
-  std::vector<lanelet::Lanelet> llts1 = sample_map_ptr->laneletLayer.findUsages(pcl_unreg_ls);
-  ASSERT_EQ(llts1.size(), 0);
-  Point3d pz1 = Point3d(getId(), 0., 88., 0.);
-  Point3d pz2 = Point3d(getId(), 0., 89., 0.);
-  LineString3d lss_left = LineString3d(getId(), { pz1, pz2 });  
-  //road_lanelet = Lanelet(getId(), lss_left, ls_right);
-  std::vector<lanelet::LineString3d> lss = sample_map_ptr->lineStringLayer.findUsages(pz1);
-  ASSERT_EQ(lss.size(), 0);
-  //ASSERT_EQ(lss[0].id(), lss_left.id());
-  std::vector<lanelet::Lanelet> llt2 = sample_map_ptr->laneletLayer.findUsages(lss_left);
-  ASSERT_EQ(llt2.size(), 0);
-  //ASSERT_EQ(llt2[0].id(), road_lanelet.id());
-
-  ///// OK if I remove linestring from a lanelet that was in the map, would I still get the lienstring
-  std::vector<lanelet::Lanelet> llt3 = sample_map_ptr->laneletLayer.findUsages(tl);
-  ASSERT_EQ(llt3.size(), 1);
-  ASSERT_EQ(llt3[0].id(), road_lanelet.id());
-  llt3[0].removeRegulatoryElement(tl);
-  std::vector<lanelet::Lanelet> llt1 = sample_map_ptr->laneletLayer.findUsages(tl);  
-  ASSERT_EQ(llt1.size(), 1);
-  ASSERT_EQ(llt3[0].id(), llt1[0].id());
-  for (auto regem: llt3[0].regulatoryElements())
-  {
-    ASSERT_EQ(regem->id(), 1033);
-  }
-  for (auto regem: llt1[0].regulatoryElements())
-  {
-    ASSERT_EQ(regem->id(), 1033);
-  }
-
-  // First actual test if regulatory element removal is working
-  lanelet::utils::removeRegulatoryElements({pcl_unreg}, sample_map_ptr);
-  lanelet::utils::query::References rf = lanelet::utils::query::findReferences(pcl_unreg, sample_map_ptr);
-  ASSERT_EQ(rf.regems.size(), 0); //pcl_unreg is gone
-  ASSERT_EQ(rf.lss.size(), 1); //not part of pcl_unreg anymore so stand alone
-  ASSERT_EQ(rf.lss.begin()->id(), pcl_unreg_ls.id());
-  ASSERT_EQ(rf.llts.size(), 0); 
-  ASSERT_EQ(rf.areas.size(), 0);
-  std::vector<lanelet::RegulatoryElementPtr> regems1 = sample_map_ptr->regulatoryElementLayer.findUsages(pcl_unreg_ls);
-  ASSERT_EQ(regems1.size(), 0);
-  
-  // test if the map is valid
-  // TODO: there is a file called Validation folder inside lanelet2, gotta look into it
-  
-}
 TEST_F(TestSuite, QueryReferences)
 {
   // Test references to a point

--- a/common/lanelet2_extension/test/src/test_utilities.cpp
+++ b/common/lanelet2_extension/test/src/test_utilities.cpp
@@ -316,13 +316,7 @@ TEST_F(TestSuite, RemoveRegulatoryElements)
   auto report = lanelet::validation::buildReport(issues);
   EXPECT_EQ(13, report.warnings.size()); // these 13 warnings have been verified  
                                          // that they are not related to our issue of focus
-  EXPECT_EQ(0ul, report.errors.size());
-  // In fact, it should be routable
-  traffic_rules::TrafficRulesPtr trafficRules =
-    traffic_rules::TrafficRulesFactory::create(Locations::Germany, Participants::Vehicle);
-  auto new_routing_graph = lanelet::routing::RoutingGraph::build(*map, *trafficRules);
-  new_routing_graph->exportGraphViz("modified_map_graph.viz"); //TODO: not sure where it is writing to...
-                                                               // open to see if the map is valid still
+  EXPECT_EQ(0ul, report.errors.size());                                                          
   EXPECT_EQ(map->regulatoryElementLayer.size(), 1);
 }
 

--- a/common/lanelet2_extension/test/src/test_utilities.cpp
+++ b/common/lanelet2_extension/test/src/test_utilities.cpp
@@ -30,30 +30,12 @@
 #include <lanelet2_extension/io/autoware_osm_parser.h>
 #include <lanelet2_validation/Validation.h>
 
-///
-
-#include <stdio.h>  /* defines FILENAME_MAX */
-// #define WINDOWS  /* uncomment this line to use it for windows.*/ 
-#ifdef WINDOWS
-#include <direct.h>
-#define GetCurrentDir _getcwd
-#else
-#include <unistd.h>
-#define GetCurrentDir getcwd
-#endif
-#include<iostream>
-
-///
-
 using lanelet::Lanelet;
 using lanelet::LineString3d;
-using lanelet::LineStringOrPolygon3d;
 using lanelet::Point3d;
 using lanelet::Points3d;
 using lanelet::Area;
 using lanelet::utils::getId;
-
-
 
 class TestSuite : public ::testing::Test
 {
@@ -202,7 +184,7 @@ public:
   }
 
   lanelet::LaneletMapPtr sample_map_ptr;
-  Lanelet road_lanelet, road_lanelet1;
+  Lanelet road_lanelet;
   Lanelet next_lanelet;
   Lanelet next_lanelet2;
   Lanelet merging_lanelet;

--- a/common/lanelet2_extension/test/src/test_utilities.cpp
+++ b/common/lanelet2_extension/test/src/test_utilities.cpp
@@ -15,16 +15,136 @@
  */
 
 #include <gtest/gtest.h>
+#include <lanelet2_extension/utility/query.h>
 #include <lanelet2_extension/utility/utilities.h>
 #include <lanelet2_routing/RoutingGraphContainer.h>
 #include <lanelet2_traffic_rules/TrafficRulesFactory.h>
+#include <lanelet2_extension/regulatory_elements/PassingControlLine.h>
 #include <map>
 #include <ros/ros.h>
 
+#include <lanelet2_extension/projection/local_frame_projector.h>
+#include <lanelet2_io/Io.h>
+#include <lanelet2_io/io_handlers/Factory.h>
+#include <lanelet2_io/io_handlers/Writer.h>
+#include <lanelet2_extension/io/autoware_osm_parser.h>
+#include <lanelet2_validation/Validation.h>
+
+///
+
+#include <stdio.h>  /* defines FILENAME_MAX */
+// #define WINDOWS  /* uncomment this line to use it for windows.*/ 
+#ifdef WINDOWS
+#include <direct.h>
+#define GetCurrentDir _getcwd
+#else
+#include <unistd.h>
+#define GetCurrentDir getcwd
+#endif
+#include<iostream>
+
+///
+
 using lanelet::Lanelet;
 using lanelet::LineString3d;
+using lanelet::LineStringOrPolygon3d;
 using lanelet::Point3d;
+using lanelet::Points3d;
+using lanelet::Area;
 using lanelet::utils::getId;
+
+
+
+class TestSuite : public ::testing::Test
+{
+public:
+  Point3d p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p_unreg1, p_unreg2;
+  LineString3d ls_left, ls_right, ls_right_right, traffic_light_base, 
+    traffic_light_bulbs, stop_line, ls_area_right, ls_area_top, ls_area_bottom, pcl_unreg_ls, ls_unreg;
+  lanelet::ConstLineString3d centerline;
+  Lanelet road_lanelet, road_lanelet1, crosswalk_lanelet;
+  Area side_area;
+  lanelet::autoware::AutowareTrafficLight::Ptr tl;
+  std::shared_ptr<lanelet::PassingControlLine> pcl, pcl_unreg;
+
+  TestSuite() : sample_map_ptr(new lanelet::LaneletMap())
+  {  // NOLINT
+
+    // create sample lanelets
+    p1 = Point3d(getId(), 0., 0., 0.);
+    p2 = Point3d(getId(), 0., 1., 0.);
+    p_unreg1 = Point3d(getId(), 0., 11., 0.);
+    p_unreg2 = Point3d(getId(), 0., 12., 0.);
+
+    p3 = Point3d(getId(), 1., 0., 0.);
+    p4 = Point3d(getId(), 1., 1., 0.);
+
+    p5 = Point3d(getId(), 2., 0., 0.);
+    p6 = Point3d(getId(), 2., 1., 0.);
+
+    // create a sample area
+    p14 = Point3d(getId(), 3., 0., 0.);
+    p15 = Point3d(getId(), 3., 1., 0.);
+
+    ls_left  = LineString3d(getId(), { p1, p2 });   // NOLINT
+    ls_right = LineString3d(getId(), { p3, p4 });  // NOLINT
+    ls_right_right = LineString3d(getId(), { p5, p6 });  // NOLINT
+    ls_area_right = LineString3d(getId(), { p14, p15 });  // NOLINT
+    ls_area_top = LineString3d(getId(), { p15, p6 });
+    ls_area_bottom = LineString3d(getId(), { p14, p5 });
+    ls_unreg = LineString3d(getId(), { p_unreg1, p_unreg2 });
+    
+    road_lanelet = Lanelet(getId(), ls_left, ls_right);
+    road_lanelet.attributes()[lanelet::AttributeName::Subtype] = lanelet::AttributeValueString::Road;
+    centerline = road_lanelet.centerline();
+    road_lanelet1 = Lanelet(getId(), ls_right, ls_right_right);
+    road_lanelet1.attributes()[lanelet::AttributeName::Subtype] = lanelet::AttributeValueString::Road;
+    crosswalk_lanelet = Lanelet(getId(), ls_left, ls_right);
+    crosswalk_lanelet.attributes()[lanelet::AttributeName::Subtype] = lanelet::AttributeValueString::Crosswalk;
+    side_area = Area(getId(), {ls_area_top, ls_area_right, ls_area_bottom, ls_right_right});
+
+    // create sample traffic light
+    p7 = Point3d(getId(), 0., 1., 4.);
+    p8 = Point3d(getId(), 1., 1., 4.);
+
+    p9 = Point3d(getId(), 0., 1., 4.5);
+    p10 = Point3d(getId(), 0.5, 1., 4.5);
+    p11 = Point3d(getId(), 1., 1., 4.5);
+
+    p12 = Point3d(getId(), 0., 0., 0.);
+    p13 = Point3d(getId(), 1., 0., 0.);
+
+    traffic_light_base = LineString3d(getId(), Points3d{ p7, p8 });        // NOLINT
+    traffic_light_bulbs = LineString3d(getId(), Points3d{ p9, p10, p11 });  // NOLINT
+    stop_line = LineString3d(getId(), Points3d{ p12, p13 });               // NOLINT
+    pcl_unreg_ls = LineString3d(getId(), { p16, p17 });
+
+    tl = lanelet::autoware::AutowareTrafficLight::make(getId(), lanelet::AttributeMap(), { traffic_light_base },
+                                                            stop_line, { traffic_light_bulbs });  // NOLINT
+
+    pcl = std::make_shared<lanelet::PassingControlLine>(lanelet::PassingControlLine::buildData(
+      lanelet::utils::getId(), {road_lanelet1.leftBound() }, {}, { lanelet::Participants::Vehicle }));
+
+    pcl_unreg = std::make_shared<lanelet::PassingControlLine>(lanelet::PassingControlLine::buildData(
+      lanelet::utils::getId(), {pcl_unreg_ls}, {}, { lanelet::Participants::Vehicle }));
+
+    road_lanelet.addRegulatoryElement(tl);
+    road_lanelet.addRegulatoryElement(pcl);
+    side_area.addRegulatoryElement(pcl);
+    // add items to map
+    sample_map_ptr->add(road_lanelet);
+    sample_map_ptr->add(road_lanelet1);
+    sample_map_ptr->add(crosswalk_lanelet);
+    sample_map_ptr->add(side_area);
+    sample_map_ptr->add(pcl_unreg);
+  }
+
+  ~TestSuite(){}
+
+  lanelet::LaneletMapPtr sample_map_ptr;
+
+private:
+};
 
 class TestSuite1 : public ::testing::Test
 {
@@ -71,29 +191,6 @@ public:
 
     merging_lanelet = Lanelet(getId(), ls_left4, ls_right4);
     merging_lanelet.attributes()[lanelet::AttributeName::Subtype] = lanelet::AttributeValueString::Road;
-
-    Point3d p_unreg1,p_unreg;
-    p_unreg1 = Point3d(getId(), 0., 11., 0.);
-    p_unreg2 = Point3d(getId(), 0., 12., 0.);
-
-    road_lanelet1 = Lanelet(getId(), ls_right, ls_right_right);
-    road_lanelet1.attributes()[lanelet::AttributeName::Subtype] = lanelet::AttributeValueString::Road;
-
-
-    LineString3d pcl_unreg_ls, ls_unreg;
-    std::shared_ptr<lanelet::PassingControlLine> pcl, pcl_unreg;
-    ls_unreg = LineString3d(getId(), { p_unreg1, p_unreg2 });
-
-    tl = lanelet::autoware::AutowareTrafficLight::make(getId(), lanelet::AttributeMap(), { traffic_light_base },
-                                                        stop_line, { traffic_light_bulbs });  // NOLINT
-
-    pcl = std::make_shared<lanelet::PassingControlLine>(lanelet::PassingControlLine::buildData(
-          lanelet::utils::getId(), {road_lanelet1.leftBound() }, {}, { lanelet::Participants::Vehicle }));
-
-    pcl_unreg = std::make_shared<lanelet::PassingControlLine>(lanelet::PassingControlLine::buildData(
-          lanelet::utils::getId(), {pcl_unreg_ls}, {}, { lanelet::Participants::Vehicle }));
-
-
 
     sample_map_ptr->add(road_lanelet);
     sample_map_ptr->add(next_lanelet);
@@ -160,22 +257,9 @@ TEST_F(TestSuite1, OverwriteLaneletsCenterline)
   }
 }
 
-TEST_F(TestSuite2, RemoveRegulatoryElements)
+TEST_F(TestSuite, RemoveRegulatoryElements)
 {
-    
-  LineString3d pcl_unreg_ls, ls_unreg;
-  std::shared_ptr<lanelet::PassingControlLine> pcl, pcl_unreg;
-
-  Point3d p1, p2;
-  p1 = Point3d(getId(), 0., 1., 4.);
-  p2 = Point3d(getId(), 1., 1., 4.);
-
-  pcl_unreg_ls = LineString3d(getId(), { p1, p2 });
-  pcl_unreg = std::make_shared<lanelet::PassingControlLine>(lanelet::PassingControlLine::buildData(
-  lanelet::utils::getId(), {pcl_unreg_ls}, {}, { lanelet::Participants::Vehicle }));
-  // we added pcl_unreg in TestSuite 
-
-  // call remove function for remove REG elem
+  // call remove function for REG elem
   std::vector<lanelet::RegulatoryElementPtr> regem_list = {pcl_unreg};
   lanelet::utils::removeRegulatoryElements(regem_list, sample_map_ptr);
 
@@ -187,16 +271,77 @@ TEST_F(TestSuite2, RemoveRegulatoryElements)
 
   // find regems that are using pcl_unreg_ls
   std::vector<lanelet::RegulatoryElementPtr> regems1 = sample_map_ptr->regulatoryElementLayer.findUsages(pcl_unreg_ls);
-  ASSERT_EQ(regems1.size(), 0);
+  ASSERT_EQ(regems1.size(), 0); //there should be none as it was removed
 
   // check if other primitives are referencing the removed regem
-  std::vector<lanelet::RegulatoryElementPtr> regems1 = sample_map_ptr->laneletLayer.findUsages(pcl_unreg_ls);
-  ASSERT_EQ(regems1.size(), 0);
+  // road_lanelet had 2 regems originally: pcl, tf
+  ASSERT_EQ(sample_map_ptr->laneletLayer.find(road_lanelet.id())->regulatoryElements().size(),2);
+  lanelet::utils::removeRegulatoryElements({tl}, sample_map_ptr);
 
+  // now it should only have 1 regem: pcl
+  ASSERT_EQ(sample_map_ptr->regulatoryElementLayer.find(tl->id()),sample_map_ptr->regulatoryElementLayer.end());
+  ASSERT_EQ(sample_map_ptr->regulatoryElementLayer.findUsages(stop_line).size(), 0); //dangling parameter not referencing back
+  ASSERT_EQ(sample_map_ptr->laneletLayer.find(road_lanelet.id())->regulatoryElements().size(),1);
+  ASSERT_EQ(sample_map_ptr->laneletLayer.find(road_lanelet.id())->regulatoryElements()[0]->id(),pcl->id());
+  rf = lanelet::utils::query::findReferences(tl, sample_map_ptr);
+  ASSERT_EQ(rf.regems.size(), 0); 
+  ASSERT_EQ(rf.lss.size(), 3); //tl local copy still references these 3 parameters, 
+                              // but those parameters don't reference it back as it should 
+  ASSERT_EQ(rf.llts.size(), 0); // connection with parent llt is severed
 
-  // TODO 
-  // test if map is valid
+  // Test if map is valid by writing it to a file and loading it
+  // Build new map from modified data
+  std::vector<lanelet::Area> new_areas;
+  std::vector<lanelet::Lanelet> new_lanelets;
+  for (auto lanelet : sample_map_ptr->laneletLayer)
+  {
+    std::cerr << "Adding lanelet: " << lanelet.id() << std::endl;
+    lanelet::Lanelet mutable_ll = sample_map_ptr->laneletLayer.get(lanelet.id());
+    new_lanelets.emplace_back(mutable_ll);
+  }
+  for (auto area : sample_map_ptr->areaLayer)
+  {
+    std::cerr << "Adding area: " << area.id() << std::endl;
+    lanelet::Area mutable_area = sample_map_ptr->areaLayer.get(area.id());
+    new_areas.emplace_back(mutable_area);
+  }
+  auto new_map = lanelet::utils::createMap(new_lanelets, new_areas);
+  // Write new map to file
+  std::string new_file = "modified_map.osm";
+  lanelet::projection::LocalFrameProjector local_projector("+proj=tmerc +lat_0=39.46636844371259 +lon_0=-76.16919523566943 +k=1 +x_0=0 +y_0=0 +datum=WGS84 +units=m +vunits=m +no_defs");
+  lanelet::ErrorMessages write_errors;
 
+  lanelet::write(new_file, *new_map, local_projector, &write_errors);
+
+  if (write_errors.size() > 0)
+  {
+    std::cerr << "Errors occurred while writing the map! Output file located at " << new_file << std::endl;
+  }
+  else
+  {
+    std::cerr << "Map written without errors to: " << new_file << std::endl;
+  }
+  for (auto msg : write_errors)
+  {
+    std::cerr << "Write Error: " << msg << std::endl;
+  }
+
+  // Now try to load it back
+  using namespace lanelet;
+  LaneletMapPtr map = lanelet::load(new_file, local_projector);
+  lanelet::validation::ValidationConfig config;
+  auto issues = lanelet::validation::validateMap(*map, config);
+  auto report = lanelet::validation::buildReport(issues);
+  EXPECT_EQ(13, report.warnings.size()); // these 13 warnings have been verified  
+                                         // that they are not related to our issue of focus
+  EXPECT_EQ(0ul, report.errors.size());
+  // In fact, it should be routable
+  traffic_rules::TrafficRulesPtr trafficRules =
+    traffic_rules::TrafficRulesFactory::create(Locations::Germany, Participants::Vehicle);
+  auto new_routing_graph = lanelet::routing::RoutingGraph::build(*map, *trafficRules);
+  new_routing_graph->exportGraphViz("modified_map_graph.viz"); //TODO: not sure where it is writing to...
+                                                               // open to see if the map is valid still
+  EXPECT_EQ(map->regulatoryElementLayer.size(), 1);
 }
 
 int main(int argc, char** argv)

--- a/lanelet2/lanelet2_core/include/lanelet2_core/LaneletMap.h
+++ b/lanelet2/lanelet2_core/include/lanelet2_core/LaneletMap.h
@@ -442,6 +442,7 @@ class LaneletMap : public LaneletMapLayers {
    * @throw InvalidInputError if regElem has InvalId as Id
    *
    * NOTE: currently removing this regElem will not remove elements that it owns from the map.
+   *       This means that elements that are no longer being referenced anywhere would still remain in the map.
    *       The function is expected to be overloaded with remaining primitive types in the future.
    */
   void remove(const RegulatoryElementPtr& regElem);

--- a/lanelet2/lanelet2_core/include/lanelet2_core/LaneletMap.h
+++ b/lanelet2/lanelet2_core/include/lanelet2_core/LaneletMap.h
@@ -434,6 +434,17 @@ class LaneletMap : public LaneletMapLayers {
    * sure that the id has not already been for a different element.
    */
   void add(Point3d point);
+
+  /**
+   * @brief removes the regulatory element without removing its referenced parameters
+   * @param regElem regulatory element to be removed
+   * @throws NullptrError if regElem is a nullptr or has InvalId as Id
+   *
+   * NOTE: currently removing this regElem will not remove elements that it owns from the map
+   *       the function is expected to be overloaded with remaining primitive types in the future
+   *       by that time, all overloads could be one function with expected input of just lanelet Id
+   */
+  void remove(const RegulatoryElementPtr& regElem);
 };
 
 /**

--- a/lanelet2/lanelet2_core/include/lanelet2_core/LaneletMap.h
+++ b/lanelet2/lanelet2_core/include/lanelet2_core/LaneletMap.h
@@ -438,11 +438,11 @@ class LaneletMap : public LaneletMapLayers {
   /**
    * @brief removes the regulatory element without removing its referenced parameters
    * @param regElem regulatory element to be removed
-   * @throws NullptrError if regElem is a nullptr or has InvalId as Id
+   * @throw NullptrError if regElem is a nullptr
+   * @throw InvalidInputError if regElem has InvalId as Id
    *
-   * NOTE: currently removing this regElem will not remove elements that it owns from the map
-   *       the function is expected to be overloaded with remaining primitive types in the future
-   *       by that time, all overloads could be one function with expected input of just lanelet Id
+   * NOTE: currently removing this regElem will not remove elements that it owns from the map.
+   *       The function is expected to be overloaded with remaining primitive types in the future.
    */
   void remove(const RegulatoryElementPtr& regElem);
 };

--- a/lanelet2/lanelet2_core/src/LaneletMap.cpp
+++ b/lanelet2/lanelet2_core/src/LaneletMap.cpp
@@ -468,11 +468,11 @@ void PrimitiveLayer<T>::remove(Id id) {
 
 template <>
 void PrimitiveLayer<Point3d>::remove(Id id) {
-  /*tree_->usage.add(p);
-  elements_.insert({p.id(), p});
-  tree_->insert(p);
+  /*tree_->usage.remove(p);
+  elements_.remove({p.id(), p});
+  tree_->remove(p);
+  TODO
   */
-  std::cout<< "Hey we entered point primitive remove func" << std::endl;
   return;
 }
 
@@ -690,16 +690,28 @@ void LaneletMap::add(Area area) {
 
 void LaneletMap::remove(const RegulatoryElementPtr& regElem)
 {
-  // TODO check the conditionals correctly here
-  if (!regElem || regElem->id() == InvalId) 
+  if (!regElem) 
   {
-    throw NullptrError("Empty regulatory element passed to add()!");
+    throw NullptrError("Empty regulatory element passed to remove()!");
+  }
+  if (regElem->id() == InvalId)
+  {
+    throw InvalidInputError("Regulatory element with InvalidId is passed to remove()!");
   }
   if (regulatoryElementLayer.exists(regElem->id()))
   {
     regulatoryElementLayer.remove(regElem->id());
   }
-  // remove its parameters
+  // remove local copies of regem inside lanelet and areas
+  for (Lanelet llt : laneletLayer.findUsages(regElem))
+  {
+    llt.removeRegulatoryElement(regElem);
+  }
+  for (Area area : areaLayer.findUsages(regElem))
+  {
+    area.removeRegulatoryElement(regElem);
+  }
+  // remove its (possibly dangling) parameters 
   // TODO: uncomment when each layer's remove is implemented
   /*
   RemoveVisitor visitor(this);

--- a/lanelet2/lanelet2_core/src/LaneletMap.cpp
+++ b/lanelet2/lanelet2_core/src/LaneletMap.cpp
@@ -468,12 +468,10 @@ void PrimitiveLayer<T>::remove(Id id) {
 
 template <>
 void PrimitiveLayer<Point3d>::remove(Id id) {
-  /*tree_->usage.remove(p);
-  elements_.remove({p.id(), p});
-  tree_->remove(p);
-  TODO
-  */
-  return;
+  Point3d p = elements_.find(id)->second;
+  tree_->usage.remove(p);
+  elements_.erase(id);
+  tree_->erase(p);
 }
 
 template <>

--- a/lanelet2/lanelet2_core/src/LaneletMap.cpp
+++ b/lanelet2/lanelet2_core/src/LaneletMap.cpp
@@ -135,30 +135,6 @@ struct AssignIdVisitor : public boost::static_visitor<void> {
   LaneletMap* map_;
 };
 
-/* TODO: Uncomment when each layer's remove function is implemented
-struct RemoveVisitor : public lanelet::internal::MutableParameterVisitor {
-  explicit RemoveVisitor(LaneletMap* map) : map_(map) {}
-
-  void operator()(const Point3d& p) override { map_->remove(p); }
-  void operator()(const LineString3d& l) override { map_->remove(l); }
-  void operator()(const Polygon3d& p) override { map_->remove(p); }
-  void operator()(const WeakLanelet& ll) override {
-    if (ll.expired()) {  // NOLINT
-      return;
-    }
-    map_->remove(ll.lock());
-  }
-  void operator()(const WeakArea& ar) override {
-    if (ar.expired()) {  // NOLINT
-      return;
-    }
-    map_->remove(ar.lock());
-  }
-
- private:
-  LaneletMap* map_;
-};
-*/
 struct AddVisitor : public lanelet::internal::MutableParameterVisitor {
   explicit AddVisitor(LaneletMap* map) : map_(map) {}
 
@@ -709,12 +685,6 @@ void LaneletMap::remove(const RegulatoryElementPtr& regElem)
   {
     area.removeRegulatoryElement(regElem);
   }
-  // remove its (possibly dangling) parameters 
-  // TODO: uncomment when each layer's remove is implemented
-  /*
-  RemoveVisitor visitor(this);
-  regElem->applyVisitor(visitor);
-  */
 }
 
 void LaneletMap::add(const RegulatoryElementPtr& regElem) {


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->

This PR developed a logic to remove only regulatory elements from the map. 
Logic consists of 
- removing local copies of regems in lanelet and areas, so that lanelet.regulatoryElements() doesn't return the removed regems
- removing regems from regulatoryElement layer by deleting them from elements_, tree_.usage, and tree_ members of the layer. This is so that regulatoryElementLayer.findUsage() doesn't return the removed regems.

## Related Issue
https://github.com/usdot-fhwa-stol/carma-platform/issues/705
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
In order to update a lanelet2 map to support geofences we will need to be able to remove regulatory elements from a lanelet map so they can be replaced. This PR is to develop a function in autoware.ai/lanelet2 that can remove regulatory elements from the map. It is done in such a way that the resulting map is self valid despite the resulting map may cannot be routed over when a regulation required be CARMAUsTrafficRules is removed as it is expected that we will add this back in right after updating a regulation. 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tested the logic and validated the map by writing it to a file and loading it again without errors.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.