### PR TITLE
Feature/geofence speed support autoware

### DIFF
--- a/common/map_file/include/map_file/map_param_loader.h
+++ b/common/map_file/include/map_file/map_param_loader.h
@@ -24,7 +24,7 @@
 
 #include <lanelet2_extension/projection/local_frame_projector.h>
 #include <lanelet2_extension/io/autoware_osm_parser.h>
-
+#include <std_msgs/String.h>
 namespace map_param_loader
 {
 // Get transform from map_frame to ecef_frame using respective proj strings.
@@ -32,4 +32,5 @@ tf2::Transform getTransform(const std::string& map_frame);
 
 // Broadcast the input transform to tf_static.
 void broadcastTransform(const tf2::Transform& transform);
+
 }

--- a/common/map_file/nodes/map_param_loader/map_param_loader.cpp
+++ b/common/map_file/nodes/map_param_loader/map_param_loader.cpp
@@ -15,7 +15,6 @@
  */
 
 #include "map_file/map_param_loader.h"
-#include <std_msgs/String.h>
 
 namespace map_param_loader
 {

--- a/common/map_file/nodes/map_param_loader/map_param_loader.cpp
+++ b/common/map_file/nodes/map_param_loader/map_param_loader.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "map_file/map_param_loader.h"
+#include <std_msgs/String.h>
 
 namespace map_param_loader
 {
@@ -78,6 +79,7 @@ int main(int argc, char **argv)
   int projector_type = 1; // default value
   std::string target_frame, lanelet2_filename;
   private_nh.param<std::string>("file_name", lanelet2_filename, "");
+
   
   // Parse geo reference info from the lanelet map (.osm)
   lanelet::io_handlers::AutowareOsmParser::parseMapParams(lanelet2_filename, &projector_type, &target_frame);
@@ -87,6 +89,12 @@ int main(int argc, char **argv)
 
   // Broadcast the transform
   map_param_loader::broadcastTransform(tf);
+
+  // Broadcast the georeference
+  ros::Publisher georef_pub = private_nh.advertise<std_msgs::String>("georeference", 1, true);
+  std_msgs::String georef_msg;
+  georef_msg.data = target_frame;
+  georef_pub.publish(georef_msg);
 
   ros::spin();
 

--- a/lanelet2/lanelet2_core/include/lanelet2_core/LaneletMap.h
+++ b/lanelet2/lanelet2_core/include/lanelet2_core/LaneletMap.h
@@ -395,7 +395,8 @@ class LaneletMap : public LaneletMapLayers {
   /**
    * @brief adds the regElem to specified ll that is in the map
    * @throws NullptrError if has a regulatory element without members and 
-   *         InvalidInputError if lanelet is not in the map, or has InvalId
+   *         InvalidInputError if lanelet is not in the map, or it has InvalId, or
+   *         regElem with ID that is already in the map is passed in
    * If the new element that will be owned by lanelet have InvalId as Id, they
    * will be assigned a new, unique id. Otherwise you are responsible for making
    * sure that the id has not already been for a different element.

--- a/lanelet2/lanelet2_core/include/lanelet2_core/LaneletMap.h
+++ b/lanelet2/lanelet2_core/include/lanelet2_core/LaneletMap.h
@@ -246,6 +246,9 @@ class PrimitiveLayer {
   // removes specified subelement from the element's UsageLookup
   template <typename SubT>
   void remove(Id element_id, const SubT& subelement);
+  // adds specified subelement to the the element's UsageLookup
+  template <typename SubT>
+  void update(Id element_id, const SubT& subelement);
 
   // NOLINTNEXTLINE
   Map elements_;  //!< the list of elements in this layer
@@ -380,7 +383,7 @@ class LaneletMap : public LaneletMapLayers {
 
   /**
    * @brief adds a lanelet and all the elements it owns to the map
-   * @throws InvalidInputError if lanelet has a reglatory element without
+   * @throws InvalidInputError if lanelet has a regulatory element without
    * members
    *
    * If the lanelet or elements owned by the lanelet have InvalId as Id, they
@@ -388,6 +391,16 @@ class LaneletMap : public LaneletMapLayers {
    * sure that the id has not already been for a different element.
    */
   void add(Lanelet lanelet);
+
+  /**
+   * @brief adds the regElem to specified ll that is in the map
+   * @throws NullptrError if has a regulatory element without members and 
+   *         InvalidInputError if lanelet is not in the map, or has InvalId
+   * If the new element that will be owned by lanelet have InvalId as Id, they
+   * will be assigned a new, unique id. Otherwise you are responsible for making
+   * sure that the id has not already been for a different element.
+   */
+  void update(Lanelet ll, const RegulatoryElementPtr& regElem);
 
   /**
    * @brief adds an area and all the elements it owns

--- a/lanelet2/lanelet2_core/src/LaneletMap.cpp
+++ b/lanelet2/lanelet2_core/src/LaneletMap.cpp
@@ -276,16 +276,6 @@ struct UsageLookup<Area> {
       regElemLookup.insert(std::make_pair(elem, area));
     }
   }
-  void remove(Area area, ConstLineString3d ls)
-  {
-    for (auto it = ownedLookup.begin(); it != ownedLookup.end(); ){
-      if (it->second.id() == area.id() && it->first.id() == ls.id()) { 
-        ownedLookup.erase(it++); 
-      } else { 
-        ++it;          
-      }
-    }
-  }
   void remove(Area area, RegulatoryElementConstPtr regem_ptr)
   {
     for (auto it = regElemLookup.begin(); it != regElemLookup.end(); ){
@@ -306,16 +296,6 @@ struct UsageLookup<Lanelet> {
     ownedLookup.insert(std::make_pair(ll.rightBound(), ll));
     for (const auto& elem : ll.regulatoryElements()) {
       regElemLookup.insert(std::make_pair(elem, ll));
-    }
-  }
-  void remove(Lanelet ll, ConstLineString3d ls)
-  {
-    for (auto it = ownedLookup.begin(); it != ownedLookup.end(); ){
-      if (it->second.id() == ll.id() && it->first.id() == ls.id()) { 
-        ownedLookup.erase(it++); 
-      } else { 
-        ++it;          
-      }
     }
   }
   void remove(Lanelet ll, RegulatoryElementConstPtr regem_ptr)
@@ -517,23 +497,6 @@ void PrimitiveLayer<T>::remove(Id id) {
 
 template <typename T>
 template <typename SubT>
-void PrimitiveLayer<T>::remove(Id element_id, const SubT& subelement)
-{
-  // find the element with this id (the user must make sure it exists)
-  T element = elements_.find(element_id)->second;
-  // remove the subelement from usage lookup of element with this Id in this layer
-  for (auto it = tree_->usage.ownedLookup.begin(); it != tree_->usage.ownedLookup.end(); )
-  {
-    if (it->second.id() == element.id() && it->first.id() == subelement.id()) { 
-      tree_->usage.ownedLookup.erase(it++); 
-    } else { 
-      ++it;          
-    }
-  }
-}
-
-template <typename T>
-template <typename SubT>
 void PrimitiveLayer<T>::update(Id element_id, const SubT& subelement)
 {
   // find the element with this id (the user must make sure it exists)
@@ -555,11 +518,6 @@ void PrimitiveLayer<Point3d>::remove(Id id) {
   elements_.erase(id);
   tree_->erase(p);
 }
-template <>
-template <>
-void PrimitiveLayer<Point3d>::remove(Id id, const traits::ConstPrimitiveType<traits::OwnedT<PrimitiveT>>& subelement) {
-  //not used as point doesn't have any sub_element
-}
 
 template <>
 void PrimitiveLayer<RegulatoryElementPtr>::remove(Id id) {
@@ -576,12 +534,6 @@ void PrimitiveLayer<RegulatoryElementPtr>::remove(Id element_id, const traits::C
   tree_->usage.remove(element, subelement);
 }
 
-template <>
-template <>
-void PrimitiveLayer<Area>::remove(Id element_id, const traits::ConstPrimitiveType<traits::OwnedT<PrimitiveT>>& subelement) {
-  Area element = elements_.find(element_id)->second;
-  tree_->usage.remove(element, subelement);
-}
 
 template <>
 template <>
@@ -590,12 +542,6 @@ void PrimitiveLayer<Area>::remove(Id element_id, const RegulatoryElementPtr& reg
   tree_->usage.remove(element, regElem);
 }
 
-template <>
-template <>
-void PrimitiveLayer<Lanelet>::remove(Id element_id, const traits::ConstPrimitiveType<traits::OwnedT<PrimitiveT>>& subelement) {
-  Lanelet element = elements_.find(element_id)->second;
-  tree_->usage.remove(element, subelement);
-}
 template <>
 template <>
 void PrimitiveLayer<Lanelet>::remove(Id element_id, const RegulatoryElementPtr&  regElem) {

--- a/lanelet2/lanelet2_core/src/LaneletMap.cpp
+++ b/lanelet2/lanelet2_core/src/LaneletMap.cpp
@@ -497,6 +497,23 @@ void PrimitiveLayer<T>::remove(Id id) {
 
 template <typename T>
 template <typename SubT>
+void PrimitiveLayer<T>::remove(Id element_id, const SubT& subelement)	
+{
+  // find the element with this id (the user must make sure it exists)
+  T element = elements_.find(element_id)->second;
+  // remove the subelement from usage lookup of element with this Id in this layer
+  for (auto it = tree_->usage.ownedLookup.begin(); it != tree_->usage.ownedLookup.end(); )
+  {
+    if (it->second.id() == element.id() && it->first.id() == subelement.id()) { 
+      tree_->usage.ownedLookup.erase(it++); 
+    } else { 
+      ++it;
+    }          
+  }
+}
+
+template <typename T>
+template <typename SubT>
 void PrimitiveLayer<T>::update(Id element_id, const SubT& subelement)
 {
   // find the element with this id (the user must make sure it exists)
@@ -737,6 +754,7 @@ void LaneletMap::add(Lanelet lanelet) {
   }
 }
 
+
 void LaneletMap::add(Area area) {
   if (area.id() == InvalId) {
     area.setId(areaLayer.uniqueId());
@@ -797,7 +815,7 @@ void LaneletMap::remove(const RegulatoryElementPtr& regElem)
 void LaneletMap::update(Lanelet ll, const RegulatoryElementPtr& regElem)
 {
   if (!regElem) {
-    throw NullptrError("Empty regulatory element passed to add()!");
+    throw NullptrError("Empty regulatory element passed to update()!");
   }
   if (regElem->id() == InvalId) {
     regElem->setId(regulatoryElementLayer.uniqueId());

--- a/lanelet2/lanelet2_core/test/test_lanelet_map.cpp
+++ b/lanelet2/lanelet2_core/test/test_lanelet_map.cpp
@@ -26,6 +26,17 @@ TEST_F(LaneletMapTest, AddWorks) {  // NOLINT
   EXPECT_TRUE(map->laneletLayer.exists(ll2.id()));
 }
 
+TEST_F(LaneletMapTest, UpdateWorks) {  // NOLINT
+  EXPECT_FALSE(map->pointLayer.exists(p5.id()));
+  map->add(ll2);
+  EXPECT_TRUE(map->pointLayer.exists(p5.id()));
+  EXPECT_TRUE(map->laneletLayer.exists(ll2.id()));
+  EXPECT_EQ(map->laneletLayer.findUsages(regelem1).size(), 0);
+  map->update(ll2, regelem1);
+  EXPECT_EQ(map->laneletLayer.findUsages(regelem1).size(), 1);
+  
+}
+
 TEST_F(LaneletMapTest, AddAPolygon) {  // NOLINT
   poly1.setId(InvalId);
   auto map = utils::createMap({poly1});


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
This PR gives map_param_loader to publish georeference when it loads the map so that it can be compared with that of geofence when carma_wm_ctrl receives a new one.
This also adds capability to LaneletMap to "update" (or add specifically) a specific regulatory element to the existing lanelet in the map as the library did not have it before. 

This is because existing add functionality only works by adding the parent element into the map to achieve what we want. For example, to add a new regulatory element to certain lanelet, we would need to add the entire new lanelet into the map, but this won't work because that lanelet is already in the map. In other words:
- `lanelet.addRegulatoryElement(regem)` only suffices `lanelet.regulatoryElements()`
- `lanelet_map->add(regem)` only suffices `lanelet_map->regululatoryElementLayer.exists(regem)`
but `lanelet_map->laneletLayer.findUsage(regem)` relation won't be there unless we recreate the map or change existing library `add` functions. So this approach was chosen.
 
## Related Issue
These change blocks the PR [here](https://github.com/usdot-fhwa-stol/carma-platform/pull/721).
And it related to the issue [here](https://github.com/usdot-fhwa-stol/carma-platform/issues/722).
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Geofence speed limit change support requires it.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tested

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.