### PR TITLE
Fix/regem queries

### DIFF
--- a/common/lanelet2_extension/include/lanelet2_extension/utility/internal/query.tpp
+++ b/common/lanelet2_extension/include/lanelet2_extension/utility/internal/query.tpp
@@ -61,6 +61,7 @@ query::References query::findReferences(const primT& prim, const lanelet::Lanele
 {
   query::References references;
   recurse(prim, ll_Map, query::direction::CHECK_CHILD, references);
+  recurse(prim, ll_Map, query::direction::CHECK_PARENT, references);
   return references;
 } 
 } // namespace utils

--- a/common/lanelet2_extension/lib/query.cpp
+++ b/common/lanelet2_extension/lib/query.cpp
@@ -39,7 +39,7 @@ void recurse (const lanelet::ConstPoint3d& prim, const lanelet::LaneletMapPtr ll
   // get LineStrings that own this point
   auto ls_list_owning_point = ll_Map->lineStringLayer.findUsages(prim);
 
-  // if it's not owned by anyone, do not record it since points are not meaningful objects in Lanelet
+  // if it's not owned by anyone, do not record it since points are not meaningful objects by only themselves in Lanelet
   if (ls_list_owning_point.size() == 0)
       return;
 
@@ -90,7 +90,7 @@ void recurse (const lanelet::ConstLineString3d& prim, const lanelet::LaneletMapP
     recurse(regem, ll_Map, query::CHECK_PARENT, rfs);
   }
 
-  if (area_list_owning_ls.size() ==0 && llt_list_owning_ls.size() == 0 && regem_list_owning_ls.size() == 0)
+  if (area_list_owning_ls.size() ==0 && llt_list_owning_ls.size() == 0 && regem_list_owning_ls.size() == 0 && ll_Map->lineStringLayer.exists(prim.id()))
     rfs.lss.insert(prim);
 }
 
@@ -111,7 +111,8 @@ void recurse (const lanelet::ConstLanelet& prim, const lanelet::LaneletMapPtr ll
 
   // go up, query::CHECK_PARENT
   // no one 'owns' lanelet, so just add it
-  rfs.llts.insert(prim);
+  if (ll_Map->laneletLayer.exists(prim.id()))
+    rfs.llts.insert(prim);
   return;
 }
 
@@ -139,7 +140,8 @@ void recurse (const lanelet::ConstArea& prim, const lanelet::LaneletMapPtr ll_Ma
 
   // go up, query::CHECK_PARENT
   // no one 'owns' area, so just add it
-  rfs.areas.insert(prim);
+  if (ll_Map->areaLayer.exists(prim.id()))
+    rfs.areas.insert(prim);
   return;
 }
 
@@ -172,7 +174,7 @@ void recurse (const lanelet::RegulatoryElementConstPtr& prim_ptr, const lanelet:
     recurse(area, ll_Map, query::CHECK_PARENT, rfs);
   }
 
-  if (area_list_owning_regem.size() ==0 && llt_list_owning_regem.size() == 0)
+  if (area_list_owning_regem.size() ==0 && llt_list_owning_regem.size() == 0 && ll_Map->regulatoryElementLayer.exists(prim_ptr->id()))
     rfs.regems.insert(prim_ptr);
 }
 

--- a/common/lanelet2_extension/test/src/test_utilities.cpp
+++ b/common/lanelet2_extension/test/src/test_utilities.cpp
@@ -269,7 +269,9 @@ TEST_F(TestSuite, RemoveRegulatoryElements)
   ASSERT_EQ(rf.regems.size(), 0); 
   ASSERT_EQ(rf.lss.size(), 3); //tl local copy still references these 3 parameters, 
                               // but those parameters don't reference it back as it should 
-  ASSERT_EQ(rf.llts.size(), 1); // TODO, should be 0 connection with parent llt is severed
+  ASSERT_EQ(rf.llts.size(), 0); // should be 0 connection with parent llt is severed
+  ASSERT_EQ(sample_map_ptr->laneletLayer.findUsages(tl).size(), 0); // this is proved by looking for a owner for tl regem in 
+                                                                    // lanelet layer will result in 0
 
   // Test if map is valid by writing it to a file and loading it
   // Build new map from modified data

