### PR TITLE
Add hardcoded params package to provide single source of truth

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -69,3 +69,6 @@ For any modified file please follow these steps to ensure proper documentation o
   - 9/13/2020
   - Kyle Rush
 
+- Added hardcoded_params package to be used by twist_filter for the longitudinal velocity change above. 
+  - 10/6/2020
+  - Michael McConnell

--- a/common/hardcoded_params/CMakeLists.txt
+++ b/common/hardcoded_params/CMakeLists.txt
@@ -1,0 +1,17 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(hardcoded_params)
+
+find_package(catkin REQUIRED)
+
+catkin_package(
+  INCLUDE_DIRS include
+)
+
+include_directories(
+        include
+        ${catkin_INCLUDE_DIRS}
+)
+
+install(DIRECTORY include/${PROJECT_NAME}/
+        DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+        )

--- a/common/hardcoded_params/README.md
+++ b/common/hardcoded_params/README.md
@@ -1,0 +1,35 @@
+# hardcoded_params
+
+This header only package stores constants that are meant to be hard-coded values in the CARMA Platform system. For example maximum allowed velocity or acceleration. Any package that needs such hard-coded limits should use the parameters in this package to ensure uniform settings across system components
+
+## Usage
+
+To use this package in your own package, simply include it as a catkin dependency and then access the required header file.
+
+package.xml
+
+```xml
+  <depend>hardcoded_params</depend> <!-- build_depend should also be sufficient -->
+```
+
+CMakeList.txt file
+
+```cmake
+find_package(
+  catkin REQUIRED COMPONENTS
+    hardcoded_params
+)
+
+catkin_package(
+  CATKIN_DEPENDS hardcoded_params
+)
+```
+
+C++ Source Code
+
+```c++
+#include <hardcoded_params/control_limits/control_limits.h>
+
+constexpr double my_max_val = hardcoded_params::control_limits::MAX_LONGITUDINAL_VELOCITY_MPS;
+
+```

--- a/common/hardcoded_params/include/hardcoded_params/control_limits/control_limits.h
+++ b/common/hardcoded_params/include/hardcoded_params/control_limits/control_limits.h
@@ -1,0 +1,28 @@
+#pragma once
+
+/*
+ * Copyright (C) 2020 LEIDOS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+namespace hardcoded_params
+{
+namespace control_limits
+{
+/**
+ * The maximum allowable longitudinal velocity of the vehicle in m/s 
+ */
+constexpr double MAX_LONGITUDINAL_VELOCITY_MPS = 35.7632;
+}
+}  // namespace hardcoded_params

--- a/common/hardcoded_params/package.xml
+++ b/common/hardcoded_params/package.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<!--  
+ Copyright (C) 2019-2020 LEIDOS.
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ use this file except in compliance with the License. You may obtain a copy of
+ the License at
+ http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ License for the specific language governing permissions and limitations under
+ the License.
+-->
+<package format="3">
+  <name>hardcoded_params</name>
+  <version>0.0.1</version>
+  <description>Package containing hardcoded parameters which can be shared between packages</description>
+  <maintainer email="carma@dot.gov">carma</maintainer>
+  <license>Apache 2</license>
+
+  <buildtool_depend>catkin</buildtool_depend>
+</package>

--- a/common/lanelet2_extension/CMakeLists.txt
+++ b/common/lanelet2_extension/CMakeLists.txt
@@ -45,6 +45,7 @@ find_package(catkin REQUIRED COMPONENTS
   geometry_msgs
   visualization_msgs
   roslint
+  hardcoded_params
 )
 
 set(ROSLINT_CPP_OPTS "--filter=-build/c++14")
