### PR TITLE
Feature/speed limiter

### DIFF
--- a/.sonarqube/sonar-scanner.properties
+++ b/.sonarqube/sonar-scanner.properties
@@ -35,7 +35,8 @@ sonar.modules= map_tools, \
   points_preprocessor, \
   waypoint_maker, \
   as, \
-  waypoint_planner
+  waypoint_planner, \
+  twist_filter
 
 map_tools.sonar.projectBaseDir           = /opt/carma/autoware.ai/utilities/map_tools
 lidar_localizer.sonar.projectBaseDir     = /opt/carma/autoware.ai/core_perception/lidar_localizer
@@ -46,6 +47,7 @@ points_preprocessor.sonar.projectBaseDir = /opt/carma/autoware.ai/core_perceptio
 waypoint_maker.sonar.projectBaseDir      = /opt/carma/autoware.ai/core_planning/waypoint_maker
 as.sonar.projectBaseDir                  = /opt/carma/autoware.ai/drivers/as
 waypoint_planner.sonar.projectBaseDir    = /opt/carma/autoware.ai/core_planning/waypoint_planner
+twist_filter.sonar.projectBaseDir    = /opt/carma/autoware.ai/core_planning/twist_filter
 
 # C++ Package differences
 # Sources
@@ -58,6 +60,7 @@ points_preprocessor.sonar.sources = nodes
 waypoint_maker.sonar.sources      = nodes
 as.sonar.sources                  = nodes
 waypoint_planner.sonar.sources    = src
+twist_filter.sonar.sources    = src
 
 # Tests
 # Note: For C++ setting this field does not cause test analysis to occur. It only allows the test source code to be evaluated.
@@ -71,3 +74,4 @@ waypoint_planner.sonar.sources    = src
 #waypoint_maker.sonar.tests      = test
 #as.sonar.tests                  = test
 #waypoint_planner.sonar.tests    = test
+twist_filter.sonar.tests    = test

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -64,3 +64,8 @@ For any modified file please follow these steps to ensure proper documentation o
   - 7/16/2020
   - Michael McConnell
 
+- Added support for longitudinal velocity limiting in twist_filter, refactored
+  node to support unit testing for added feature.
+  - 9/13/2020
+  - Kyle Rush
+

--- a/core_planning/twist_filter/CMakeLists.txt
+++ b/core_planning/twist_filter/CMakeLists.txt
@@ -1,3 +1,9 @@
+# Modifications:
+# - Add unit testing for CARMA velocity limit code and adjust CMake to account
+#   for refactoring required in that process
+#    - Kyle Rush
+#    - 9/13/2020
+
 cmake_minimum_required(VERSION 2.8.3)
 project(twist_filter)
 
@@ -33,6 +39,7 @@ SET(CMAKE_CXX_FLAGS "-O2 -g -Wall ${CMAKE_CXX_FLAGS}")
 
 include_directories(
   ${catkin_INCLUDE_DIRS}
+  include
 )
 
 add_executable(twist_filter src/twist_filter.cpp)
