### PR TITLE
built with colcon

### DIFF
--- a/autoware/ros/carma_autoware_build
+++ b/autoware/ros/carma_autoware_build
@@ -68,7 +68,7 @@ cd ${autoware_src}
 if [[ -z ${autoware_build_args} ]]; then
   if [[ "${use_catkin}" = true ]]; then
     echo "Building release with catkin_make_isolated. NOTE: Formal releases should use colcon"
-    catkin_make_isolated --source . --install --install-space ./ros/install -j1 --only-pkg-with-deps "${AUTOWARE_PACKAGE_SELECTION}"
+    colcon build --base-paths .  --install-base ./ros/install  --packages-up-to "${AUTOWARE_PACKAGE_SELECTION}"
   else
     # Default Build Behavior
     ./autoware/ros/colcon_release --executor sequential --install-base ./ros/install --packages-up-to ${AUTOWARE_PACKAGE_SELECTION}
@@ -76,7 +76,7 @@ if [[ -z ${autoware_build_args} ]]; then
 else
   if [[ "${use_catkin}" = true ]]; then
     echo "Building with CMake args: ${autoware_build_args} and with catkin_make_isolated. NOTE: Formal releases should use colcon"
-    catkin_make_isolated --source . --install --install-space ./ros/install -j1 --only-pkg-with-deps "${AUTOWARE_PACKAGE_SELECTION}" --cmake-args "${autoware_build_args}"
+    colcon build --base-paths .  --install-base ./ros/install  --packages-up-to "${AUTOWARE_PACKAGE_SELECTION}" --cmake-args "${autoware_build_args}"
   else
     echo "Building with CMake args: ${autoware_build_args}"
     colcon build --cmake-args "${autoware_build_args}" --executor sequential --install-base ./ros/install --packages-up-to ${AUTOWARE_PACKAGE_SELECTION}


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
<!--- Describe your changes in detail -->
Changed docker build to allow it to be built with colcon instead of catkin_make.
## Related Issue
https://github.com/usdot-fhwa-stol/carma-platform/issues/810
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Supports migration to ROS2.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
The package has been locally tested to build, the docker image has been locally tested to build, and the docker image is locally detected.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.