--- a/common/lanelet2_extension/test/src/test_utilities.cpp
+++ b/common/lanelet2_extension/test/src/test_utilities.cpp
@@ -247,7 +247,7 @@ TEST_F(TestSuite, RemoveRegulatoryElements)
 
   // check if reg was removed
   lanelet::utils::query::References rf = lanelet::utils::query::findReferences(pcl_unreg, sample_map_ptr);
-  ASSERT_EQ(rf.regems.size(), 0); //pcl_unreg is gone
+  ASSERT_EQ(rf.regems.size(), 0); // because pcl_unreg is now removed
   ASSERT_EQ(rf.lss.size(), 1); //not part of pcl_unreg anymore so stand alone
   ASSERT_EQ(rf.lss.begin()->id(), pcl_unreg_ls.id());
 
@@ -269,7 +269,7 @@ TEST_F(TestSuite, RemoveRegulatoryElements)
   ASSERT_EQ(rf.regems.size(), 0); 
   ASSERT_EQ(rf.lss.size(), 3); //tl local copy still references these 3 parameters, 
                               // but those parameters don't reference it back as it should 
-  ASSERT_EQ(rf.llts.size(), 0); // connection with parent llt is severed
+  ASSERT_EQ(rf.llts.size(), 1); // TODO, should be 0 connection with parent llt is severed
 
   // Test if map is valid by writing it to a file and loading it
   // Build new map from modified data

--- a/lanelet2/lanelet2_core/include/lanelet2_core/LaneletMap.h
+++ b/lanelet2/lanelet2_core/include/lanelet2_core/LaneletMap.h
@@ -243,6 +243,9 @@ class PrimitiveLayer {
 
   void add(const PrimitiveT& element);
   void remove(Id element);
+  // removes specified subelement from the element's UsageLookup
+  template <typename SubT>
+  void remove(Id element_id, const SubT& subelement);
 
   // NOLINTNEXTLINE
   Map elements_;  //!< the list of elements in this layer

--- a/lanelet2/lanelet2_core/src/LaneletMap.cpp
+++ b/lanelet2/lanelet2_core/src/LaneletMap.cpp
@@ -242,6 +242,16 @@ struct UsageLookup<RegulatoryElementPtr> {
       }
     }
   }
+  void remove(const RegulatoryElementPtr& prim, ConstRuleParameter owned_element) {
+    for (auto it = ownedLookup.begin(); it != ownedLookup.end(); ){
+      if (it->second->id() == prim->id() && lanelet::IdVisitor().getId(it->first) == lanelet::IdVisitor().getId(owned_element)) { 
+        ownedLookup.erase(it++); 
+      } else { 
+        ++it;          
+      }
+    }
+  }
+
   std::unordered_multimap<ConstRuleParameter, RegulatoryElementPtr> ownedLookup;
 };
 template <>
@@ -258,6 +268,26 @@ struct UsageLookup<Area> {
       regElemLookup.insert(std::make_pair(elem, area));
     }
   }
+  void remove(Area area, ConstLineString3d ls)
+  {
+    for (auto it = ownedLookup.begin(); it != ownedLookup.end(); ){
+      if (it->second.id() == area.id() && it->first.id() == ls.id()) { 
+        ownedLookup.erase(it++); 
+      } else { 
+        ++it;          
+      }
+    }
+  }
+  void remove(Area area, RegulatoryElementConstPtr regem_ptr)
+  {
+    for (auto it = regElemLookup.begin(); it != regElemLookup.end(); ){
+      if (it->second.id() == area.id() && it->first->id() == regem_ptr->id()) { 
+        regElemLookup.erase(it++); 
+      } else { 
+        ++it;          
+      }
+    }
+  }
   std::unordered_multimap<ConstLineString3d, Area> ownedLookup;
   std::unordered_multimap<RegulatoryElementConstPtr, Area> regElemLookup;
 };
@@ -270,6 +300,27 @@ struct UsageLookup<Lanelet> {
       regElemLookup.insert(std::make_pair(elem, ll));
     }
   }