@@ -54,4 +61,7 @@ install(
 if (CATKIN_ENABLE_TESTING)
   find_package(rostest REQUIRED)
   roslint_add_test()
+  catkin_add_gtest(${PROJECT_NAME}-test 
+    test/test_twist_filter.cpp
+    src/twist_filter.cpp)
 endif ()

--- a/core_planning/twist_filter/CMakeLists.txt
+++ b/core_planning/twist_filter/CMakeLists.txt
@@ -42,7 +42,9 @@ include_directories(
   include
 )
 
-add_executable(twist_filter src/twist_filter.cpp)
+add_executable(twist_filter 
+  src/twist_filter_node.cpp
+  src/twist_filter.cpp)
 target_link_libraries(twist_filter ${catkin_LIBRARIES})
 add_dependencies(twist_filter ${catkin_EXPORTED_TARGETS})
 

--- a/core_planning/twist_filter/CMakeLists.txt
+++ b/core_planning/twist_filter/CMakeLists.txt
@@ -64,4 +64,5 @@ if (CATKIN_ENABLE_TESTING)
   catkin_add_gtest(${PROJECT_NAME}-test 
     test/test_twist_filter.cpp
     src/twist_filter.cpp)
+  target_link_libraries(${PROJECT_NAME}-test ${catkin_LIBRARIES})
 endif ()

--- a/core_planning/twist_filter/CMakeLists.txt
+++ b/core_planning/twist_filter/CMakeLists.txt
@@ -44,6 +44,7 @@ include_directories(
 
 add_executable(twist_filter 
   src/twist_filter_node.cpp
+  src/velocity_limit.cpp
   src/twist_filter.cpp)
 target_link_libraries(twist_filter ${catkin_LIBRARIES})
 add_dependencies(twist_filter ${catkin_EXPORTED_TARGETS})
@@ -65,6 +66,6 @@ if (CATKIN_ENABLE_TESTING)
   roslint_add_test()
   catkin_add_gtest(${PROJECT_NAME}-test 
     test/test_twist_filter.cpp
-    src/twist_filter.cpp)
+    src/velocity_limit.cpp)
   target_link_libraries(${PROJECT_NAME}-test ${catkin_LIBRARIES})
 endif ()

--- a/core_planning/twist_filter/include/twist_filter.hpp
+++ b/core_planning/twist_filter/include/twist_filter.hpp
@@ -1,0 +1,106 @@
+// TODO: Figure out copyright notice?
+
+#include <iostream>
+#include <boost/optional.hpp>
+#include <ros/ros.h>
+#include <std_msgs/Float32.h>
+#include <geometry_msgs/TwistStamped.h>
+#include <autoware_msgs/ControlCommandStamped.h>
+#include <autoware_config_msgs/ConfigTwistFilter.h>
+#include <autoware_health_checker/health_checker/health_checker.h>
+#include <gtest/gtest_prod.h>
+
+namespace twist_filter
+{
+// const values
+constexpr double MIN_LINEAR_X = 1e-3;
+constexpr double MIN_LENGTH = 1e-3;
+constexpr double MIN_DURATION = 1e-3;
+constexpr double MAX_LONGITUDINAL_VELOCITY_HARDCODED_LIMIT_M_S = 35.7632;
+
+struct StampedValue
+{
+  ros::Time time;
+  double dt;
+  double val;
+  StampedValue() : time(0.0), dt(0.0), val(0.0) {}
+  void reset()
+  {
+    time = ros::Time(0.0);
+    val = 0.0;
+  }
+};
+
+class TwistFilter
+{
+public:
+  TwistFilter();
+private:
+  ros::NodeHandle nh_;
+  ros::NodeHandle private_nh_;
+
+  // publishers
+  ros::Publisher twist_pub_, ctrl_pub_;
+  ros::Publisher twist_lacc_limit_debug_pub_, twist_ljerk_limit_debug_pub_;
+  ros::Publisher ctrl_lacc_limit_debug_pub_, ctrl_ljerk_limit_debug_pub_;
+  ros::Publisher twist_lacc_result_pub_, twist_ljerk_result_pub_;
+  ros::Publisher ctrl_lacc_result_pub_, ctrl_ljerk_result_pub_;
+
+  // subscribers
+  ros::Subscriber twist_sub_, ctrl_sub_, config_sub_;
+
+  // ros params
+  double wheel_base_;
+  double longitudinal_velocity_limit_;
+  double lateral_accel_limit_;
+  double lateral_jerk_limit_;
+  double lowpass_gain_linear_x_;
+  double lowpass_gain_angular_z_;
+  double lowpass_gain_steering_angle_;
+
+  // dataset
+  StampedValue az_prev_;
+  StampedValue sa_prev_;
+
+  // health_checker
+  autoware_health_checker::HealthChecker health_checker_;
+
+  boost::optional<double>
+    calcLaccWithAngularZ(const double& lv, const double& az) const;
+  boost::optional<double>
+    calcLjerkWithAngularZ(const double& lv, const double& az) const;
+  boost::optional<double>
+    calcLaccWithSteeringAngle(const double& lv, const double& sa) const;
+  boost::optional<double>
+    calcLjerkWithSteeringAngle(const double& lv, const double& sa) const;
+  void publishLateralResultsWithTwist(
+    const geometry_msgs::TwistStamped& msg) const;
+  void publishLateralResultsWithCtrl(
+    const autoware_msgs::ControlCommandStamped& msg) const;
+  void checkTwist(const geometry_msgs::TwistStamped& msg);
+  void checkCtrl(const autoware_msgs::ControlCommandStamped& msg);
+  geometry_msgs::TwistStamped
+    lateralLimitTwist(const geometry_msgs::TwistStamped& msg);
+  geometry_msgs::TwistStamped
+    longitudinalLimitTwist(const geometry_msgs::TwistStamped& msg);
+  geometry_msgs::TwistStamped
+    smoothTwist(const geometry_msgs::TwistStamped& msg);
+  autoware_msgs::ControlCommandStamped
+    longitudinalLimitCtrl(const autoware_msgs::ControlCommandStamped& msg);
+  autoware_msgs::ControlCommandStamped
+    lateralLimitCtrl(const autoware_msgs::ControlCommandStamped& msg);
+  autoware_msgs::ControlCommandStamped
+    smoothCtrl(const autoware_msgs::ControlCommandStamped& msg);
+  void updatePrevTwist(const geometry_msgs::TwistStamped& msg);
+  void updatePrevCtrl(const autoware_msgs::ControlCommandStamped& msg);
+  void configCallback(
+    const autoware_config_msgs::ConfigTwistFilterConstPtr& config);
+  void TwistCmdCallback(const geometry_msgs::TwistStampedConstPtr& msg);
+  void CtrlCmdCallback(const autoware_msgs::ControlCommandStampedConstPtr& msg);
+  
+  // Friend test setup for unit testing of private methods
+  FRIEND_TEST(TwistFilterTest, test_longitudinal_twist_filter);
+  FRIEND_TEST(TwistFilterTest, test_longitudinal_ctrl_filter);
+};
+
+}

--- a/core_planning/twist_filter/include/twist_filter.hpp
+++ b/core_planning/twist_filter/include/twist_filter.hpp
@@ -1,4 +1,26 @@
-// TODO: Figure out copyright notice?
+/*
+ * Copyright 2015-2019 Autoware Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Modifications:
+ * - Added limiting for longitudinal velocity per CARMA specifications. Refactored
+ *   namespacing and header as needed to support unit testing.
+ *   - Kyle Rush 
+ *   - 9/11/2020
+ */
 
 #include <iostream>
 #include <boost/optional.hpp>

--- a/core_planning/twist_filter/include/twist_filter.hpp
+++ b/core_planning/twist_filter/include/twist_filter.hpp
@@ -1,3 +1,4 @@
+#pragma once
 /*
  * Copyright 2015-2019 Autoware Foundation. All rights reserved.
  *
@@ -38,7 +39,6 @@ namespace twist_filter
 constexpr double MIN_LINEAR_X = 1e-3;
 constexpr double MIN_LENGTH = 1e-3;
 constexpr double MIN_DURATION = 1e-3;
-constexpr double MAX_LONGITUDINAL_VELOCITY_HARDCODED_LIMIT_M_S = 35.7632;
 
 struct StampedValue
 {
@@ -104,11 +104,7 @@ private:
   geometry_msgs::TwistStamped
     lateralLimitTwist(const geometry_msgs::TwistStamped& msg);
   geometry_msgs::TwistStamped
-    longitudinalLimitTwist(const geometry_msgs::TwistStamped& msg);
-  geometry_msgs::TwistStamped
     smoothTwist(const geometry_msgs::TwistStamped& msg);
-  autoware_msgs::ControlCommandStamped
-    longitudinalLimitCtrl(const autoware_msgs::ControlCommandStamped& msg);
   autoware_msgs::ControlCommandStamped
     lateralLimitCtrl(const autoware_msgs::ControlCommandStamped& msg);
   autoware_msgs::ControlCommandStamped

--- a/core_planning/twist_filter/include/twist_filter.hpp
+++ b/core_planning/twist_filter/include/twist_filter.hpp
@@ -34,10 +34,10 @@ struct StampedValue
 class TwistFilter
 {
 public:
-  TwistFilter();
+  TwistFilter(ros::NodeHandle* nh, ros::NodeHandle* private_nh);
 private:
-  ros::NodeHandle nh_;
-  ros::NodeHandle private_nh_;
+  ros::NodeHandle* nh_ = nullptr;
+  ros::NodeHandle* private_nh_ = nullptr;
 
   // publishers
   ros::Publisher twist_pub_, ctrl_pub_;

--- a/core_planning/twist_filter/include/velocity_limit.hpp
+++ b/core_planning/twist_filter/include/velocity_limit.hpp
@@ -1,0 +1,47 @@
+#pragma once
+/*
+ * Copyright (C) 2018-2020 LEIDOS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+#include <ros/ros.h>
+#include <geometry_msgs/TwistStamped.h>
+#include <autoware_msgs/ControlCommandStamped.h>
+
+namespace twist_filter {
+
+constexpr double MAX_LONGITUDINAL_VELOCITY_HARDCODED_LIMIT_M_S = 35.7632;
+
+/**
+ * Limit the longitudinal speed found in the input ControlCommandStamped
+ * 
+ * \param msg The message to be evaluated
+ * \param limit The configurable limit to use in addition to the hardcoded limit
+ * \return A copy of the message with the longitudinal speed limited 
+ * based on params or hardcoded limit
+ */
+autoware_msgs::ControlCommandStamped
+    longitudinalLimitCtrl(const autoware_msgs::ControlCommandStamped& msg, const double limit);
+
+/**
+ * Limit the longitudinal speed found in the input TwistStamped
+ * 
+ * \param msg The message to be evaluated
+ * \param limit The configurable limit to use in addition to the hardcoded limit
+ * \return A copy of the message with the longitudinal speed limited 
+ * based on params or hardcoded limit
+ */
+geometry_msgs::TwistStamped
+    longitudinalLimitTwist(const geometry_msgs::TwistStamped& msg, const double limit);
+}

