### PR TITLE
Remove manual center line overwrite

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -60,3 +60,7 @@ For any modified file please follow these steps to ensure proper documentation o
   - 3/11/2020
   - Kyle Rush
 
+- Removed the use of centerline overwriting as it was causing issues with map loading. It may be added back in the future if the need arises. 
+  - 7/16/2020
+  - Michael McConnell
+

--- a/common/map_file/nodes/lanelet2_map_loader/lanelet2_map_loader.cpp
+++ b/common/map_file/nodes/lanelet2_map_loader/lanelet2_map_loader.cpp
@@ -36,6 +36,9 @@
 *  - Modified lanelet2_map_loader to to parse georeference data from .osm file instead of yaml config file.
 *    - 2/3/2020
 *    - Misheel Bayartsengel
+*  - Removed call to overwrite lanelet centerlines as it was causing issues with loading maps and not providing a clear benefit
+*    - 7/16/2020
+*    - Michael McConnell
 */
 
 void printUsage()
@@ -93,7 +96,6 @@ int main(int argc, char** argv)
     return EXIT_FAILURE;
   }
 
-  lanelet::utils::overwriteLaneletsCenterline(map, false);
 
   std::string format_version, map_version;
   lanelet::io_handlers::AutowareOsmParser::parseVersions(lanelet2_filename, &format_version, &map_version);


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
This PR removes the manual centerline overwrite call from the lanelet2 map loader. This is meant to resolve the issue which causes the loader to fail if a lanelet does not contain exactly the same number of points in its left and right bounds. Unit testing in carma_wm has shown this will likely work for the integration/routing branch use case base. But we won't know for sure until integration testing is completed. 
<!--- Describe your changes in detail -->

## Related Issue
https://github.com/usdot-fhwa-stol/carma-platform/issues/755
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Keep develop build functional and resolve above issue. 
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
carma_wm unit tests pass and system can load TFHRC and Perryman maps using this change. 
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.