+  void remove(Lanelet ll, ConstLineString3d ls)
+  {
+    for (auto it = ownedLookup.begin(); it != ownedLookup.end(); ){
+      if (it->second.id() == ll.id() && it->first.id() == ls.id()) { 
+        ownedLookup.erase(it++); 
+      } else { 
+        ++it;          
+      }
+    }
+  }
+  void remove(Lanelet ll, RegulatoryElementConstPtr regem_ptr)
+  {
+    for (auto it = regElemLookup.begin(); it != regElemLookup.end(); ){
+      if (it->second.id() == ll.id() && it->first->id() == regem_ptr->id()) { 
+        regElemLookup.erase(it++); 
+      } else { 
+        ++it;          
+      }
+    }
+  }
+
   std::unordered_multimap<ConstLineString3d, Lanelet> ownedLookup;
   std::unordered_multimap<RegulatoryElementConstPtr, Lanelet> regElemLookup;
 };
@@ -442,12 +493,34 @@ void PrimitiveLayer<T>::remove(Id id) {
   tree_->erase(element);
 }
 
+template <typename T>
+template <typename SubT>
+void PrimitiveLayer<T>::remove(Id element_id, const SubT& subelement)
+{
+  // find the element with this id (the user must make sure it exists)
+  T element = elements_.find(element_id)->second;
+  // remove the subelement from usage lookup of element with this Id in this layer
+  for (auto it = tree_->usage.ownedLookup.begin(); it != tree_->usage.ownedLookup.end(); )
+  {
+    if (it->second.id() == element.id() && it->first.id() == subelement.id()) { 
+      tree_->usage.ownedLookup.erase(it++); 
+    } else { 
+      ++it;          
+    }
+  }
+}
+
 template <>
 void PrimitiveLayer<Point3d>::remove(Id id) {
   Point3d p = elements_.find(id)->second;
   tree_->usage.remove(p);
   elements_.erase(id);
   tree_->erase(p);
+}
+template <>
+template <>
+void PrimitiveLayer<Point3d>::remove(Id id, const traits::ConstPrimitiveType<traits::OwnedT<PrimitiveT>>& subelement) {
+  //not used as point doesn't have any sub_element
 }
 
 template <>
@@ -457,6 +530,41 @@ void PrimitiveLayer<RegulatoryElementPtr>::remove(Id id) {
   elements_.erase(id);
   tree_->erase(element);
 }
+
+template <>
+template <>
+void PrimitiveLayer<RegulatoryElementPtr>::remove(Id element_id, const traits::ConstPrimitiveType<traits::OwnedT<PrimitiveT>>& subelement) {
+  RegulatoryElementPtr element = elements_.find(element_id)->second;
+  tree_->usage.remove(element, subelement);
+}
+
+template <>
+template <>
+void PrimitiveLayer<Area>::remove(Id element_id, const traits::ConstPrimitiveType<traits::OwnedT<PrimitiveT>>& subelement) {
+  Area element = elements_.find(element_id)->second;
+  tree_->usage.remove(element, subelement);
+}
+
+template <>
+template <>
+void PrimitiveLayer<Area>::remove(Id element_id, const RegulatoryElementPtr& regElem) {
+  Area element = elements_.find(element_id)->second;
+  tree_->usage.remove(element, regElem);
+}
+
+template <>
+template <>
+void PrimitiveLayer<Lanelet>::remove(Id element_id, const traits::ConstPrimitiveType<traits::OwnedT<PrimitiveT>>& subelement) {
+  Lanelet element = elements_.find(element_id)->second;
+  tree_->usage.remove(element, subelement);
+}
+template <>
+template <>
+void PrimitiveLayer<Lanelet>::remove(Id element_id, const RegulatoryElementPtr&  regElem) {
+  Lanelet element = elements_.find(element_id)->second;
+  tree_->usage.remove(element, regElem);
+}
+
 
 template <typename T>
 std::vector<typename PrimitiveLayer<T>::ConstPrimitiveT> PrimitiveLayer<T>::findUsages(
@@ -679,10 +787,12 @@ void LaneletMap::remove(const RegulatoryElementPtr& regElem)
   // remove local copies of regem inside lanelet and areas
   for (Lanelet llt : laneletLayer.findUsages(regElem))
   {
+    laneletLayer.remove(llt.id(), regElem);
     llt.removeRegulatoryElement(regElem);
   }
   for (Area area : areaLayer.findUsages(regElem))
   {
+    areaLayer.remove(area.id(), regElem);
     area.removeRegulatoryElement(regElem);
   }
 }

--- a/lanelet2/lanelet2_core/src/LaneletMap.cpp
+++ b/lanelet2/lanelet2_core/src/LaneletMap.cpp
@@ -268,16 +268,7 @@ struct UsageLookup<Area> {
       regElemLookup.insert(std::make_pair(elem, area));
     }
   }