--- a/core_planning/twist_filter/launch/twist_filter.launch
+++ b/core_planning/twist_filter/launch/twist_filter.launch
@@ -10,6 +10,7 @@
 
   <!-- rosrun waypoint_follower twist_filter -->
   <node pkg="twist_filter" type="twist_filter" name="twist_filter" output="log">
+    <param name="longitudinal_velocity_limit" value="$(arg longitudinal_velocity_limit)" />
     <param name="lateral_accel_limit" value="$(arg lateral_accel_limit)" />
     <param name="lateral_jerk_limit" value="$(arg lateral_jerk_limit)" />
     <param name="lowpass_gain_linear_x" value="$(arg lowpass_gain_linear_x)" />

--- a/core_planning/twist_filter/src/twist_filter.cpp
+++ b/core_planning/twist_filter/src/twist_filter.cpp
@@ -477,12 +477,3 @@ TwistFilter::TwistFilter(ros::NodeHandle *nh, ros::NodeHandle *private_nh):
 
 }  // namespace
 
-int main(int argc, char** argv)
-{
-  ros::init(argc, argv, "twist_filter");
-  ros::NodeHandle nh;
-  ros::NodeHandle pnh("~");
-  twist_filter::TwistFilter twist_filter(&nh, &pnh);
-  ros::spin();
-  return 0;
-}

