### PR TITLE
Feature/add stop and wait

### DIFF
--- a/common/lanelet2_extension/CMakeLists.txt
+++ b/common/lanelet2_extension/CMakeLists.txt
@@ -135,7 +135,7 @@ if(CATKIN_ENABLE_TESTING)
   test/src/CarmaTestsMain.cpp
   test/src/RegionAccessRuleTest.cpp
   test/src/PassingControlLineTest.cpp
-  test/src/StopRule.cpp
+  test/src/StopRuleTest.cpp
   test/src/DirectionOfTravelTest.cpp
   test/src/DigitalSpeedLimitTest.cpp
   test/src/CarmaUSTrafficRulesTest.cpp

--- a/common/lanelet2_extension/CMakeLists.txt
+++ b/common/lanelet2_extension/CMakeLists.txt
@@ -77,6 +77,7 @@ add_library( lanelet2_extension_lib
   lib/visualization.cpp
   lib/CarmaUSTrafficRules.cpp
   lib/PassingControlLine.cpp
+  lib/StopRule.cpp
   lib/DigitalSpeedLimit.cpp
   lib/RegionAccessRule.cpp
   lib/DirectionOfTravel.cpp
@@ -134,6 +135,7 @@ if(CATKIN_ENABLE_TESTING)
   test/src/CarmaTestsMain.cpp
   test/src/RegionAccessRuleTest.cpp
   test/src/PassingControlLineTest.cpp
+  test/src/StopRule.cpp
   test/src/DirectionOfTravelTest.cpp
   test/src/DigitalSpeedLimitTest.cpp
   test/src/CarmaUSTrafficRulesTest.cpp

--- a/common/lanelet2_extension/docs/RegulatoryElements.md
+++ b/common/lanelet2_extension/docs/RegulatoryElements.md
@@ -206,18 +206,18 @@ To support multiple types of participants a new attribute should be added for ea
 
 ## Stop Rule
 
-Represents a virtual stop and wait line horizontally laying on the roadway. Restricts whether a given
-participant can cross the line over to go forward. General usage is as a stop line that is not represented by an actual
-physical roadway object.
+Represents a virtual stop and wait line horizontally laying on the roadway. It indicates whether a given participant 
+should stop and wait momentarily before passing the line. General usage is as a stop line that is not represented by an actual
+physical roadway object. By default, it does not apply to all objects except the ones in participant list.
 
-A StopRule is created from a list of contiguous LineString3d and participants who are allowed to cross ver to go forward.
+A StopRule is created from a list of contiguous LineString3d and participants who should stop and wait before crossing.
 The object is agnostic to the line's invertedness.
 
 ### Parameters
 
 | **Role** | **Possible Type** | **description**                |
 |-------------|--------------|----------------------------------|
-| **ref_line**    | **LineString3d**    | The linestrings which define the geometry of this control line. Must be contiguous |
+| **ref_line**    | **LineString3d**    | The linestrings which define the geometry of this stop line. Must be contiguous |
 
 ### Custom Attributes
 

--- a/common/lanelet2_extension/docs/RegulatoryElements.md
+++ b/common/lanelet2_extension/docs/RegulatoryElements.md
@@ -163,7 +163,7 @@ The left an right nature of the control line is defined by the non-inverted view
 | **Key** | **Value Type** | **description**                |
 |-------------|--------------|----------------------------------|
 | **subtype** | **passing_control_line**    | Subtype name |
-| **participant:XXX** | **from_left/from_right/from_both**    | The participant type this speed limit applies to |
+| **participant:XXX** | **from_left/from_right/from_both**    | The participant type this passing control line applies to |
 
 #### Note on participant tags
 
@@ -200,6 +200,57 @@ To support multiple types of participants a new attribute should be added for ea
   <tag k='subtype' v='passing_control_line' />
   <tag k='type' v='regulatory_element' />
   <!-- No crossing -->
+</relation>
+
+```
+
+## Stop Rule
+
+Represents a virtual stop and wait line horizontally laying on the roadway. Restricts whether a given
+participant can cross the line over to go forward. General usage is as a stop line that is not represented by an actual
+physical roadway object.
+
+A StopRule is created from a list of contiguous LineString3d and participants who are allowed to cross ver to go forward.
+The object is agnostic to the line's invertedness.
+
+### Parameters
+
+| **Role** | **Possible Type** | **description**                |
+|-------------|--------------|----------------------------------|
+| **ref_line**    | **LineString3d**    | The linestrings which define the geometry of this control line. Must be contiguous |
+
+### Custom Attributes
+
+| **Key** | **Value Type** | **description**                |
+|-------------|--------------|----------------------------------|
+| **subtype** | **stop_rule**    | Subtype name |
+| **participant:XXX** | **yes/no**    | The participant type this stop rule applies to |
+
+#### Note on participant tags
+
+To support multiple types of participants a new attribute should be added for each desired type and the value field set to "yes", or "no". There is no need to explicitly mark participants as not passable, this will be implied. The lanelet2 participant heirarchy found [here](https://github.com/fzi-forschungszentrum-informatik/Lanelet2/blob/master/lanelet2_core/doc/LaneletAndAreaTagging.md#overriding) is supported.
+
+### OSM XML Example
+
+```(xml)
+<!-- Lanelet -->
+<relation id="1349" visible="true" version="1">
+  <member type="way" ref="1347" role="left" />
+  <member type="way" ref="1348" role="right" />
+  <tag k="location" v="urban" />
+  <tag k="subtype" v="road" />
+  <tag k="type" v="lanelet" />
+
+  <!-- Stop Rule -->
+  <member type='relation' ref='45221' role='regulatory_element' />
+</relation>
+
+<!-- Regulatory Stop Rule -->
+<relation id='45221' visible='true' version='1'>
+  <member type="way" ref="1349" role="ref_line" /> <!-- Horizontal linestring representing the stop line -->
+  <tag k='subtype' v='stop_rule' />
+  <tag k='type' v='regulatory_element' />
+  <tag k='participant:vehicle' v='yes' /> <!-- Allow cars but not trucks -->
 </relation>
 
 ```

--- a/common/lanelet2_extension/docs/RegulatoryElements.md
+++ b/common/lanelet2_extension/docs/RegulatoryElements.md
@@ -245,6 +245,14 @@ To support multiple types of participants a new attribute should be added for ea
   <member type='relation' ref='45221' role='regulatory_element' />
 </relation>
 
+<!-- Virtual Linestring for Stop Rule>
+<way id="1349" visible="false" version="1">
+  <nd ref="1339" />
+  <nd ref="1342" />
+  <tag k="subtype" v="-" />
+  <tag k="type" v="virtual" />
+</way>
+
 <!-- Regulatory Stop Rule -->
 <relation id='45221' visible='true' version='1'>
   <member type="way" ref="1349" role="ref_line" /> <!-- Horizontal linestring representing the stop line -->

--- a/common/lanelet2_extension/include/lanelet2_extension/regulatory_elements/StopRule.h
+++ b/common/lanelet2_extension/include/lanelet2_extension/regulatory_elements/StopRule.h
@@ -25,7 +25,7 @@ namespace lanelet
  * participant can cross the line over to go forward. General usage is as a stop line that is not represented by an actual
  * physical roadway object.
  *
- * A StopRule is created from a list of contiguous LineString3d and participants who are allowed to cross ver to go forward.
+ * A StopRule is created from a list of contiguous LineString3d and participants who are allowed to crossover to go forward.
  * The object is agnostic to the line's invertedness.
  *
  * @ingroup RegulatoryElementPrimitives
@@ -56,7 +56,7 @@ public:
    *
    * @return True if participant can cross
    */
-  bool passable(const std::string& participant) const;
+  bool appliesTo(const std::string& participant) const;
 
   /**
    * @brief Helper function to match a given bound with a stop and wait line regulatory element then determine if it can be
@@ -70,14 +70,14 @@ public:
    * @param stopAndWaitLines The set of possible stop lines which this bound might be a part of
    * @param participant The participant being evaluated
    *
-   * @return True if the bound can be crossed or if none of the stopAndWaitLines match the
-   * provided bound
+   * @return True if the line can be crossed or if none of the stopAndWaitLines match the
+   * provided line
    */
-  static bool boundPassable(const ConstLineString3d& bound,
+  static bool appliesTo(const ConstLineString3d& bound,
                             const std::vector<std::shared_ptr<const StopRule>>& stopAndWaitLines,
                             const std::string& participant);
 
-  static bool boundPassable(const ConstLineString3d& bound,
+  static bool appliesTo(const ConstLineString3d& bound,
                             const std::vector<std::shared_ptr<StopRule>>& stopAndWaitLines,
                             const std::string& participant);
 

--- a/common/lanelet2_extension/include/lanelet2_extension/regulatory_elements/StopRule.h
+++ b/common/lanelet2_extension/include/lanelet2_extension/regulatory_elements/StopRule.h
@@ -21,11 +21,11 @@
 namespace lanelet
 {
 /**
- * @brief Represents a virtual stop and wait line horizontally laying on the roadway. Restricts whether a given
- * participant can cross the line over to go forward. General usage is as a stop line that is not represented by an actual
- * physical roadway object.
+ * @brief Represents a virtual stop and wait line horizontally laying on the roadway. It indicates whether a given participant 
+ * should stop and wait momentarily before passing the line. General usage is as a stop line that is not represented by an actual
+ * physical roadway object. By default, it does not apply to all objects except the ones in participant list.
  *
- * A StopRule is created from a list of contiguous LineString3d and participants who are allowed to crossover to go forward.
+ * A StopRule is created from a list of contiguous LineString3d and participants who should stop and wait before crossing.
  * The object is agnostic to the line's invertedness.
  *
  * @ingroup RegulatoryElementPrimitives
@@ -50,34 +50,33 @@ public:
   LineStrings3d stopAndWaitLine();
 
   /**
-   * @brief Returns true if the provided participant is allowed to cross this stop-and-wait line
+   * @brief Returns true if the provided participant should stop and wait before crossing the line
    *
    * @param participant The string classification of the participant type
    *
-   * @return True if participant can cross
+   * @return True if participant should stop and wait momentarily before the line
    */
   bool appliesTo(const std::string& participant) const;
 
   /**
-   * @brief Helper function to match a given bound with a stop and wait line regulatory element then determine if it can be
-   * passed over to go forward
+   * @brief Helper function to match a given line with a stop and wait line regulatory element then determine if it applies to
+   * the given participant
    *
    * The set of line strings contained in each of the provided stop and wait lines is searched until a sub-line is found that
-   * matches the provided lanelet or area bound. The returned value indicates if the stop and wait
-   * line can be crossed.
+   * matches the provided lanelet or area line. The returned value indicates if the rule is applied to the participant
    *
-   * @param bound The bound to try passing forward.
-   * @param stopAndWaitLines The set of possible stop lines which this bound might be a part of
+   * @param line The line to stop before
+   * @param stopAndWaitLines The set of possible stop lines which this line might be a part of
    * @param participant The participant being evaluated
    *
-   * @return True if the line can be crossed or if none of the stopAndWaitLines match the
+   * @return True if the rule is applied to the participant or if none of the stopAndWaitLines match the
    * provided line
    */
-  static bool appliesTo(const ConstLineString3d& bound,
+  static bool appliesTo(const ConstLineString3d& line,
                             const std::vector<std::shared_ptr<const StopRule>>& stopAndWaitLines,
                             const std::string& participant);
 
-  static bool appliesTo(const ConstLineString3d& bound,
+  static bool appliesTo(const ConstLineString3d& line,
                             const std::vector<std::shared_ptr<StopRule>>& stopAndWaitLines,
                             const std::string& participant);
 
@@ -87,13 +86,13 @@ public:
   explicit StopRule(const lanelet::RegulatoryElementDataPtr& data);
 
   /**
-   * @brief Static helper function that creates a passing control line data object based on the provided inputs
+   * @brief Static helper function that creates a stop line data object based on the provided inputs
    *
    * @param id The lanelet::Id of this element
    * @param stopAndWaitLine The line strings which represent this regularoty elements geometry
-   * @param participants The set of participants which can cross this line forward
+   * @param participants The set of participants which this rule applies to
    *
-   * @return RegulatoryElementData containing all the necessary information to construct a passing control line
+   * @return RegulatoryElementData containing all the necessary information to construct a stop rule
    */
   static std::unique_ptr<lanelet::RegulatoryElementData> buildData(Id id, LineStrings3d stopAndWaitLine,
                                                      std::vector<std::string> participants);

--- a/common/lanelet2_extension/include/lanelet2_extension/regulatory_elements/StopRule.h
+++ b/common/lanelet2_extension/include/lanelet2_extension/regulatory_elements/StopRule.h
@@ -21,13 +21,11 @@
 namespace lanelet
 {
 /**
- * @brief TODO: Represents a  restriction in the form of a line laying on the roadway. Restricts whether a given
- * participant can cross the line from the left or right. General usage is as lane boundaries.
+ * @brief TODO: Represents a virtual stop and wait line horizontally laying on the roadway. Restricts whether a given
+ * participant can cross the line over to go forward. General usage is as a stop line that is not represented by an actual
+ * physical roadway object.
  *
- * A PassingControlLine is created from a list of contiguous LineString3d and participants who are allowed to cross from
- * the left or right. If the control line is representing a lane boundary, each LineString3d parameter should exactly
- * match a right or left bound of an adjacent lanelet. In this fashion, a single regulatory element can represent the
- * lane change restrictions of multiple lanelets while still allowing each lanelet to be associated individually.
+ * A StopRule is created from a list of contiguous LineString3d and participants who are allowed to cross ver to go forward. 
  *
  * @ingroup RegulatoryElementPrimitives
  * @ingroup Primitives
@@ -60,22 +58,18 @@ public:
   bool passable(const std::string& participant) const;
 
   /**
-   * @brief Helper function to match a given bound with a control line regulatory element then determine if it can be
-   * passed on the right or left
+   * @brief Helper function to match a given bound with a stop and wait line regulatory element then determine if it can be
+   * passed over to go forward
    *
-   * The set of line strings contained in each of the provided control lines is searched until a sub-line is found that
-   * matches the provided lanelet or area bound. Then the inverted ness of that line is evaluated to determine whether
-   * the passableFromLeft or passableFromRight function should be called. The returned value indicates if the control
-   * line can be crossed from the direction specified by the fromLeft parameter where the left/rightness relates to the
-   * provided bound not the control line
+   * The set of line strings contained in each of the provided stop and wait lines is searched until a sub-line is found that
+   * matches the provided lanelet or area bound. The returned value indicates if the stop and wait
+   * line can be crossed.
    *
-   * @param bound The bound to try passing. The fromLeft is treated relative to this bound
-   * @param controlLines The set of possible control lines which this bound might be a part of
-   * @param fromLeft True if the user is trying to check if the bound is passable from its left. False if the user is
-   * trying to check if the bound is passable from its right
+   * @param bound The bound to try passing forward.
+   * @param stopAndWaitLines The set of possible stop lines which this bound might be a part of
    * @param participant The participant being evaluated
    *
-   * @return True if the bound can be crossed from the specified direction or if none of the controlLines match the
+   * @return True if the bound can be crossed or if none of the stopAndWaitLines match the
    * provided bound
    */
   static bool boundPassable(const ConstLineString3d& bound,

--- a/common/lanelet2_extension/include/lanelet2_extension/regulatory_elements/StopRule.h
+++ b/common/lanelet2_extension/include/lanelet2_extension/regulatory_elements/StopRule.h
@@ -60,6 +60,33 @@ public:
   bool passable(const std::string& participant) const;
 
   /**
+   * @brief Helper function to match a given bound with a control line regulatory element then determine if it can be
+   * passed on the right or left
+   *
+   * The set of line strings contained in each of the provided control lines is searched until a sub-line is found that
+   * matches the provided lanelet or area bound. Then the inverted ness of that line is evaluated to determine whether
+   * the passableFromLeft or passableFromRight function should be called. The returned value indicates if the control
+   * line can be crossed from the direction specified by the fromLeft parameter where the left/rightness relates to the
+   * provided bound not the control line
+   *
+   * @param bound The bound to try passing. The fromLeft is treated relative to this bound
+   * @param controlLines The set of possible control lines which this bound might be a part of
+   * @param fromLeft True if the user is trying to check if the bound is passable from its left. False if the user is
+   * trying to check if the bound is passable from its right
+   * @param participant The participant being evaluated
+   *
+   * @return True if the bound can be crossed from the specified direction or if none of the controlLines match the
+   * provided bound
+   */
+  static bool boundPassable(const ConstLineString3d& bound,
+                            const std::vector<std::shared_ptr<const StopRule>>& stopAndWaitLines,
+                            const std::string& participant);
+
+  static bool boundPassable(const ConstLineString3d& bound,
+                            const std::vector<std::shared_ptr<StopRule>>& stopAndWaitLines,
+                            const std::string& participant);
+
+  /**
    * @brief Constructor defined to support loading from lanelet files
    */
   explicit StopRule(const lanelet::RegulatoryElementDataPtr& data);

--- a/common/lanelet2_extension/include/lanelet2_extension/regulatory_elements/StopRule.h
+++ b/common/lanelet2_extension/include/lanelet2_extension/regulatory_elements/StopRule.h
@@ -1,0 +1,89 @@
+#pragma once
+/*
+ * Copyright (C) 2020 LEIDOS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+#include <lanelet2_core/primitives/RegulatoryElement.h>
+#include <boost/algorithm/string.hpp>
+#include <unordered_set>
+
+namespace lanelet
+{
+/**
+ * @brief TODO: Represents a  restriction in the form of a line laying on the roadway. Restricts whether a given
+ * participant can cross the line from the left or right. General usage is as lane boundaries.
+ *
+ * A PassingControlLine is created from a list of contiguous LineString3d and participants who are allowed to cross from
+ * the left or right. If the control line is representing a lane boundary, each LineString3d parameter should exactly
+ * match a right or left bound of an adjacent lanelet. In this fashion, a single regulatory element can represent the
+ * lane change restrictions of multiple lanelets while still allowing each lanelet to be associated individually.
+ *
+ * @ingroup RegulatoryElementPrimitives
+ * @ingroup Primitives
+ */
+class StopRule : public RegulatoryElement
+{
+public:
+  static constexpr char RuleName[] = "stop_rule";
+  static constexpr char Participants[] = "participants";
+  std::unordered_set<std::string> participants_;
+
+  /**
+   * @brief get the list of contigious line strings that form this stop and wait line
+   * @return the lines as a list of line strings
+   */
+  ConstLineStrings3d stopAndWaitLine() const;
+  /**
+   * @brief Same as ConstLineStrings3d stopAndWaitLine() const but without the const modifier
+   * However, the implementation of this method is expected to be const
+   */
+  LineStrings3d stopAndWaitLine();
+
+  /**
+   * @brief Returns true if the provided participant is allowed to cross this stop and wait line
+   *
+   * @param participant The string classification of the participant type
+   *
+   * @return True if participant can cross
+   */
+  bool passable(const std::string& participant) const;
+
+  /**
+   * @brief Constructor defined to support loading from lanelet files
+   */
+  explicit StopRule(const lanelet::RegulatoryElementDataPtr& data);
+
+  /**
+   * @brief Static helper function that creates a passing control line data object based on the provided inputs
+   *
+   * @param id The lanelet::Id of this element
+   * @param stopAndWaitLine The line strings which represent this regularoty elements geometry
+   * @param participants The set of participants which can cross this line forward
+   *
+   * @return RegulatoryElementData containing all the necessary information to construct a passing control line
+   */
+  static std::unique_ptr<lanelet::RegulatoryElementData> buildData(Id id, LineStrings3d stopAndWaitLine,
+                                                     std::vector<std::string> participants);
+
+protected:
+  // the following lines are required so that lanelet2 can create this object when loading a map with this regulatory
+  // element
+  friend class RegisterRegulatoryElement<StopRule>;
+};
+
+// Convenience Ptr Declarations
+using StopRulePtr = std::shared_ptr<StopRule>;
+using StopRuleConstPtr = std::shared_ptr<const StopRule>;
+
+}  // namespace lanelet

--- a/common/lanelet2_extension/include/lanelet2_extension/regulatory_elements/StopRule.h
+++ b/common/lanelet2_extension/include/lanelet2_extension/regulatory_elements/StopRule.h
@@ -50,7 +50,7 @@ public:
   LineStrings3d stopAndWaitLine();
 
   /**
-   * @brief Returns true if the provided participant is allowed to cross this stop and wait line
+   * @brief Returns true if the provided participant is allowed to cross this stop-and-wait line
    *
    * @param participant The string classification of the participant type
    *

--- a/common/lanelet2_extension/include/lanelet2_extension/regulatory_elements/StopRule.h
+++ b/common/lanelet2_extension/include/lanelet2_extension/regulatory_elements/StopRule.h
@@ -21,11 +21,12 @@
 namespace lanelet
 {
 /**
- * @brief TODO: Represents a virtual stop and wait line horizontally laying on the roadway. Restricts whether a given
+ * @brief Represents a virtual stop and wait line horizontally laying on the roadway. Restricts whether a given
  * participant can cross the line over to go forward. General usage is as a stop line that is not represented by an actual
  * physical roadway object.
  *
- * A StopRule is created from a list of contiguous LineString3d and participants who are allowed to cross ver to go forward. 
+ * A StopRule is created from a list of contiguous LineString3d and participants who are allowed to cross ver to go forward.
+ * The object is agnostic to the line's invertedness.
  *
  * @ingroup RegulatoryElementPrimitives
  * @ingroup Primitives

--- a/common/lanelet2_extension/lib/RegionAccessRule.cpp
+++ b/common/lanelet2_extension/lib/RegionAccessRule.cpp
@@ -47,7 +47,7 @@ bool RegionAccessRule::accessable(const std::string& participant) const
 RegionAccessRule::RegionAccessRule(const lanelet::RegulatoryElementDataPtr& data) : RegulatoryElement(data)
 {
   // Read participants
-  addParticipantsToSetFromMap(participants_, attributes());
+  addParticipantsToSetFromMap(participants_, attributes(), "yes");
 }
 
 std::unique_ptr<lanelet::RegulatoryElementData> RegionAccessRule::buildData(Id id, Lanelets lanelets, Areas areas,

--- a/common/lanelet2_extension/lib/StopRule.cpp
+++ b/common/lanelet2_extension/lib/StopRule.cpp
@@ -39,7 +39,7 @@ bool StopRule::appliesTo(const std::string& participant) const
   return setContainsParticipant(participants_, participant);
 }
 
-bool StopRule::appliesTo(const ConstLineString3d& bound,
+bool StopRule::appliesTo(const ConstLineString3d& line,
                                        const std::vector<std::shared_ptr<const StopRule>>& stopAndWaitLines,
                                        const std::string& participant)
 {
@@ -47,7 +47,7 @@ bool StopRule::appliesTo(const ConstLineString3d& bound,
   {
     for (auto sub_line : stop_line->stopAndWaitLine())
     {
-      if (bound.id() == sub_line.id())
+      if (line.id() == sub_line.id())
       {
         return stop_line->appliesTo(participant);
       }
@@ -56,11 +56,11 @@ bool StopRule::appliesTo(const ConstLineString3d& bound,
   return true;
 }
 
-bool StopRule::appliesTo(const ConstLineString3d& bound,
+bool StopRule::appliesTo(const ConstLineString3d& line,
                                        const std::vector<std::shared_ptr<StopRule>>& stopAndWaitLines,
                                        const std::string& participant)
 {
-  return appliesTo(bound, utils::transformSharedPtr<const StopRule>(stopAndWaitLines), participant);
+  return appliesTo(line, utils::transformSharedPtr<const StopRule>(stopAndWaitLines), participant);
 }
 
 

--- a/common/lanelet2_extension/lib/StopRule.cpp
+++ b/common/lanelet2_extension/lib/StopRule.cpp
@@ -34,12 +34,12 @@ LineStrings3d StopRule::stopAndWaitLine()
   return getParameters<LineString3d>(RoleName::RefLine);
 }
 
-bool StopRule::passable(const std::string& participant) const
+bool StopRule::appliesTo(const std::string& participant) const
 {
   return setContainsParticipant(participants_, participant);
 }
 
-bool StopRule::boundPassable(const ConstLineString3d& bound,
+bool StopRule::appliesTo(const ConstLineString3d& bound,
                                        const std::vector<std::shared_ptr<const StopRule>>& stopAndWaitLines,
                                        const std::string& participant)
 {
@@ -49,18 +49,18 @@ bool StopRule::boundPassable(const ConstLineString3d& bound,
     {
       if (bound.id() == sub_line.id())
       {
-        return stop_line->passable(participant);
+        return stop_line->appliesTo(participant);
       }
     }
   }
   return true;
 }
 
-bool StopRule::boundPassable(const ConstLineString3d& bound,
+bool StopRule::appliesTo(const ConstLineString3d& bound,
                                        const std::vector<std::shared_ptr<StopRule>>& stopAndWaitLines,
                                        const std::string& participant)
 {
-  return boundPassable(bound, utils::transformSharedPtr<const StopRule>(stopAndWaitLines), participant);
+  return appliesTo(bound, utils::transformSharedPtr<const StopRule>(stopAndWaitLines), participant);
 }
 
 

--- a/common/lanelet2_extension/lib/StopRule.cpp
+++ b/common/lanelet2_extension/lib/StopRule.cpp
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2020 LEIDOS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+#include <lanelet2_extension/regulatory_elements/StopRule.h>
+#include "RegulatoryHelpers.h"
+
+namespace lanelet
+{
+// C++ 14 vs 17 parameter export
+#if __cplusplus < 201703L
+constexpr char StopRule::RuleName[];  // instantiate string in cpp file
+constexpr char StopRule::Participants[];
+#endif
+
+ConstLineStrings3d StopRule::stopAndWaitLine() const
+{
+  return getParameters<ConstLineString3d>(RoleName::RefLine);
+}
+
+LineStrings3d StopRule::stopAndWaitLine()
+{
+  return getParameters<LineString3d>(RoleName::RefLine);
+}
+
+bool StopRule::passable(const std::string& participant) const
+{
+  return setContainsParticipant(participants_, participant);
+}
+
+StopRule::StopRule(const lanelet::RegulatoryElementDataPtr& data) : RegulatoryElement(data)
+{
+  // Read participants
+  addParticipantsToSetFromMap(participants_, attributes());
+}
+
+std::unique_ptr<lanelet::RegulatoryElementData> StopRule::buildData(Id id, LineStrings3d stopAndWaitLine,
+                                                                std::vector<std::string> participants)
+{
+  // Add parameters
+  RuleParameterMap rules;
+
+  rules[lanelet::RoleNameString::RefLine].insert(rules[lanelet::RoleNameString::RefLine].end(), stopAndWaitLine.begin(),
+                                                 stopAndWaitLine.end());
+
+  // Add attributes
+  AttributeMap attribute_map({
+      { AttributeNamesString::Type, AttributeValueString::RegulatoryElement },
+      { AttributeNamesString::Subtype, RuleName },
+  });
+
+  for (auto participant : participants)
+  {
+    const std::string key = std::string(AttributeNamesString::Participant) + ":" + participant;
+    attribute_map[key] = "yes";
+  }
+
+  return std::make_unique<RegulatoryElementData>(id, rules, attribute_map);
+}
+
+namespace
+{
+// this object actually does the registration work for us
+lanelet::RegisterRegulatoryElement<lanelet::StopRule> reg;
+}  // namespace
+
+}  // namespace lanelet

--- a/common/lanelet2_extension/test/resources/test_map.osm
+++ b/common/lanelet2_extension/test/resources/test_map.osm
@@ -21,6 +21,13 @@
     <tag k="subtype" v="solid" />
     <tag k="type" v="line_thin" />
   </way>
+  <!-- Middle/Horizontal -->
+  <way id="1350" visible="true" version="1">
+    <nd ref="1339" />
+    <nd ref="1340" />
+    <tag k="subtype" v="solid" />
+    <tag k="type" v="line_thin" />
+  </way>
 
   <!-- Lanelet -->
   <relation id="1349" visible="true" version="1">
@@ -42,6 +49,8 @@
     <member type='relation' ref='45221' role='regulatory_element' />
     <!-- Control Line Right -->
     <member type='relation' ref='45222' role='regulatory_element' />
+    <!-- Stop Rule -->
+    <member type='relation' ref='45223' role='regulatory_element' />
   </relation>
 
   <!-- Regulatory speed limit -->
@@ -82,6 +91,14 @@
   <relation id='45222' visible='true' version='1'>
     <member type="way" ref="1348" role="ref_line" />
     <tag k='subtype' v='passing_control_line' />
+    <tag k='type' v='regulatory_element' />
+    <!-- No crossing -->
+  </relation>
+
+  <!-- Regulatory Stop Rule -->
+  <relation id='45223' visible='true' version='1'>
+    <member type="way" ref="1350" role="ref_line" />
+    <tag k='subtype' v='stop_rule' />
     <tag k='type' v='regulatory_element' />
     <!-- No crossing -->
   </relation>

--- a/common/lanelet2_extension/test/resources/test_map.osm
+++ b/common/lanelet2_extension/test/resources/test_map.osm
@@ -22,11 +22,11 @@
     <tag k="type" v="line_thin" />
   </way>
   <!-- Middle/Horizontal -->
-  <way id="1350" visible="true" version="1">
+  <way id="1350" visible="false" version="1">
     <nd ref="1339" />
-    <nd ref="1340" />
-    <tag k="subtype" v="solid" />
-    <tag k="type" v="line_thin" />
+    <nd ref="1342" />
+    <tag k="subtype" v="-" />
+    <tag k="type" v="virtual" />
   </way>
 
   <!-- Lanelet -->

--- a/common/lanelet2_extension/test/src/MapLoadingTest.cpp
+++ b/common/lanelet2_extension/test/src/MapLoadingTest.cpp
@@ -110,7 +110,7 @@ TEST(MapLoadingTest, mapLoadingTest)
   ASSERT_EQ(1, stop_lines.size());
 
   ASSERT_FALSE(
-      StopRule::appliesTo(map->lineStringLayer.get(1350), stop_lines, lanelet::Participants::VehicleCar)); //"no": (not passable by default) is implied in the map
+      StopRule::appliesTo(map->lineStringLayer.get(1350), stop_lines, lanelet::Participants::VehicleCar)); //"no": (not applied to this vehicle by default) is implied in the map
 }
 
 }  // namespace lanelet

--- a/common/lanelet2_extension/test/src/MapLoadingTest.cpp
+++ b/common/lanelet2_extension/test/src/MapLoadingTest.cpp
@@ -25,6 +25,7 @@
 #include <lanelet2_extension/regulatory_elements/DigitalSpeedLimit.h>
 #include <lanelet2_extension/regulatory_elements/DirectionOfTravel.h>
 #include <lanelet2_extension/regulatory_elements/PassingControlLine.h>
+#include <lanelet2_extension/regulatory_elements/StopRule.h>
 
 #include <lanelet2_core/geometry/LineString.h>
 #include <lanelet2_traffic_rules/TrafficRulesFactory.h>
@@ -104,6 +105,12 @@ TEST(MapLoadingTest, mapLoadingTest)
   ASSERT_EQ(1, dot.size());
   ASSERT_TRUE(rar[0]->accessable("vehicle:car"));
   ASSERT_FALSE(rar[0]->accessable("vehicle"));
+
+  auto stop_lines = (*ll_1).regulatoryElementsAs<StopRule>();
+  ASSERT_EQ(1, stop_lines.size());
+
+  ASSERT_FALSE(
+      StopRule::boundPassable(map->lineStringLayer.get(1350), stop_lines, lanelet::Participants::VehicleCar)); //"no": (not passable by default) is implied in the map
 }
 
 }  // namespace lanelet

--- a/common/lanelet2_extension/test/src/MapLoadingTest.cpp
+++ b/common/lanelet2_extension/test/src/MapLoadingTest.cpp
@@ -110,7 +110,7 @@ TEST(MapLoadingTest, mapLoadingTest)
   ASSERT_EQ(1, stop_lines.size());
 
   ASSERT_FALSE(
-      StopRule::boundPassable(map->lineStringLayer.get(1350), stop_lines, lanelet::Participants::VehicleCar)); //"no": (not passable by default) is implied in the map
+      StopRule::appliesTo(map->lineStringLayer.get(1350), stop_lines, lanelet::Participants::VehicleCar)); //"no": (not passable by default) is implied in the map
 }
 
 }  // namespace lanelet

--- a/common/lanelet2_extension/test/src/StopRuleTest.cpp
+++ b/common/lanelet2_extension/test/src/StopRuleTest.cpp
@@ -57,13 +57,13 @@ TEST(StopRuleTest, StopRule)
   ASSERT_EQ(1, nonconstLine.size());
   ASSERT_EQ(nonconstLine.front().id(), stop_line_id);
 
-  ASSERT_TRUE(stop_and_wait->passable(lanelet::Participants::VehicleBus));
-  ASSERT_FALSE(stop_and_wait->passable(lanelet::Participants::Bicycle));
+  ASSERT_TRUE(stop_and_wait->appliesTo(lanelet::Participants::VehicleBus));
+  ASSERT_FALSE(stop_and_wait->appliesTo(lanelet::Participants::Bicycle));
 
   
-  ASSERT_TRUE(StopRule::boundPassable(virtual_stop_line, ll_1.regulatoryElementsAs<StopRule>(),
+  ASSERT_TRUE(StopRule::appliesTo(virtual_stop_line, ll_1.regulatoryElementsAs<StopRule>(),
                                                  lanelet::Participants::Vehicle));
-  ASSERT_FALSE(StopRule::boundPassable(virtual_stop_line, ll_1.regulatoryElementsAs<StopRule>(),
+  ASSERT_FALSE(StopRule::appliesTo(virtual_stop_line, ll_1.regulatoryElementsAs<StopRule>(),
                                                 lanelet::Participants::Bicycle));
 }
 

--- a/common/lanelet2_extension/test/src/StopRuleTest.cpp
+++ b/common/lanelet2_extension/test/src/StopRuleTest.cpp
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2019 LEIDOS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+#include <gmock/gmock.h>
+#include <iostream>
+#include <lanelet2_extension/regulatory_elements/StopRule.h>
+#include <lanelet2_core/geometry/LineString.h>
+#include <lanelet2_traffic_rules/TrafficRulesFactory.h>
+#include <lanelet2_core/Attribute.h>
+#include "TestHelpers.h"
+
+using ::testing::_;
+using ::testing::A;
+using ::testing::DoAll;
+using ::testing::InSequence;
+using ::testing::Return;
+using ::testing::ReturnArg;
+
+namespace lanelet
+{
+
+TEST(StopRuleTest, StopRule)
+{
+  auto pl1 = carma_wm::getPoint(0, 0, 0);
+  auto pl2 = carma_wm::getPoint(0, 1, 0);
+  auto pl3 = carma_wm::getPoint(0, 2, 0);
+  auto pr1 = carma_wm::getPoint(1, 0, 0);
+  auto pr2 = carma_wm::getPoint(1, 1, 0);
+  auto pr3 = carma_wm::getPoint(1, 2, 0);
+
+  std::vector<lanelet::Point3d> left_1 = { pl1, pl2, pl3 };
+  std::vector<lanelet::Point3d> right_1 = { pr1, pr2, pr3 };
+  auto ll_1 = carma_wm::getLanelet(left_1, right_1, lanelet::AttributeValueString::SolidDashed,
+                                   lanelet::AttributeValueString::Dashed);
+  lanelet::Id stop_line_id = utils::getId();
+  LineString3d virtual_stop_line(stop_line_id, {pl2, pr2});
+  // Creat passing control line for solid dashed line
+  std::shared_ptr<StopRule> stop_and_wait(new StopRule(StopRule::buildData(
+      lanelet::utils::getId(), { virtual_stop_line }, { lanelet::Participants::Vehicle })));
+
+  ll_1.addRegulatoryElement(stop_and_wait);
+
+  LineStrings3d nonconstLine = stop_and_wait->stopAndWaitLine();
+  ASSERT_EQ(1, nonconstLine.size());
+  ASSERT_EQ(nonconstLine.front().id(), stop_line_id);
+
+  ASSERT_TRUE(stop_and_wait->passable(lanelet::Participants::VehicleBus));
+  ASSERT_TRUE(stop_and_wait->passable(lanelet::Participants::Bicycle));
+
+  /*
+  ASSERT_FALSE(StopRule::boundPassable(ll_1.leftBound(), ll_1.regulatoryElementsAs<StopRule>(),
+                                                 true, lanelet::Participants::Vehicle));
+  ASSERT_TRUE(StopRule::boundPassable(ll_1.leftBound(), ll_1.regulatoryElementsAs<StopRule>(),
+                                                false, lanelet::Participants::Vehicle));
+
+  // Check inverted bound
+  ASSERT_TRUE(StopRule::boundPassable(ll_1.leftBound().invert(),
+                                                ll_1.regulatoryElementsAs<StopRule>(), true,
+                                                lanelet::Participants::Vehicle));
+  ASSERT_FALSE(StopRule::boundPassable(ll_1.leftBound().invert(),
+                                                 ll_1.regulatoryElementsAs<StopRule>(), false,
+                                                 lanelet::Participants::Vehicle));
+  */
+
+}
+
+}  // namespace lanelet

--- a/common/lanelet2_extension/test/src/StopRuleTest.cpp
+++ b/common/lanelet2_extension/test/src/StopRuleTest.cpp
@@ -58,23 +58,13 @@ TEST(StopRuleTest, StopRule)
   ASSERT_EQ(nonconstLine.front().id(), stop_line_id);
 
   ASSERT_TRUE(stop_and_wait->passable(lanelet::Participants::VehicleBus));
-  ASSERT_TRUE(stop_and_wait->passable(lanelet::Participants::Bicycle));
+  ASSERT_FALSE(stop_and_wait->passable(lanelet::Participants::Bicycle));
 
-  /*
-  ASSERT_FALSE(StopRule::boundPassable(ll_1.leftBound(), ll_1.regulatoryElementsAs<StopRule>(),
-                                                 true, lanelet::Participants::Vehicle));
-  ASSERT_TRUE(StopRule::boundPassable(ll_1.leftBound(), ll_1.regulatoryElementsAs<StopRule>(),
-                                                false, lanelet::Participants::Vehicle));
-
-  // Check inverted bound
-  ASSERT_TRUE(StopRule::boundPassable(ll_1.leftBound().invert(),
-                                                ll_1.regulatoryElementsAs<StopRule>(), true,
-                                                lanelet::Participants::Vehicle));
-  ASSERT_FALSE(StopRule::boundPassable(ll_1.leftBound().invert(),
-                                                 ll_1.regulatoryElementsAs<StopRule>(), false,
+  
+  ASSERT_TRUE(StopRule::boundPassable(virtual_stop_line, ll_1.regulatoryElementsAs<StopRule>(),
                                                  lanelet::Participants::Vehicle));
-  */
-
+  ASSERT_FALSE(StopRule::boundPassable(virtual_stop_line, ll_1.regulatoryElementsAs<StopRule>(),
+                                                lanelet::Participants::Bicycle));
 }
 
 }  // namespace lanelet


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
Port Drayage Plugin needs a new regulatory element that should convey the same information as a stop sign + stop bar but should not reference any physical object.

<!--- Describe your changes in detail -->

## Related Issue
https://github.com/usdot-fhwa-stol/carma-platform/issues/855
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
See above.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Unit tests pass and regression tested locally
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have added any new packages to the sonar-scanner.properties file | No Need
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.