-  void remove(Area area, ConstLineString3d ls)
-  {
-    for (auto it = ownedLookup.begin(); it != ownedLookup.end(); ){
-      if (it->second.id() == area.id() && it->first.id() == ls.id()) { 
-        ownedLookup.erase(it++); 
-      } else { 
-        ++it;          
-      }
-    }
-  }
+
   void remove(Area area, RegulatoryElementConstPtr regem_ptr)
   {
     for (auto it = regElemLookup.begin(); it != regElemLookup.end(); ){
@@ -298,16 +289,6 @@ struct UsageLookup<Lanelet> {
     ownedLookup.insert(std::make_pair(ll.rightBound(), ll));
     for (const auto& elem : ll.regulatoryElements()) {
       regElemLookup.insert(std::make_pair(elem, ll));
-    }
-  }
-  void remove(Lanelet ll, ConstLineString3d ls)
-  {
-    for (auto it = ownedLookup.begin(); it != ownedLookup.end(); ){
-      if (it->second.id() == ll.id() && it->first.id() == ls.id()) { 
-        ownedLookup.erase(it++); 
-      } else { 
-        ++it;          
-      }
     }
   }
   void remove(Lanelet ll, RegulatoryElementConstPtr regem_ptr)
@@ -517,11 +498,6 @@ void PrimitiveLayer<Point3d>::remove(Id id) {
   elements_.erase(id);
   tree_->erase(p);
 }
-template <>
-template <>
-void PrimitiveLayer<Point3d>::remove(Id id, const traits::ConstPrimitiveType<traits::OwnedT<PrimitiveT>>& subelement) {
-  //not used as point doesn't have any sub_element
-}
 
 template <>
 void PrimitiveLayer<RegulatoryElementPtr>::remove(Id id) {
@@ -540,13 +516,6 @@ void PrimitiveLayer<RegulatoryElementPtr>::remove(Id element_id, const traits::C
 
 template <>
 template <>
-void PrimitiveLayer<Area>::remove(Id element_id, const traits::ConstPrimitiveType<traits::OwnedT<PrimitiveT>>& subelement) {
-  Area element = elements_.find(element_id)->second;
-  tree_->usage.remove(element, subelement);
-}
-
-template <>
-template <>
 void PrimitiveLayer<Area>::remove(Id element_id, const RegulatoryElementPtr& regElem) {
   Area element = elements_.find(element_id)->second;
   tree_->usage.remove(element, regElem);
@@ -554,17 +523,10 @@ void PrimitiveLayer<Area>::remove(Id element_id, const RegulatoryElementPtr& reg
 
 template <>
 template <>
-void PrimitiveLayer<Lanelet>::remove(Id element_id, const traits::ConstPrimitiveType<traits::OwnedT<PrimitiveT>>& subelement) {
-  Lanelet element = elements_.find(element_id)->second;
-  tree_->usage.remove(element, subelement);
-}
-template <>
-template <>
 void PrimitiveLayer<Lanelet>::remove(Id element_id, const RegulatoryElementPtr&  regElem) {
   Lanelet element = elements_.find(element_id)->second;
   tree_->usage.remove(element, regElem);
 }
-
 
 template <typename T>
 std::vector<typename PrimitiveLayer<T>::ConstPrimitiveT> PrimitiveLayer<T>::findUsages(


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
Recently added removeRegulatoryElements function in autoware/common/lanelet2_extension/utils/utilities.h is not accounting for the fact that lanelet and area layers themselves have another indexes that still say the elements are in the map although it is not. This is different than lanelet and area elements themselves having indexes inside to record, which is previously thought to handle this overlooked scenario. This was not tested covered correctly in the test because the findReference uses different type of querying method to check that relation, and it was correctly removed according to that.
Therefore, in this PR:
- findReference is fixed to return correct relations (especially for regem as it was not accounting lanelet and areas)
- removeRegulatoryElements is fixed to delete subelements from lanelet and area layer's ownedUsage structure, so that regem relation won't exist within that layer

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/usdot-fhwa-stol/carma-platform/issues/719

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
It was blocking implementing the geofence speed change support as we need to remove old speed limit regulatory element and add a new one.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added new unit test and correct way of verifying if the relation is still there.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.