--- a/core_planning/twist_filter/src/twist_filter_node.cpp
+++ b/core_planning/twist_filter/src/twist_filter_node.cpp
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2015-2019 Autoware Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Modifications:
+ * - Added limiting for longitudinal velocity per CARMA specifications. Refactored
+ *   namespacing and header as needed to support unit testing.
+ *   - Kyle Rush 
+ *   - 9/11/2020
+ */
+
+#include <ros/ros.h>
+#include "twist_filter.hpp"
+
+int main(int argc, char** argv)
+{
+  ros::init(argc, argv, "twist_filter");
+  ros::NodeHandle nh;
+  ros::NodeHandle pnh("~");
+  twist_filter::TwistFilter twist_filter(&nh, &pnh);
+  ros::spin();
+  return 0;
+}

--- a/core_planning/twist_filter/src/velocity_limit.cpp
+++ b/core_planning/twist_filter/src/velocity_limit.cpp
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2018-2020 LEIDOS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+#include "velocity_limit.hpp"
+
+namespace twist_filter {
+geometry_msgs::TwistStamped
+  longitudinalLimitTwist(const geometry_msgs::TwistStamped& msg, const double limit)
+{
+  geometry_msgs::TwistStamped ts;
+  ts = msg;
+
+  auto orig_longitudinal_velocity = msg.twist.linear.x;
+  auto longitudinal_velocity = msg.twist.linear.x;
+
+  if (longitudinal_velocity > limit) {
+    ROS_WARN_STREAM("Longitudinal velocity of " << 
+      orig_longitudinal_velocity << 
+      " exceeds configured limit of " <<
+      limit);
+    longitudinal_velocity = limit;
+  }
+  if (longitudinal_velocity > MAX_LONGITUDINAL_VELOCITY_HARDCODED_LIMIT_M_S) {
+    ROS_ERROR_STREAM("Longitudinal velocity of " << 
+      orig_longitudinal_velocity << 
+      " exceeds hard-coded limit of " <<
+      MAX_LONGITUDINAL_VELOCITY_HARDCODED_LIMIT_M_S);
+    longitudinal_velocity = MAX_LONGITUDINAL_VELOCITY_HARDCODED_LIMIT_M_S;
+  }
+  
+  ts.twist.linear.x = longitudinal_velocity;
+  return ts;
+}
+
+autoware_msgs::ControlCommandStamped
+  longitudinalLimitCtrl(const autoware_msgs::ControlCommandStamped& msg, const double limit)
+{
+  autoware_msgs::ControlCommandStamped ccs;
+  ccs = msg;
+
+  auto orig_longitudinal_velocity = msg.cmd.linear_velocity;
+  auto longitudinal_velocity = msg.cmd.linear_velocity;
+
+  if (longitudinal_velocity > limit) {
+    ROS_WARN_STREAM("Longitudinal velocity of " << 
+      orig_longitudinal_velocity << 
+      " exceeds configured limit of " <<
+      limit);
+    longitudinal_velocity = limit;
+  }
+  if (longitudinal_velocity > MAX_LONGITUDINAL_VELOCITY_HARDCODED_LIMIT_M_S) {
+    ROS_ERROR_STREAM("Longitudinal velocity of " << 
+      orig_longitudinal_velocity << 
+      " exceeds hard-coded limit of " <<
+      MAX_LONGITUDINAL_VELOCITY_HARDCODED_LIMIT_M_S);
+    longitudinal_velocity = MAX_LONGITUDINAL_VELOCITY_HARDCODED_LIMIT_M_S;
+  }
+  
+  ccs.cmd.linear_velocity = longitudinal_velocity;
+  return ccs;
+}
+}