@@ -53,7 +54,7 @@ roslint_cpp()
 catkin_package(
   INCLUDE_DIRS include
   LIBRARIES lanelet2_extension_lib
-  CATKIN_DEPENDS amathutils_lib roscpp lanelet2_core lanelet2_io lanelet2_maps lanelet2_projection lanelet2_routing lanelet2_traffic_rules lanelet2_validation autoware_lanelet2_msgs autoware_msgs geometry_msgs visualization_msgs
+  CATKIN_DEPENDS amathutils_lib roscpp lanelet2_core lanelet2_io lanelet2_maps lanelet2_projection lanelet2_routing lanelet2_traffic_rules lanelet2_validation autoware_lanelet2_msgs autoware_msgs geometry_msgs visualization_msgs hardcoded_params
 )
 
 include_directories(

--- a/common/lanelet2_extension/include/lanelet2_extension/traffic_rules/CarmaUSTrafficRules.h
+++ b/common/lanelet2_extension/include/lanelet2_extension/traffic_rules/CarmaUSTrafficRules.h
@@ -27,6 +27,7 @@
 #include <lanelet2_extension/regulatory_elements/DigitalSpeedLimit.h>
 #include <lanelet2_extension/regulatory_elements/PassingControlLine.h>
 #include <lanelet2_extension/regulatory_elements/DirectionOfTravel.h>
+#include <hardcoded_params/control_limits/control_limits.h>
 
 namespace lanelet
 {
@@ -38,6 +39,7 @@ class CarmaUSTrafficRules : public TrafficRules
 public:
   // Declare new US location. Prefix with carma to prevent future collisions if lanelet adds US support
   static constexpr char Location[] = "carma_us";
+  const lanelet::Velocity MAX_SPEED_LIMIT = lanelet::Velocity(hardcoded_params::control_limits::MAX_LONGITUDINAL_VELOCITY_MPS * lanelet::units::MPS());
 
   CarmaUSTrafficRules(Configuration config = Configuration()) : TrafficRules(config){};
 

--- a/common/lanelet2_extension/lib/CarmaUSTrafficRules.cpp
+++ b/common/lanelet2_extension/lib/CarmaUSTrafficRules.cpp
@@ -256,17 +256,17 @@ SpeedLimitInformation CarmaUSTrafficRules::speedLimit(const ConstLaneletOrArea& 
   {
     sL = trafficSignToVelocity(sign_speed_limit->type()); //Retrieve speed limit information from  trafficSignToVelocity function
 
-    if(config_limit > 0_mph && config_limit < 80_mph)//Accounting for the configured speed limit, input zero when not in use
+    if(config_limit > 0_mph && config_limit < MAX_SPEED_LIMIT)//Accounting for the configured speed limit, input zero when not in use
       {
         ROS_WARN_STREAM("Configurable value in use.");
         sL = config_limit;
       }
 
     //Determine whether or not the value exceeds the predetermined maximum speed limit value.
-    if (sL > 80_mph)
+    if (sL > MAX_SPEED_LIMIT)
     {
       ROS_WARN_STREAM("Invalid speed limit value. Value reset to maximum speed limit. ");//Display warning message
-      sL = 80_mph;//Reset the speed limit value to be capped at the maximum value.
+      sL = MAX_SPEED_LIMIT;//Reset the speed limit value to be capped at the maximum value.
     }
     speed_limit = sL ;
   }
@@ -274,7 +274,7 @@ SpeedLimitInformation CarmaUSTrafficRules::speedLimit(const ConstLaneletOrArea& 
   {
     sL = dig_speed_limit->getSpeedLimit();
 
-    if(config_limit > 0_mph && config_limit < 80_mph)//Accounting for the configured speed limit, input zero when not in use
+    if(config_limit > 0_mph && config_limit < MAX_SPEED_LIMIT)//Accounting for the configured speed limit, input zero when not in use
        { 
           ROS_WARN_STREAM("Configurable value in use.");
 
@@ -284,10 +284,10 @@ SpeedLimitInformation CarmaUSTrafficRules::speedLimit(const ConstLaneletOrArea& 
     if (dig_speed_limit->appliesTo(participant()))
     {
         //Determine whether or not the value exceeds the predetermined maximum speed limit value.
-        if (sL > 80_mph)
+        if (sL > MAX_SPEED_LIMIT)
         {
           ROS_WARN_STREAM("Invalid speed limit value. Value reset to maximum speed limit. ");//Display warning message
-          sL = 80_mph;//Reset the speed limit value to be capped at the maximum value.
+          sL = MAX_SPEED_LIMIT;//Reset the speed limit value to be capped at the maximum value.
         }
       speed_limit = sL;
     }

--- a/common/lanelet2_extension/package.xml
+++ b/common/lanelet2_extension/package.xml
@@ -27,4 +27,5 @@
   <depend>visualization_msgs</depend>
   <depend>pugixml-dev</depend>
   <depend>roslint</depend>
+  <depend>hardcoded_params</depend>
 </package>

--- a/core_planning/twist_filter/CMakeLists.txt
+++ b/core_planning/twist_filter/CMakeLists.txt
@@ -19,6 +19,7 @@ find_package(
     rostest
     std_msgs
     roslint
+    hardcoded_params
 )
 
 catkin_package(

--- a/core_planning/twist_filter/include/velocity_limit.hpp
+++ b/core_planning/twist_filter/include/velocity_limit.hpp
@@ -18,10 +18,11 @@
 #include <ros/ros.h>
 #include <geometry_msgs/TwistStamped.h>
 #include <autoware_msgs/ControlCommandStamped.h>
+#include <hardcoded_params/control_limits/control_limits.h>
 
 namespace twist_filter {
 
-constexpr double MAX_LONGITUDINAL_VELOCITY_HARDCODED_LIMIT_M_S = 35.7632;
+constexpr double MAX_LONGITUDINAL_VELOCITY_HARDCODED_LIMIT_M_S = hardcoded_params::control_limits::MAX_LONGITUDINAL_VELOCITY_MPS;
 
 /**
  * Limit the longitudinal speed found in the input ControlCommandStamped

--- a/core_planning/twist_filter/package.xml
+++ b/core_planning/twist_filter/package.xml
@@ -16,4 +16,5 @@
   <depend>std_msgs</depend>
   <depend>autoware_msgs</depend>
   <depend>roslint</depend>
+  <depend>hardcoded_params</depend>
 </package>


### PR DESCRIPTION


<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
This PR creates a header only package to provide hardcoded limits such as maximum speed limits to other components. At the moment only the hard coded speed limit value is created and applied to the twist_filter node and CARMAUsTrafficRules objects. 

Having this package will be less error prone than values set individually by each developer and allows for easier changes to the configuration in the future without sacrificing the security of a hardcoded limit. 
## Related Issue
Supports
https://github.com/usdot-fhwa-stol/carma-platform/issues/888

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
See above description
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
TBD
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.