### PR TITLE
Fix/Id checking when updating map

### DIFF
--- a/lanelet2/lanelet2_core/include/lanelet2_core/LaneletMap.h
+++ b/lanelet2/lanelet2_core/include/lanelet2_core/LaneletMap.h
@@ -396,7 +396,7 @@ class LaneletMap : public LaneletMapLayers {
    * @brief adds the regElem to specified ll that is in the map
    * @throws NullptrError if has a regulatory element without members and 
    *         InvalidInputError if lanelet is not in the map, or it has InvalId, or
-   *         regElem with ID that is already in the map is passed in
+   *         regElem and lanelet with ID combination that is already in the map is passed in
    * If the new element that will be owned by lanelet have InvalId as Id, they
    * will be assigned a new, unique id. Otherwise you are responsible for making
    * sure that the id has not already been for a different element.

--- a/lanelet2/lanelet2_core/include/lanelet2_core/LaneletMap.h
+++ b/lanelet2/lanelet2_core/include/lanelet2_core/LaneletMap.h
@@ -395,11 +395,11 @@ class LaneletMap : public LaneletMapLayers {
   /**
    * @brief adds the regElem to specified ll that is in the map
    * @throws NullptrError if has a regulatory element without members and 
-   *         InvalidInputError if lanelet is not in the map, or it has InvalId, or
-   *         regElem and lanelet with ID combination that is already in the map is passed in
-   * If the new element that will be owned by lanelet have InvalId as Id, they
-   * will be assigned a new, unique id. Otherwise you are responsible for making
-   * sure that the id has not already been for a different element.
+   * @throws InvalidInputError if lanelet is not in the map, or it has InvalId, or
+   *         if regElem that is different from the one in the map with same ID is passed,
+   *         this regElem and lanelet combination is already there
+   * Except above, if the new element that will be owned by lanelet have InvalId as Id, they
+   * will be assigned a new, unique id.
    */
   void update(Lanelet ll, const RegulatoryElementPtr& regElem);
 

--- a/lanelet2/lanelet2_core/src/LaneletMap.cpp
+++ b/lanelet2/lanelet2_core/src/LaneletMap.cpp
@@ -816,7 +816,7 @@ void LaneletMap::update(Lanelet ll, const RegulatoryElementPtr& regElem)
   }
   
   if (regElem->id() == InvalId) {
-    regElem->setId(regulatoryElementLayer.uniqueId());
+    regElem->setId(utils::getId());
   }
   lanelet::Lanelets parent_llts = laneletLayer.findUsages(regElem);
 

--- a/lanelet2/lanelet2_core/src/LaneletMap.cpp
+++ b/lanelet2/lanelet2_core/src/LaneletMap.cpp
@@ -804,17 +804,6 @@ void LaneletMap::remove(const RegulatoryElementPtr& regElem)
 
 void LaneletMap::update(Lanelet ll, const RegulatoryElementPtr& regElem)
 {
-  if (!regElem) {
-    throw NullptrError("Empty regulatory element passed to update()!");
-  }
-  if (regElem->id() == InvalId) {
-    regElem->setId(utils::getId());
-  } else if (regulatoryElementLayer.exists(regElem->id())) {
-    throw InvalidInputError("Regulatory Element with Id that is already in the map is passed to update()!");
-  }
-  else {
-    utils::registerId(regElem->id());
-  }
   if (ll.id() == InvalId) {
     throw InvalidInputError("Lanelet element with InvalId is passed to update()!");
   }
@@ -822,6 +811,22 @@ void LaneletMap::update(Lanelet ll, const RegulatoryElementPtr& regElem)
   {
     throw InvalidInputError("Lanelet element that is not in the map is passed to update()!");
   }
+  if (!regElem) {
+    throw NullptrError("Empty regulatory element passed to update()!");
+  }
+  
+  if (regElem->id() == InvalId) {
+    regElem->setId(regulatoryElementLayer.uniqueId());
+  }
+  lanelet::Lanelets parent_llts = laneletLayer.findUsages(regElem);
+
+  if (regulatoryElementLayer.exists(regElem->id()) && std::find(parent_llts.begin(), parent_llts.end(), ll) != parent_llts.end()) {
+    throw InvalidInputError("Regulatory Element and Lanelet whose relation is already in the map is passed to update()!");
+  }
+  else {
+    utils::registerId(regElem->id());
+  }
+ 
   // Add the regem to the map in general (regulatoryElementLayer)
   add(regElem);
   // Add this regem to specified ll so that it can be queried in laneletLayer

--- a/lanelet2/lanelet2_core/src/LaneletMap.cpp
+++ b/lanelet2/lanelet2_core/src/LaneletMap.cpp
@@ -820,7 +820,10 @@ void LaneletMap::update(Lanelet ll, const RegulatoryElementPtr& regElem)
   }
   lanelet::Lanelets parent_llts = laneletLayer.findUsages(regElem);
 
-  if (regulatoryElementLayer.exists(regElem->id()) && std::find(parent_llts.begin(), parent_llts.end(), ll) != parent_llts.end()) {
+  if (regulatoryElementLayer.exists(regElem->id()) && regulatoryElementLayer.get(regElem->id()) != regElem) {
+    throw InvalidInputError("Regulatory Element passed in to update() has an Id that is being used by different regElement!");
+  }
+  else if (regulatoryElementLayer.exists(regElem->id()) && std::find(parent_llts.begin(), parent_llts.end(), ll) != parent_llts.end()) {
     throw InvalidInputError("Regulatory Element and Lanelet whose relation is already in the map is passed to update()!");
   }
   else {

--- a/lanelet2/lanelet2_core/test/test_lanelet_map.cpp
+++ b/lanelet2/lanelet2_core/test/test_lanelet_map.cpp
@@ -34,7 +34,7 @@ TEST_F(LaneletMapTest, UpdateWorks) {  // NOLINT
   EXPECT_EQ(map->laneletLayer.findUsages(regelem1).size(), 0);
   map->update(ll2, regelem1);
   EXPECT_EQ(map->laneletLayer.findUsages(regelem1).size(), 1);
-  
+  EXPECT_THROW(map->update(ll2, regelem1), InvalidInputError);
 }
 
 TEST_F(LaneletMapTest, AddAPolygon) {  // NOLINT

--- a/lanelet2/lanelet2_core/test/test_lanelet_map.cpp
+++ b/lanelet2/lanelet2_core/test/test_lanelet_map.cpp
@@ -34,7 +34,12 @@ TEST_F(LaneletMapTest, UpdateWorks) {  // NOLINT
   EXPECT_EQ(map->laneletLayer.findUsages(regelem1).size(), 0);
   map->update(ll2, regelem1);
   EXPECT_EQ(map->laneletLayer.findUsages(regelem1).size(), 1);
-  EXPECT_THROW(map->update(ll2, regelem1), InvalidInputError);
+  EXPECT_THROW(map->update(ll2, regelem1), InvalidInputError); // it is already there
+  // create a different type of regem with existing id erroneously
+  RuleParameterMap rules{
+    {"test"s, {ll1}}, {"point"s, {p1, p9}}, {"areas"s, {ar1}}, {"linestr"s, {outside}}, {"poly"s, {poly1}}};
+  auto regelem_err = std::make_shared<GenericRegulatoryElement>(regelem1->id(), rules);
+  EXPECT_THROW(map->update(ll2, regelem_err), InvalidInputError); //cant add different regem with existing id
 }
 
 TEST_F(LaneletMapTest, AddAPolygon) {  // NOLINT


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
This PR is to fix id checking bug in the latest push. 
New issue is not created due to the overall task is still being in progress and this PR is treated as part of this [PR](https://github.com/usdot-fhwa-stol/autoware.ai/pull/109)

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/usdot-fhwa-stol/carma-platform/issues/722
## Motivation and Context
update function takes in two objects lanelet, and regulatory element. As this function is supposed to only enter the relationship between these two, the id checking should actually check if the relation is already there instead of only checking whether if the individual ids are already in the map.

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Existing and new unit tests pass
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.