--- a/core_planning/twist_filter/test/test_twist_filter.cpp
+++ b/core_planning/twist_filter/test/test_twist_filter.cpp
@@ -7,31 +7,31 @@
 namespace twist_filter
 {
     TEST(TwistFilterTest, test_longitudinal_twist_filter) {
-        twist_filter::TwistFilter tf;
+        twist_filter::TwistFilter tf(nullptr, nullptr);
 
         tf.longitudinal_velocity_limit_ = 5.0;
 
         geometry_msgs::TwistStamped twist;
-        twist.linear.x = 7.0;
+        twist.twist.linear.x = 7.0;
 
-        geomentry_msgs::TwistStamped out = tf.longitudinalLimitTwist(twist);
+        geometry_msgs::TwistStamped out = tf.longitudinalLimitTwist(twist);
 
-        ASSERT_DOUBLE_EQ(5.0, out.linear.x);
+        ASSERT_DOUBLE_EQ(5.0, out.twist.linear.x);
 
-        twist_filter::TwistFilter tf2;
+        twist_filter::TwistFilter tf2(nullptr, nullptr);
 
         tf2.longitudinal_velocity_limit_ = 100.0;
 
         geometry_msgs::TwistStamped twist2;
-        twist2.linear.x = 50.0;
+        twist2.twist.linear.x = 50.0;
 
-        geomentry_msgs::TwistStamped out2 = tf2.longitudinalLimitTwist(twist2);
+        geometry_msgs::TwistStamped out2 = tf2.longitudinalLimitTwist(twist2);
 
-        ASSERT_LT(36.0, out2.linear.x);
+        ASSERT_LT(36.0, out2.twist.linear.x);
     }
 
     TEST(TwistFilterTest, test_longitudinal_ctrl_filter) {
-        twist_filter::TwistFilter tf;
+        twist_filter::TwistFilter tf(nullptr, nullptr);
 
         tf.longitudinal_velocity_limit_ = 5.0;
 
@@ -42,7 +42,7 @@ namespace twist_filter
 
         ASSERT_DOUBLE_EQ(5.0, out.cmd.linear_velocity);
 
-        twist_filter::TwistFilter tf2;
+        twist_filter::TwistFilter tf2(nullptr, nullptr);
 
         tf2.longitudinal_velocity_limit_ = 100.0;
 

--- a/core_planning/twist_filter/test/test_twist_filter.cpp
+++ b/core_planning/twist_filter/test/test_twist_filter.cpp
@@ -1,0 +1,57 @@
+// TODO: Add CARMA copyright notice
+
+#include <ros/ros.h>
+#include <gtest/gtest.h>
+#include "twist_filter.hpp"
+
+namespace twist_filter
+{
+    TEST(TwistFilterTest, test_longitudinal_twist_filter) {
+        twist_filter::TwistFilter tf;
+
+        tf.longitudinal_velocity_limit_ = 5.0;
+
+        geometry_msgs::TwistStamped twist;
+        twist.linear.x = 7.0;
+
+        geomentry_msgs::TwistStamped out = tf.longitudinalLimitTwist(twist);
+
+        ASSERT_DOUBLE_EQ(5.0, out.linear.x);
+
+        twist_filter::TwistFilter tf2;
+
+        tf2.longitudinal_velocity_limit_ = 100.0;
+
+        geometry_msgs::TwistStamped twist2;
+        twist2.linear.x = 50.0;
+
+        geomentry_msgs::TwistStamped out2 = tf2.longitudinalLimitTwist(twist2);
+
+        ASSERT_LT(36.0, out2.linear.x);
+    }
+
+    TEST(TwistFilterTest, test_longitudinal_ctrl_filter) {
+        twist_filter::TwistFilter tf;
+
+        tf.longitudinal_velocity_limit_ = 5.0;
+
+        autoware_msgs::ControlCommandStamped ccs;
+        ccs.cmd.linear_velocity = 7.0;
+
+        autoware_msgs::ControlCommandStamped out = tf.longitudinalLimitCtrl(ccs);
+
+        ASSERT_DOUBLE_EQ(5.0, out.cmd.linear_velocity);
+
+        twist_filter::TwistFilter tf2;
+
+        tf2.longitudinal_velocity_limit_ = 100.0;
+
+        autoware_msgs::ControlCommandStamped ccs2;
+        ccs2.cmd.linear_velocity = 7.0;
+
+        autoware_msgs::ControlCommandStamped out2 = tf2.longitudinalLimitCtrl(ccs2);
+
+
+        ASSERT_LT(36.0, out2.cmd.linear_velocity);
+    }
+}

--- a/core_planning/twist_filter/test/test_twist_filter.cpp
+++ b/core_planning/twist_filter/test/test_twist_filter.cpp
@@ -16,57 +16,40 @@
 
 #include <ros/ros.h>
 #include <gtest/gtest.h>
-#include "twist_filter.hpp"
+#include "velocity_limit.hpp"
 
 namespace twist_filter
 {
     TEST(TwistFilterTest, test_longitudinal_twist_filter) {
-        twist_filter::TwistFilter tf(nullptr, nullptr);
-
-        tf.longitudinal_velocity_limit_ = 5.0;
-
         geometry_msgs::TwistStamped twist;
         twist.twist.linear.x = 7.0;
 
-        geometry_msgs::TwistStamped out = tf.longitudinalLimitTwist(twist);
+        geometry_msgs::TwistStamped out = twist_filter::longitudinalLimitTwist(twist, 5.0);
 
         ASSERT_DOUBLE_EQ(5.0, out.twist.linear.x);
-
-        twist_filter::TwistFilter tf2(nullptr, nullptr);
-
-        tf2.longitudinal_velocity_limit_ = 100.0;
 
         geometry_msgs::TwistStamped twist2;
         twist2.twist.linear.x = 50.0;
 
-        geometry_msgs::TwistStamped out2 = tf2.longitudinalLimitTwist(twist2);
+        geometry_msgs::TwistStamped out2 = twist_filter::longitudinalLimitTwist(twist2, 100.0);
 
-        ASSERT_LT(36.0, out2.twist.linear.x);
+        ASSERT_LT(out2.twist.linear.x, 36.0);
     }
 
     TEST(TwistFilterTest, test_longitudinal_ctrl_filter) {
-        twist_filter::TwistFilter tf(nullptr, nullptr);
-
-        tf.longitudinal_velocity_limit_ = 5.0;
-
         autoware_msgs::ControlCommandStamped ccs;
         ccs.cmd.linear_velocity = 7.0;
 
-        autoware_msgs::ControlCommandStamped out = tf.longitudinalLimitCtrl(ccs);
+        autoware_msgs::ControlCommandStamped out = twist_filter::longitudinalLimitCtrl(ccs, 5.0);
 
         ASSERT_DOUBLE_EQ(5.0, out.cmd.linear_velocity);
 
-        twist_filter::TwistFilter tf2(nullptr, nullptr);
-
-        tf2.longitudinal_velocity_limit_ = 100.0;
-
         autoware_msgs::ControlCommandStamped ccs2;
-        ccs2.cmd.linear_velocity = 7.0;
+        ccs2.cmd.linear_velocity = 50.0;
 
-        autoware_msgs::ControlCommandStamped out2 = tf2.longitudinalLimitCtrl(ccs2);
+        autoware_msgs::ControlCommandStamped out2 = twist_filter::longitudinalLimitCtrl(ccs2, 100.0);
 
-
-        ASSERT_LT(36.0, out2.cmd.linear_velocity);
+        ASSERT_LT(out2.cmd.linear_velocity, 36.0);
     }
 }
 

--- a/core_planning/twist_filter/test/test_twist_filter.cpp
+++ b/core_planning/twist_filter/test/test_twist_filter.cpp
@@ -1,4 +1,18 @@
-// TODO: Add CARMA copyright notice
+/*
+ * Copyright (C) 2018-2020 LEIDOS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 
 #include <ros/ros.h>
 #include <gtest/gtest.h>
@@ -54,4 +68,9 @@ namespace twist_filter
 
         ASSERT_LT(36.0, out2.cmd.linear_velocity);
     }
+}
+
+int main(int argc, char **argv) {
+    testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
Adds an upper limiter to the twist_filter node. This limiter has two limits, a configurable limit which can be set by parameters or arguments, and a hardcoded upper max of 80mph. Implementation and unit testing of this functionality required refactoring the twist_filter node a bit to support this.

## Related Issue
usdotfhwastol/carma-platform#856
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This solves the above mentioned issue by adding a limiter watching the speed outputs from CARMA and preventing them from exceeding limits.

## How Has This Been Tested?

This has been unit tested locally.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.