### PR TITLE
Feature/pure pursuit next point

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM usdotfhwastolcandidate/carma-base:candidate as build
+FROM usdotfhwastol/carma-base:3.7.1 as build
 
 COPY --chown=carma . /home/carma/autoware.ai
 RUN /home/carma/autoware.ai/docker/checkout.bash
 RUN ./home/carma/autoware.ai/docker/install.sh
 
-FROM usdotfhwastolcandidate/carma-base:candidate
+FROM usdotfhwastol/carma-base:3.7.1
 
 ARG BUILD_DATE="NULL"
 ARG VCS_REF="NULL"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM usdotfhwastol/carma-base:3.7.1 as build
+FROM usdotfhwastolcandidate/carma-base:candidate as build
 
 COPY --chown=carma . /home/carma/autoware.ai
 RUN /home/carma/autoware.ai/docker/checkout.bash
 RUN ./home/carma/autoware.ai/docker/install.sh
 
-FROM usdotfhwastol/carma-base:3.7.1
+FROM usdotfhwastolcandidate/carma-base:candidate
 
 ARG BUILD_DATE="NULL"
 ARG VCS_REF="NULL"

--- a/core_planning/pure_pursuit/include/pure_pursuit/pure_pursuit.h
+++ b/core_planning/pure_pursuit/include/pure_pursuit/pure_pursuit.h
@@ -55,15 +55,6 @@ public:
   {
     current_waypoints_ = wps;
   }
-  void initializeUsingNextWaypoint(int next_waypoint_number)
-  {
-    tf::Vector3 curr_vector(current_waypoints_.at(next_waypoint_number + 1).pose.pose.position.x - current_pose_.position.x, 
-                    current_waypoints_.at(next_waypoint_number + 1).pose.pose.position.y - current_pose_.position.y, 
-                    current_waypoints_.at(next_waypoint_number + 1).pose.pose.position.z - current_pose_.position.z);
-    previous_pose_ = current_pose_;
-    curr_vector.setZ(0);
-    prev_travelled_vector_ = curr_vector;
-  }
   void setCurrentPose(const geometry_msgs::PoseStampedConstPtr& msg)
   {
     current_pose_ = msg->pose;
@@ -98,10 +89,17 @@ public:
   {
     return minimum_lookahead_distance_;
   }
-  int getNextWaypointNumber();
+  /**
+   * \brief Returns the idx number of next waypoint that is in front of the vehicle.
+   * \param use_lookahead_distance true to use dynamic lookahead, false to ignore 
+   * \return idx number of waypoint
+   */
+  int getNextWaypointNumber(bool use_lookahead_distance = true);
+  /**
+   * \brief Sets the next waypoint's idx number. Debug purpose only
+   * \return idx number of waypoint
+   */
   void setNextWaypoint(int next_waypoint_number);
-  int getNextWaypointNumberForSpeed();
-
   // processing
   bool canGetCurvature(double* output_kappa);
 
@@ -116,16 +114,14 @@ private:
   geometry_msgs::Point next_target_position_;
   double lookahead_distance_;
   double minimum_lookahead_distance_;
-  geometry_msgs::Pose current_pose_, previous_pose_;
+  geometry_msgs::Pose current_pose_;
   double current_linear_velocity_;
-  tf::Vector3 prev_travelled_vector_;
   std::vector<autoware_msgs::Waypoint> current_waypoints_;
 
   // functions
   double calcCurvature(geometry_msgs::Point target) const;
   bool interpolateNextTarget(
     int next_waypoint, geometry_msgs::Point* next_target) const;
-  
 };
 }  // namespace waypoint_follower
 

--- a/core_planning/pure_pursuit/include/pure_pursuit/pure_pursuit.h
+++ b/core_planning/pure_pursuit/include/pure_pursuit/pure_pursuit.h
@@ -55,6 +55,15 @@ public:
   {
     current_waypoints_ = wps;
   }
+  void initializeUsingNextWaypoint(int next_waypoint_number)
+  {
+    tf::Vector3 curr_vector(current_waypoints_.at(next_waypoint_number + 1).pose.pose.position.x - current_pose_.position.x, 
+                    current_waypoints_.at(next_waypoint_number + 1).pose.pose.position.y - current_pose_.position.y, 
+                    current_waypoints_.at(next_waypoint_number + 1).pose.pose.position.z - current_pose_.position.z);
+    previous_pose_ = current_pose_;
+    curr_vector.setZ(0);
+    prev_travelled_vector_ = curr_vector;
+  }
   void setCurrentPose(const geometry_msgs::PoseStampedConstPtr& msg)
   {
     current_pose_ = msg->pose;

--- a/core_planning/pure_pursuit/include/pure_pursuit/pure_pursuit.h
+++ b/core_planning/pure_pursuit/include/pure_pursuit/pure_pursuit.h
@@ -105,6 +105,7 @@ private:
   double minimum_lookahead_distance_;
   geometry_msgs::Pose current_pose_;
   double current_linear_velocity_;
+  tf::Vector3 prev_travelled_vector_;
   std::vector<autoware_msgs::Waypoint> current_waypoints_;
 
   // functions

--- a/core_planning/pure_pursuit/include/pure_pursuit/pure_pursuit.h
+++ b/core_planning/pure_pursuit/include/pure_pursuit/pure_pursuit.h
@@ -75,8 +75,6 @@ public:
   // for debug on ROS
   geometry_msgs::Point getPoseOfNextWaypoint() const
   {
-    std::cerr << ">next_waypoint_number_ used is " << next_waypoint_number_ << std::endl;
-    std::cerr << ">and that is " << current_waypoints_.at(next_waypoint_number_).pose.pose.position.x << std::endl;
     return current_waypoints_.at(next_waypoint_number_).pose.pose.position;
   }
   geometry_msgs::Point getPoseOfNextTarget() const
@@ -99,7 +97,8 @@ public:
   {
     return minimum_lookahead_distance_;
   }
-  void getNextWaypoint();
+  int getNextWaypointNumber();
+  void setNextWaypoint(int next_waypoint_number);
 
   // processing
   bool canGetCurvature(double* output_kappa);

--- a/core_planning/pure_pursuit/include/pure_pursuit/pure_pursuit.h
+++ b/core_planning/pure_pursuit/include/pure_pursuit/pure_pursuit.h
@@ -54,14 +54,6 @@ public:
   void setCurrentWaypoints(const std::vector<autoware_msgs::Waypoint>& wps)
   {
     current_waypoints_ = wps;
-    // check if the point is in front or back
-    // we skip 0 because it is our current position
-    tf::Vector3 curr_vector(current_waypoints_.at(1).pose.pose.position.x - current_pose_.position.x, 
-                      current_waypoints_.at(1).pose.pose.position.y - current_pose_.position.y, 
-                      current_waypoints_.at(1).pose.pose.position.z - current_pose_.position.z);
-    previous_pose_ = current_pose_;
-    curr_vector.setZ(0);
-    prev_travelled_vector_ = curr_vector;
   }
   void setCurrentPose(const geometry_msgs::PoseStampedConstPtr& msg)
   {

--- a/core_planning/pure_pursuit/include/pure_pursuit/pure_pursuit.h
+++ b/core_planning/pure_pursuit/include/pure_pursuit/pure_pursuit.h
@@ -59,6 +59,7 @@ public:
     tf::Vector3 curr_vector(current_waypoints_.at(1).pose.pose.position.x - current_pose_.position.x, 
                       current_waypoints_.at(1).pose.pose.position.y - current_pose_.position.y, 
                       current_waypoints_.at(1).pose.pose.position.z - current_pose_.position.z);
+    previous_pose_ = current_pose_;
     curr_vector.setZ(0);
     prev_travelled_vector_ = curr_vector;
   }
@@ -114,7 +115,7 @@ private:
   geometry_msgs::Point next_target_position_;
   double lookahead_distance_;
   double minimum_lookahead_distance_;
-  geometry_msgs::Pose current_pose_;
+  geometry_msgs::Pose current_pose_, previous_pose_;
   double current_linear_velocity_;
   tf::Vector3 prev_travelled_vector_;
   std::vector<autoware_msgs::Waypoint> current_waypoints_;

--- a/core_planning/pure_pursuit/include/pure_pursuit/pure_pursuit.h
+++ b/core_planning/pure_pursuit/include/pure_pursuit/pure_pursuit.h
@@ -54,6 +54,13 @@ public:
   void setCurrentWaypoints(const std::vector<autoware_msgs::Waypoint>& wps)
   {
     current_waypoints_ = wps;
+    // check if the point is in front or back
+    // we skip 0 because it is our current position
+    tf::Vector3 curr_vector(current_waypoints_.at(1).pose.pose.position.x - current_pose_.position.x, 
+                      current_waypoints_.at(1).pose.pose.position.y - current_pose_.position.y, 
+                      current_waypoints_.at(1).pose.pose.position.z - current_pose_.position.z);
+    curr_vector.setZ(0);
+    prev_travelled_vector_ = curr_vector;
   }
   void setCurrentPose(const geometry_msgs::PoseStampedConstPtr& msg)
   {
@@ -67,6 +74,8 @@ public:
   // for debug on ROS
   geometry_msgs::Point getPoseOfNextWaypoint() const
   {
+    std::cerr << ">next_waypoint_number_ used is " << next_waypoint_number_ << std::endl;
+    std::cerr << ">and that is " << current_waypoints_.at(next_waypoint_number_).pose.pose.position.x << std::endl;
     return current_waypoints_.at(next_waypoint_number_).pose.pose.position;
   }
   geometry_msgs::Point getPoseOfNextTarget() const
@@ -89,6 +98,8 @@ public:
   {
     return minimum_lookahead_distance_;
   }
+  void getNextWaypoint();
+
   // processing
   bool canGetCurvature(double* output_kappa);
 
@@ -112,7 +123,7 @@ private:
   double calcCurvature(geometry_msgs::Point target) const;
   bool interpolateNextTarget(
     int next_waypoint, geometry_msgs::Point* next_target) const;
-  void getNextWaypoint();
+  
 };
 }  // namespace waypoint_follower
 

--- a/core_planning/pure_pursuit/include/pure_pursuit/pure_pursuit.h
+++ b/core_planning/pure_pursuit/include/pure_pursuit/pure_pursuit.h
@@ -100,6 +100,7 @@ public:
   }
   int getNextWaypointNumber();
   void setNextWaypoint(int next_waypoint_number);
+  int getNextWaypointNumberForSpeed();
 
   // processing
   bool canGetCurvature(double* output_kappa);

--- a/core_planning/pure_pursuit/include/pure_pursuit/pure_pursuit_core.h
+++ b/core_planning/pure_pursuit/include/pure_pursuit/pure_pursuit_core.h
@@ -119,7 +119,7 @@ private:
     autoware_msgs::Lane* expand_lane, LaneDirection direction);
   // debug
   geometry_msgs::Point getPoseOfNextWaypoint() const;
-  void getNextWaypoint();
+  void calculateNextWaypoint();
   
   int getSgn() const;
   double computeLookaheadDistance() const;

--- a/core_planning/pure_pursuit/include/pure_pursuit/pure_pursuit_core.h
+++ b/core_planning/pure_pursuit/include/pure_pursuit/pure_pursuit_core.h
@@ -117,7 +117,10 @@ private:
     const std::vector<autoware_msgs::Waypoint>& waypoints) const;
   void connectVirtualLastWaypoints(
     autoware_msgs::Lane* expand_lane, LaneDirection direction);
-
+  // debug
+  geometry_msgs::Point getPoseOfNextWaypoint() const;
+  void getNextWaypoint();
+  
   int getSgn() const;
   double computeLookaheadDistance() const;
   double computeCommandVelocity() const;

--- a/core_planning/pure_pursuit/src/pure_pursuit.cpp
+++ b/core_planning/pure_pursuit/src/pure_pursuit.cpp
@@ -218,7 +218,7 @@ int PurePursuit::getNextWaypointNumber()
     if (i == (path_size - 1))
     {
       ROS_DEBUG_STREAM(">> Search waypoint reached the last: x: " << current_waypoints_.at(i).pose.pose.position.x 
-                                              << ", y: " << current_waypoints_.at(i).pose.pose.position.y << ", speed: " << current_waypoints_.at(i).twist.twist.linear.x);
+                                              << ", y: " << current_waypoints_.at(i).pose.pose.position.y << ", speed: " << current_waypoints_.at(i).twist.twist.linear.x * 2.23694 << "mph");
       next_waypoint_number = i;
       ROS_DEBUG_STREAM(">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>");
       return next_waypoint_number;
@@ -238,10 +238,10 @@ int PurePursuit::getNextWaypointNumber()
       min_distance_satisfied = true;
       ROS_DEBUG_STREAM(">>>>>>>>>");
       ROS_DEBUG_STREAM(">> Would have picked wp at following: x: " << current_waypoints_.at(i).pose.pose.position.x 
-                                              << ", y: " << current_waypoints_.at(i).pose.pose.position.y << ", speed: " << current_waypoints_.at(i).twist.twist.linear.x);
+                                              << ", y: " << current_waypoints_.at(i).pose.pose.position.y << ", speed: " << current_waypoints_.at(i).twist.twist.linear.x * 2.23694 << "mph");
       ROS_DEBUG_STREAM(">> Where current position is x: " << current_pose_.position.x << ", y: " << current_pose_.position.y);
-      ROS_DEBUG_STREAM(">> Angle degrees: "  << std::abs(tf::tfAngle(curr_vector, prev_travelled_vector_) / M_PI * 180));
     }
+    ROS_DEBUG_STREAM(">> Angle degrees: "  << std::abs(tf::tfAngle(curr_vector, prev_travelled_vector_) / M_PI * 180));
 
     //else we check if trajectory is not turning more than 90 deg instantaneously than its previous direction
     if (std::abs(tf::tfAngle(curr_vector, prev_travelled_vector_)) < M_PI / 2)
@@ -249,7 +249,7 @@ int PurePursuit::getNextWaypointNumber()
       in_front = true;
     }
     else{
-      ROS_DEBUG_STREAM(">>>>>!!!! Did not satisfy angle requirement!");
+      ROS_DEBUG_STREAM(">>>>>!!!! Did not satisfy angle requirement!" << std::abs(tf::tfAngle(curr_vector, prev_travelled_vector_) / M_PI * 180));
     }
 
     if (min_distance_satisfied && in_front)

--- a/core_planning/pure_pursuit/src/pure_pursuit.cpp
+++ b/core_planning/pure_pursuit/src/pure_pursuit.cpp
@@ -229,7 +229,7 @@ void PurePursuit::getNextWaypoint()
                       current_waypoints_.at(i).pose.pose.position.y - current_pose_.position.y, 
                       current_waypoints_.at(i).pose.pose.position.z - current_pose_.position.z);
     curr_vector.setZ(0);
-
+    std::cerr << ">>>>>>> lookahead distance" << lookahead_distance_ << std::endl;
     // if there exists an effective waypoint
     if (getPlaneDistance(
       current_waypoints_.at(i).pose.pose.position, current_pose_.position)

--- a/core_planning/pure_pursuit/src/pure_pursuit.cpp
+++ b/core_planning/pure_pursuit/src/pure_pursuit.cpp
@@ -263,8 +263,8 @@ int PurePursuit::getNextWaypointNumber()
       prev_travelled_vector_ = (prev_travelled_vector_tmp.x() == 0 && prev_travelled_vector_tmp.y() == 0) ? prev_travelled_vector_ : prev_travelled_vector_tmp;
       previous_pose_ = current_pose_;
       next_waypoint_number = i;
-      ROS_DEBUG_STREAM(">> Following waypoint satisfied all: x: " << current_waypoints_.at(i).pose.pose.position.x 
-                                              << ", y: " << current_waypoints_.at(i).pose.pose.position.y << ", speed: " << current_waypoints_.at(i).twist.twist.linear.x);
+      ROS_DEBUG_STREAM(">> ***** Following waypoint satisfied all: x: " << current_waypoints_.at(i).pose.pose.position.x 
+                                              << ", y: " << current_waypoints_.at(i).pose.pose.position.y << ", speed: " << current_waypoints_.at(i).twist.twist.linear.x * 2.23694 << "mph");
       ROS_DEBUG_STREAM(">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>");
       return next_waypoint_number;
     }

--- a/core_planning/pure_pursuit/src/pure_pursuit.cpp
+++ b/core_planning/pure_pursuit/src/pure_pursuit.cpp
@@ -212,45 +212,42 @@ void PurePursuit::getNextWaypoint()
   {
     bool min_distance_satisfied = false;
     bool in_front = false;
-    std:: cerr << "prev_travelled: " << prev_travelled_vector_.x() << std::endl;
     // if search waypoint is the last
     if (i == (path_size - 1))
     {
-      ROS_INFO("search waypoint is the last");
-      std::cerr << "hit last: set next_waypoint to " << i << "\n";
+      ROS_DEBUG_STREAM(">> Search waypoint reached the last: x: " << current_waypoints_.at(i).pose.pose.position.x 
+                                              << ", y: " << current_waypoints_.at(i).pose.pose.position.y << ", speed: " << current_waypoints_.at(i).twist.twist.linear.x);
       next_waypoint_number_ = i;
+      ROS_DEBUG_STREAM(">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>");
       return;
     }
-    std::cerr << "prev pos " << previous_pose_.position.x << "\n";
-    std::cerr << "curr pos " << current_pose_.position.x << "\n";
 
     // check if the point is in front or back
     tf::Vector3 curr_vector(current_waypoints_.at(i).pose.pose.position.x - current_pose_.position.x, 
                       current_waypoints_.at(i).pose.pose.position.y - current_pose_.position.y, 
                       current_waypoints_.at(i).pose.pose.position.z - current_pose_.position.z);
     curr_vector.setZ(0);
-    std::cerr << ">>>>>>> lookahead distance" << lookahead_distance_ << std::endl;
-    std::cerr << "curr vec x:" << curr_vector.x() << "\n";
-    std::cerr << "curr vec y:" << curr_vector.y() << "\n";
+
     // if there exists an effective waypoint
     if (getPlaneDistance(
       current_waypoints_.at(i).pose.pose.position, current_pose_.position)
       > lookahead_distance_)
     {
       min_distance_satisfied = true;
-    }
-    else{
-      std::cerr << "Did not get through here! 1" << std::endl;
+      ROS_DEBUG_STREAM(">>>>>>>>>");
+      ROS_DEBUG_STREAM(">> Would have picked wp at following: x: " << current_waypoints_.at(i).pose.pose.position.x 
+                                              << ", y: " << current_waypoints_.at(i).pose.pose.position.y << ", speed: " << current_waypoints_.at(i).twist.twist.linear.x);
+      ROS_DEBUG_STREAM(">> Where current position is x: " << current_pose_.position.x << ", y: " << current_pose_.position.y);
+      ROS_DEBUG_STREAM(">> Angle degrees: "  << std::abs(tf::tfAngle(curr_vector, prev_travelled_vector_) / M_PI * 180));
     }
 
-    std::cerr << ">> angle:" << std::abs(tf::tfAngle(curr_vector, prev_travelled_vector_)) << std::endl;
     //else we check if trajectory is not turning more than 90 deg instantaneously than its previous direction
     if (std::abs(tf::tfAngle(curr_vector, prev_travelled_vector_)) < M_PI / 2)
     {
       in_front = true;
     }
     else{
-      std::cerr << "Did not get through here! 2" << std::endl;
+      ROS_DEBUG_STREAM(">>>>>!!!! Did not satisfy angle requirement!");
     }
 
     if (min_distance_satisfied && in_front)
@@ -264,19 +261,17 @@ void PurePursuit::getNextWaypoint()
       prev_travelled_vector_ = (prev_travelled_vector_tmp.x() == 0 && prev_travelled_vector_tmp.y() == 0) ? prev_travelled_vector_ : prev_travelled_vector_tmp;
       previous_pose_ = current_pose_;
       next_waypoint_number_ = i;
-      std::cerr << "set next_waypoint to " << i << "\n";
+      ROS_DEBUG_STREAM(">> Following waypoint satisfied all: x: " << current_waypoints_.at(i).pose.pose.position.x 
+                                              << ", y: " << current_waypoints_.at(i).pose.pose.position.y << ", speed: " << current_waypoints_.at(i).twist.twist.linear.x);
+      ROS_DEBUG_STREAM(">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>");
       return;
     }
-    else
-    {
-      std::cout << ">>>>>>>>>>>>>>>passed next_waypoint to " << i << std::endl;
-    }
-    
-      
+         
   }
-
+  
   // if this program reaches here , it means we lost the waypoint!
   next_waypoint_number_ = -1;
+  ROS_DEBUG_STREAM(">>>>>>>>>>>>>>>>>>>>>>>Lost the waypoint !>>>>>>>>>>>>>>>>>");
   return;
 }
 

--- a/core_planning/pure_pursuit/src/pure_pursuit.cpp
+++ b/core_planning/pure_pursuit/src/pure_pursuit.cpp
@@ -221,9 +221,6 @@ int PurePursuit::getNextWaypointNumber(bool use_lookahead_distance)
       ROS_INFO_STREAM(">> Search waypoint reached the last: x: " << current_waypoints_.at(i).pose.pose.position.x 
                                               << ", y: " << current_waypoints_.at(i).pose.pose.position.y << ", speed: " << current_waypoints_.at(i).twist.twist.linear.x * 2.23694 << "mph");
       next_waypoint_number = i;
-      std::cerr << ">> Search waypoint reached the last: x: " << current_waypoints_.at(i).pose.pose.position.x 
-                                              << ", y: " << current_waypoints_.at(i).pose.pose.position.y << ", speed: " << current_waypoints_.at(i).twist.twist.linear.x * 2.23694 << "mph" << std::endl;
-
       return next_waypoint_number;
     }
 
@@ -262,16 +259,12 @@ int PurePursuit::getNextWaypointNumber(bool use_lookahead_distance)
                       current_waypoints_.at(i).pose.pose.position.z - current_waypoints_.at(i - 1).pose.pose.position.z);
     traj_vector.setZ(0);
     double angle_in_rad = std::abs(tf::tfAngle(curr_vector, traj_vector));
-    std::cerr << "curr x:" << current_waypoints_.at(i).pose.pose.position.x << ",y:" << current_waypoints_.at(i).pose.pose.position.y << std::endl;
-    std::cerr << ">> Angle degrees: "  << angle_in_rad / M_PI * 180 <<std::endl;
     // if degree between curr_vector and the direction of the trajectory is more than 90 degrees, we know last point is behind us and unsatisfactory
     if (std::isnan(angle_in_rad) || angle_in_rad > M_PI / 2)
     {
-      std::cerr << ">> We are not passing: degrees: "  << angle_in_rad / M_PI * 180 <<std::endl;
       closest_distance = current_distance;
       continue;
     }
-    std::cerr << ">> We are passing: degrees: "  << angle_in_rad / M_PI * 180 <<std::endl;
     next_waypoint_number = i - 1;
     return next_waypoint_number;
   }

--- a/core_planning/pure_pursuit/src/pure_pursuit.cpp
+++ b/core_planning/pure_pursuit/src/pure_pursuit.cpp
@@ -244,9 +244,9 @@ void PurePursuit::getNextWaypoint()
       std::cerr << "Did not get through here! 1" << std::endl;
     }
 
-    std::cerr << ">> angle:" << abs(tf::tfAngle(curr_vector, prev_travelled_vector_)) << std::endl;
+    std::cerr << ">> angle:" << std::abs(tf::tfAngle(curr_vector, prev_travelled_vector_)) << std::endl;
     //else we check if trajectory is not turning more than 90 deg instantaneously than its previous direction
-    if (abs(tf::tfAngle(curr_vector, prev_travelled_vector_)) < M_PI / 2)
+    if (std::abs(tf::tfAngle(curr_vector, prev_travelled_vector_)) < M_PI / 2)
     {
       in_front = true;
     }

--- a/core_planning/pure_pursuit/src/pure_pursuit.cpp
+++ b/core_planning/pure_pursuit/src/pure_pursuit.cpp
@@ -221,7 +221,7 @@ int PurePursuit::getNextWaypointNumber()
                                               << ", y: " << current_waypoints_.at(i).pose.pose.position.y << ", speed: " << current_waypoints_.at(i).twist.twist.linear.x * 2.23694 << "mph");
       next_waypoint_number = i;
       //std::cerr << ">> Search waypoint reached the last: x: " << current_waypoints_.at(i).pose.pose.position.x 
-                                              << ", y: " << current_waypoints_.at(i).pose.pose.position.y << ", speed: " << current_waypoints_.at(i).twist.twist.linear.x * 2.23694 << "mph" <<std::endl;
+      //                                        << ", y: " << current_waypoints_.at(i).pose.pose.position.y << ", speed: " << current_waypoints_.at(i).twist.twist.linear.x * 2.23694 << "mph" <<std::endl;
       ROS_DEBUG_STREAM(">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>");
       return next_waypoint_number;
     }

--- a/core_planning/pure_pursuit/src/pure_pursuit.cpp
+++ b/core_planning/pure_pursuit/src/pure_pursuit.cpp
@@ -196,7 +196,8 @@ bool PurePursuit::interpolateNextTarget(
   }
 }
 
-int PurePursuit::getNextWaypointNumber()
+
+int PurePursuit::getNextWaypointNumberForSpeed()
 {
   int next_waypoint_number = -1;
   
@@ -228,7 +229,7 @@ int PurePursuit::getNextWaypointNumber()
 
     double current_distance = getPlaneDistance(current_waypoints_.at(i).pose.pose.position, current_pose_.position);
     // loop through until we hit closest and effective point
-    if (current_distance < closest_distance || closest_distance < lookahead_distance_)
+    if (current_distance < closest_distance)
     {
       closest_distance = current_distance;
       continue;
@@ -280,6 +281,94 @@ int PurePursuit::getNextWaypointNumber()
   // if this program reaches here , it means we lost the waypoint!
   next_waypoint_number = -1;
   ROS_DEBUG_STREAM(">>>>>>>>>>>>>>>>>>>>>>>Lost the waypoint !>>>>>>>>>>>>>>>>>");
+  return next_waypoint_number;
+}
+
+
+int PurePursuit::getNextWaypointNumber()
+{
+  int next_waypoint_number = -1;
+  
+  int path_size = static_cast<int>(current_waypoints_.size());
+
+  // if waypoints are not given, do nothing.
+  if (path_size == 0)
+  {
+    next_waypoint_number = -1;
+    return next_waypoint_number;
+  }
+  double closest_distance = getPlaneDistance(current_waypoints_.at(0).pose.pose.position, current_pose_.position);
+  // look for the next waypoint.
+  for (int i = 1; i < path_size; i++)
+  {
+    bool min_lookahead_satisfied = false;
+    bool in_front = false;
+    // if search waypoint is the last
+    if (i == (path_size - 1))
+    {
+      //ROS_DEBUG_STREAM(">> Search waypoint reached the last: x: " << current_waypoints_.at(i).pose.pose.position.x 
+      //                                        << ", y: " << current_waypoints_.at(i).pose.pose.position.y << ", speed: " << current_waypoints_.at(i).twist.twist.linear.x * 2.23694 << "mph");
+      next_waypoint_number = i;
+      //std::cerr << ">> Search waypoint reached the last: x: " << current_waypoints_.at(i).pose.pose.position.x 
+      //                                        << ", y: " << current_waypoints_.at(i).pose.pose.position.y << ", speed: " << current_waypoints_.at(i).twist.twist.linear.x * 2.23694 << "mph" <<std::endl;
+      //ROS_DEBUG_STREAM(">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>");
+      return next_waypoint_number;
+    }
+
+    double current_distance = getPlaneDistance(current_waypoints_.at(i).pose.pose.position, current_pose_.position);
+    // loop through until we hit closest and effective point
+    if (current_distance < closest_distance || closest_distance < lookahead_distance_)
+    {
+      closest_distance = current_distance;
+      continue;
+    }
+    // Else, by this point, we found that prev point is closest point and is bigger than lookahead_distance
+
+    // check if the prev point is in front or back
+    tf::Vector3 curr_vector(current_waypoints_.at(i - 1).pose.pose.position.x - current_pose_.position.x, 
+                      current_waypoints_.at(i - 1).pose.pose.position.y - current_pose_.position.y, 
+                      current_waypoints_.at(i - 1).pose.pose.position.z - current_pose_.position.z);
+    curr_vector.setZ(0);
+    tf::Vector3 traj_vector(current_waypoints_.at(i).pose.pose.position.x - current_waypoints_.at(i - 1).pose.pose.position.x, 
+                      current_waypoints_.at(i).pose.pose.position.y - current_waypoints_.at(i - 1).pose.pose.position.y, 
+                      current_waypoints_.at(i).pose.pose.position.z - current_waypoints_.at(i - 1).pose.pose.position.z);
+    traj_vector.setZ(0);
+    
+    //ROS_DEBUG_STREAM(">>>>>>>>>");
+    //ROS_DEBUG_STREAM(">> Would have picked wp at following: x: " << current_waypoints_.at(i - 1).pose.pose.position.x 
+    //                                        << ", y: " << current_waypoints_.at(i - 1).pose.pose.position.y << ", speed: " << current_waypoints_.at(i - 1).twist.twist.linear.x * 2.23694 << "mph");
+    //ROS_DEBUG_STREAM(">> Where current position is x: " << current_pose_.position.x << ", y: " << current_pose_.position.y);
+    //ROS_DEBUG_STREAM(">> Where next traj position is x: " << current_waypoints_.at(i ).pose.pose.position.x << ", y: " << current_waypoints_.at(i).pose.pose.position.y);
+    //ROS_DEBUG_STREAM(">> Angle degrees: "  << std::abs(tf::tfAngle(curr_vector, traj_vector) / M_PI * 180));
+
+    //std::cerr << ">> Would have picked wp at following: x: " << current_waypoints_.at(i - 1).pose.pose.position.x 
+    //                                        << ", y: " << current_waypoints_.at(i - 1).pose.pose.position.y << ", speed: " << current_waypoints_.at(i - 1).twist.twist.linear.x * 2.23694 << "mph" <<std::endl;
+    //std::cerr << ">> Where current position is x: " << current_pose_.position.x << ", y: " << current_pose_.position.y <<std::endl;
+    //std::cerr << ">> Where next traj position is x: " << current_waypoints_.at(i).pose.pose.position.x << ", y: " << current_waypoints_.at(i).pose.pose.position.y << std::endl;
+    //std::cerr << ">> Angle degrees: "  << std::abs(tf::tfAngle(curr_vector, traj_vector) / M_PI * 180) <<std::endl;
+
+    // if degree between curr_vector and the direction of the trajectory is more than 90 degrees, we know last point is behind us.
+    if (std::abs(tf::tfAngle(curr_vector, traj_vector)) > M_PI / 2)
+    {
+      //ROS_DEBUG_STREAM(">>>>>!!!! Did not satisfy angle requirement!" << std::abs(tf::tfAngle(curr_vector, traj_vector) / M_PI * 180));
+      //std::cerr << ">>>>>!!!! Did not satisfy angle requirement!" << std::abs(tf::tfAngle(curr_vector, traj_vector) / M_PI * 180) <<std::endl;
+      
+      closest_distance = current_distance;
+      continue;
+    }
+    next_waypoint_number = i - 1;
+    //ROS_DEBUG_STREAM(">> ***** Following waypoint satisfied all: x: " << current_waypoints_.at(i - 1).pose.pose.position.x 
+    //                                        << ", y: " << current_waypoints_.at(i - 1).pose.pose.position.y << ", speed: " << current_waypoints_.at(i - 1).twist.twist.linear.x * 2.23694 << "mph");
+    //ROS_DEBUG_STREAM(">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>");
+    //std::cerr << ">> ***** Following waypoint satisfied all: x: " << current_waypoints_.at(i - 1).pose.pose.position.x 
+    //                                        << ", y: " << current_waypoints_.at(i - 1).pose.pose.position.y << ", speed: " << current_waypoints_.at(i - 1).twist.twist.linear.x * 2.23694 << "mph" <<std::endl;
+    //std::cerr << ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"<<std::endl;
+    return next_waypoint_number;
+  }
+  
+  // if this program reaches here , it means we lost the waypoint!
+  next_waypoint_number = -1;
+  //ROS_DEBUG_STREAM(">>>>>>>>>>>>>>>>>>>>>>>Lost the waypoint !>>>>>>>>>>>>>>>>>");
   return next_waypoint_number;
 }
 

--- a/core_planning/pure_pursuit/src/pure_pursuit.cpp
+++ b/core_planning/pure_pursuit/src/pure_pursuit.cpp
@@ -272,7 +272,7 @@ int PurePursuit::getNextWaypointNumber()
                                             << ", y: " << current_waypoints_.at(i - 1).pose.pose.position.y << ", speed: " << current_waypoints_.at(i - 1).twist.twist.linear.x * 2.23694 << "mph");
     ROS_DEBUG_STREAM(">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>");
     //std::cerr << ">> ***** Following waypoint satisfied all: x: " << current_waypoints_.at(i - 1).pose.pose.position.x 
-                                            << ", y: " << current_waypoints_.at(i - 1).pose.pose.position.y << ", speed: " << current_waypoints_.at(i - 1).twist.twist.linear.x * 2.23694 << "mph" <<std::endl;
+    //                                        << ", y: " << current_waypoints_.at(i - 1).pose.pose.position.y << ", speed: " << current_waypoints_.at(i - 1).twist.twist.linear.x * 2.23694 << "mph" <<std::endl;
     //std::cerr << ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"<<std::endl;
     return next_waypoint_number;
   }

--- a/core_planning/pure_pursuit/src/pure_pursuit.cpp
+++ b/core_planning/pure_pursuit/src/pure_pursuit.cpp
@@ -212,14 +212,17 @@ void PurePursuit::getNextWaypoint()
   {
     bool min_distance_satisfied = false;
     bool in_front = false;
-    
+    std:: cerr << "prev_travelled" << prev_travelled_vector_.x() << std::endl;
     // if search waypoint is the last
     if (i == (path_size - 1))
     {
       ROS_INFO("search waypoint is the last");
+      std::cerr << "hit last: set next_waypoint to " << i << "\n";
       next_waypoint_number_ = i;
       return;
     }
+    std::cerr << "curr pos " << current_pose_.position.x << "\n";
+    std::cerr << "curr vec " << current_waypoints_.at(i).pose.pose.position.x << "\n";
 
     // check if the point is in front or back
     tf::Vector3 curr_vector(current_waypoints_.at(i).pose.pose.position.x - current_pose_.position.x, 
@@ -234,25 +237,32 @@ void PurePursuit::getNextWaypoint()
     {
       min_distance_satisfied = true;
     }
+    else{
+      std::cerr << "Did not get through here! 1" << std::endl;
+    }
 
-    // if first point, we won't have previous vector to compare
-    if (i == 0)
-    {
-      in_front = true;
-      prev_travelled_vector_ = curr_vector;
-    } 
+    std::cerr << ">> angle:" << abs(tf::tfAngle(curr_vector, prev_travelled_vector_)) << std::endl;
     //else we check if trajectory is not turning more than 90 deg instantaneously than its previous direction
-    else if (abs(tf::tfAngle(curr_vector, prev_travelled_vector_)) < M_PI / 2)
+    if (abs(tf::tfAngle(curr_vector, prev_travelled_vector_)) < M_PI / 2)
     {
       in_front = true;
     }
-    
+    else{
+      std::cerr << "Did not get through here! 2" << std::endl;
+    }
+
     if (min_distance_satisfied && in_front)
     {
       prev_travelled_vector_ = curr_vector;
       next_waypoint_number_ = i;
+      std::cerr << "set next_waypoint to " << i << "\n";
       return;
-    }    
+    }
+    else
+    {
+      std::cout << ">>>>>>>>>>>>>>>passed next_waypoint to " << i << std::endl;
+    }
+    
       
   }
 

--- a/core_planning/pure_pursuit/src/pure_pursuit.cpp
+++ b/core_planning/pure_pursuit/src/pure_pursuit.cpp
@@ -208,11 +208,11 @@ int PurePursuit::getNextWaypointNumber()
     next_waypoint_number = -1;
     return next_waypoint_number;
   }
-
+  double closest_distance = getPlaneDistance(current_waypoints_.at(0).pose.pose.position, current_pose_.position);
   // look for the next waypoint.
-  for (int i = 0; i < path_size; i++)
+  for (int i = 1; i < path_size; i++)
   {
-    bool min_distance_satisfied = false;
+    bool min_lookahead_satisfied = false;
     bool in_front = false;
     // if search waypoint is the last
     if (i == (path_size - 1))
@@ -220,55 +220,61 @@ int PurePursuit::getNextWaypointNumber()
       ROS_DEBUG_STREAM(">> Search waypoint reached the last: x: " << current_waypoints_.at(i).pose.pose.position.x 
                                               << ", y: " << current_waypoints_.at(i).pose.pose.position.y << ", speed: " << current_waypoints_.at(i).twist.twist.linear.x * 2.23694 << "mph");
       next_waypoint_number = i;
+      std::cerr << ">> Search waypoint reached the last: x: " << current_waypoints_.at(i).pose.pose.position.x 
+                                              << ", y: " << current_waypoints_.at(i).pose.pose.position.y << ", speed: " << current_waypoints_.at(i).twist.twist.linear.x * 2.23694 << "mph" <<std::endl;
       ROS_DEBUG_STREAM(">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>");
       return next_waypoint_number;
     }
 
-    // check if the point is in front or back
-    tf::Vector3 curr_vector(current_waypoints_.at(i).pose.pose.position.x - current_pose_.position.x, 
-                      current_waypoints_.at(i).pose.pose.position.y - current_pose_.position.y, 
-                      current_waypoints_.at(i).pose.pose.position.z - current_pose_.position.z);
+    double current_distance = getPlaneDistance(current_waypoints_.at(i).pose.pose.position, current_pose_.position);
+    // loop through until we hit closest and effective point
+    if (current_distance < closest_distance || closest_distance < lookahead_distance_)
+    {
+      closest_distance = current_distance;
+      continue;
+    }
+    // Else, by this point, we found that prev point is closest point and is bigger than lookahead_distance
+
+    // check if the prev point is in front or back
+    tf::Vector3 curr_vector(current_waypoints_.at(i - 1).pose.pose.position.x - current_pose_.position.x, 
+                      current_waypoints_.at(i - 1).pose.pose.position.y - current_pose_.position.y, 
+                      current_waypoints_.at(i - 1).pose.pose.position.z - current_pose_.position.z);
     curr_vector.setZ(0);
+    tf::Vector3 traj_vector(current_waypoints_.at(i).pose.pose.position.x - current_waypoints_.at(i - 1).pose.pose.position.x, 
+                      current_waypoints_.at(i).pose.pose.position.y - current_waypoints_.at(i - 1).pose.pose.position.y, 
+                      current_waypoints_.at(i).pose.pose.position.z - current_waypoints_.at(i - 1).pose.pose.position.z);
+    traj_vector.setZ(0);
+    
+    ROS_DEBUG_STREAM(">>>>>>>>>");
+    ROS_DEBUG_STREAM(">> Would have picked wp at following: x: " << current_waypoints_.at(i - 1).pose.pose.position.x 
+                                            << ", y: " << current_waypoints_.at(i - 1).pose.pose.position.y << ", speed: " << current_waypoints_.at(i - 1).twist.twist.linear.x * 2.23694 << "mph");
+    ROS_DEBUG_STREAM(">> Where current position is x: " << current_pose_.position.x << ", y: " << current_pose_.position.y);
+    ROS_DEBUG_STREAM(">> Where next traj position is x: " << current_waypoints_.at(i ).pose.pose.position.x << ", y: " << current_waypoints_.at(i).pose.pose.position.y);
+    ROS_DEBUG_STREAM(">> Angle degrees: "  << std::abs(tf::tfAngle(curr_vector, traj_vector) / M_PI * 180));
 
-    // if there exists an effective waypoint
-    if (getPlaneDistance(
-      current_waypoints_.at(i).pose.pose.position, current_pose_.position)
-      > lookahead_distance_)
-    {
-      min_distance_satisfied = true;
-      ROS_DEBUG_STREAM(">>>>>>>>>");
-      ROS_DEBUG_STREAM(">> Would have picked wp at following: x: " << current_waypoints_.at(i).pose.pose.position.x 
-                                              << ", y: " << current_waypoints_.at(i).pose.pose.position.y << ", speed: " << current_waypoints_.at(i).twist.twist.linear.x * 2.23694 << "mph");
-      ROS_DEBUG_STREAM(">> Where current position is x: " << current_pose_.position.x << ", y: " << current_pose_.position.y);
-      ROS_DEBUG_STREAM(">> Angle degrees: "  << std::abs(tf::tfAngle(curr_vector, prev_travelled_vector_) / M_PI * 180));
-    }
+    std::cerr << ">> Would have picked wp at following: x: " << current_waypoints_.at(i - 1).pose.pose.position.x 
+                                            << ", y: " << current_waypoints_.at(i - 1).pose.pose.position.y << ", speed: " << current_waypoints_.at(i - 1).twist.twist.linear.x * 2.23694 << "mph" <<std::endl;
+    std::cerr << ">> Where current position is x: " << current_pose_.position.x << ", y: " << current_pose_.position.y <<std::endl;
+    std::cerr << ">> Where next traj position is x: " << current_waypoints_.at(i).pose.pose.position.x << ", y: " << current_waypoints_.at(i).pose.pose.position.y << std::endl;
+    std::cerr << ">> Angle degrees: "  << std::abs(tf::tfAngle(curr_vector, traj_vector) / M_PI * 180) <<std::endl;
 
-    //else we check if trajectory is not turning more than 90 deg instantaneously than its previous direction
-    if (std::abs(tf::tfAngle(curr_vector, prev_travelled_vector_)) < M_PI / 2)
+    // if degree between curr_vector and the direction of the trajectory is more than 90 degrees, we know last point is behind us.
+    if (std::abs(tf::tfAngle(curr_vector, traj_vector)) > M_PI / 2)
     {
-      in_front = true;
+      ROS_DEBUG_STREAM(">>>>>!!!! Did not satisfy angle requirement!" << std::abs(tf::tfAngle(curr_vector, traj_vector) / M_PI * 180));
+      std::cerr << ">>>>>!!!! Did not satisfy angle requirement!" << std::abs(tf::tfAngle(curr_vector, traj_vector) / M_PI * 180) <<std::endl;
+      
+      closest_distance = current_distance;
+      continue;
     }
-    else{
-      ROS_DEBUG_STREAM(">>>>>!!!! Did not satisfy angle requirement!" << std::abs(tf::tfAngle(curr_vector, prev_travelled_vector_) / M_PI * 180));
-    }
-
-    if (min_distance_satisfied && in_front)
-    {
-      tf::Vector3 prev_travelled_vector_tmp(current_pose_.position.x - previous_pose_.position.x, 
-                      current_pose_.position.y - previous_pose_.position.y, 
-                      current_pose_.position.z - previous_pose_.position.z);
-      prev_travelled_vector_tmp.setZ(0);
-      // if current pose did not change, we don't change the previous vector direction
-      // this also handles the case when waypoint is set for the first time, current_pos_ and previous_pos_ are same
-      prev_travelled_vector_ = (prev_travelled_vector_tmp.x() == 0 && prev_travelled_vector_tmp.y() == 0) ? prev_travelled_vector_ : prev_travelled_vector_tmp;
-      previous_pose_ = current_pose_;
-      next_waypoint_number = i;
-      ROS_DEBUG_STREAM(">> ***** Following waypoint satisfied all: x: " << current_waypoints_.at(i).pose.pose.position.x 
-                                              << ", y: " << current_waypoints_.at(i).pose.pose.position.y << ", speed: " << current_waypoints_.at(i).twist.twist.linear.x * 2.23694 << "mph");
-      ROS_DEBUG_STREAM(">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>");
-      return next_waypoint_number;
-    }
-         
+    next_waypoint_number = i - 1;
+    ROS_DEBUG_STREAM(">> ***** Following waypoint satisfied all: x: " << current_waypoints_.at(i - 1).pose.pose.position.x 
+                                            << ", y: " << current_waypoints_.at(i - 1).pose.pose.position.y << ", speed: " << current_waypoints_.at(i - 1).twist.twist.linear.x * 2.23694 << "mph");
+    ROS_DEBUG_STREAM(">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>");
+    std::cerr << ">> ***** Following waypoint satisfied all: x: " << current_waypoints_.at(i - 1).pose.pose.position.x 
+                                            << ", y: " << current_waypoints_.at(i - 1).pose.pose.position.y << ", speed: " << current_waypoints_.at(i - 1).twist.twist.linear.x * 2.23694 << "mph" <<std::endl;
+    std::cerr << ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"<<std::endl;
+    return next_waypoint_number;
   }
   
   // if this program reaches here , it means we lost the waypoint!

--- a/core_planning/pure_pursuit/src/pure_pursuit.cpp
+++ b/core_planning/pure_pursuit/src/pure_pursuit.cpp
@@ -196,15 +196,17 @@ bool PurePursuit::interpolateNextTarget(
   }
 }
 
-void PurePursuit::getNextWaypoint()
+int PurePursuit::getNextWaypointNumber()
 {
+  int next_waypoint_number = -1;
+  
   int path_size = static_cast<int>(current_waypoints_.size());
 
   // if waypoints are not given, do nothing.
   if (path_size == 0)
   {
-    next_waypoint_number_ = -1;
-    return;
+    next_waypoint_number = -1;
+    return next_waypoint_number;
   }
 
   // look for the next waypoint.
@@ -217,9 +219,9 @@ void PurePursuit::getNextWaypoint()
     {
       ROS_DEBUG_STREAM(">> Search waypoint reached the last: x: " << current_waypoints_.at(i).pose.pose.position.x 
                                               << ", y: " << current_waypoints_.at(i).pose.pose.position.y << ", speed: " << current_waypoints_.at(i).twist.twist.linear.x);
-      next_waypoint_number_ = i;
+      next_waypoint_number = i;
       ROS_DEBUG_STREAM(">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>");
-      return;
+      return next_waypoint_number;
     }
 
     // check if the point is in front or back
@@ -260,25 +262,30 @@ void PurePursuit::getNextWaypoint()
       // this also handles the case when waypoint is set for the first time, current_pos_ and previous_pos_ are same
       prev_travelled_vector_ = (prev_travelled_vector_tmp.x() == 0 && prev_travelled_vector_tmp.y() == 0) ? prev_travelled_vector_ : prev_travelled_vector_tmp;
       previous_pose_ = current_pose_;
-      next_waypoint_number_ = i;
+      next_waypoint_number = i;
       ROS_DEBUG_STREAM(">> Following waypoint satisfied all: x: " << current_waypoints_.at(i).pose.pose.position.x 
                                               << ", y: " << current_waypoints_.at(i).pose.pose.position.y << ", speed: " << current_waypoints_.at(i).twist.twist.linear.x);
       ROS_DEBUG_STREAM(">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>");
-      return;
+      return next_waypoint_number;
     }
          
   }
   
   // if this program reaches here , it means we lost the waypoint!
-  next_waypoint_number_ = -1;
+  next_waypoint_number = -1;
   ROS_DEBUG_STREAM(">>>>>>>>>>>>>>>>>>>>>>>Lost the waypoint !>>>>>>>>>>>>>>>>>");
-  return;
+  return next_waypoint_number;
+}
+
+void PurePursuit::setNextWaypoint(int next_waypoint_number)
+{
+  next_waypoint_number_ = next_waypoint_number;
 }
 
 bool PurePursuit::canGetCurvature(double* output_kappa)
 {
   // search next waypoint
-  getNextWaypoint();
+  next_waypoint_number_ = getNextWaypointNumber();
   if (next_waypoint_number_ == -1)
   {
     ROS_INFO("lost next waypoint");

--- a/core_planning/pure_pursuit/src/pure_pursuit.cpp
+++ b/core_planning/pure_pursuit/src/pure_pursuit.cpp
@@ -213,8 +213,6 @@ int PurePursuit::getNextWaypointNumber(bool use_lookahead_distance)
   // look for the next waypoint.
   for (int i = 1; i < path_size; i++)
   {
-    bool min_lookahead_satisfied = false;
-    bool in_front = false;
     // if search waypoint is the last
     if (i == (path_size - 1))
     {
@@ -231,10 +229,15 @@ int PurePursuit::getNextWaypointNumber(bool use_lookahead_distance)
     // waypoint distances first decrease and increase back again, which helps find the closest point   
     if (use_lookahead_distance)
     {
-      // loop through until we hit the closest and effective point
-      if (current_distance < closest_distance || closest_distance < lookahead_distance_)
+      // loop through until we hit the closest point
+      if (current_distance <= closest_distance) 
       {
         closest_distance = current_distance;
+        continue;
+      }
+      // loop through until we hit the closest and effective point
+      if (current_distance < lookahead_distance_)
+      {
         continue;
       }
     }
@@ -258,11 +261,10 @@ int PurePursuit::getNextWaypointNumber(bool use_lookahead_distance)
                       current_waypoints_.at(i).pose.pose.position.y - current_waypoints_.at(i - 1).pose.pose.position.y, 
                       current_waypoints_.at(i).pose.pose.position.z - current_waypoints_.at(i - 1).pose.pose.position.z);
     traj_vector.setZ(0);
-    double angle_in_rad = std::abs(tf::tfAngle(curr_vector, traj_vector));
+    double angle_in_rad = std::fabs(tf::tfAngle(curr_vector, traj_vector));
     // if degree between curr_vector and the direction of the trajectory is more than 90 degrees, we know last point is behind us and unsatisfactory
     if (std::isnan(angle_in_rad) || angle_in_rad > M_PI / 2)
     {
-      closest_distance = current_distance;
       continue;
     }
     next_waypoint_number = i - 1;

--- a/core_planning/pure_pursuit/src/pure_pursuit.cpp
+++ b/core_planning/pure_pursuit/src/pure_pursuit.cpp
@@ -212,7 +212,7 @@ void PurePursuit::getNextWaypoint()
   {
     bool min_distance_satisfied = false;
     bool in_front = false;
-    std:: cerr << "prev_travelled" << prev_travelled_vector_.x() << std::endl;
+    std:: cerr << "prev_travelled: " << prev_travelled_vector_.x() << std::endl;
     // if search waypoint is the last
     if (i == (path_size - 1))
     {
@@ -221,14 +221,17 @@ void PurePursuit::getNextWaypoint()
       next_waypoint_number_ = i;
       return;
     }
+    std::cerr << "prev pos " << previous_pose_.position.x << "\n";
     std::cerr << "curr pos " << current_pose_.position.x << "\n";
-    std::cerr << "curr vec " << current_waypoints_.at(i).pose.pose.position.x << "\n";
 
     // check if the point is in front or back
     tf::Vector3 curr_vector(current_waypoints_.at(i).pose.pose.position.x - current_pose_.position.x, 
                       current_waypoints_.at(i).pose.pose.position.y - current_pose_.position.y, 
                       current_waypoints_.at(i).pose.pose.position.z - current_pose_.position.z);
     curr_vector.setZ(0);
+
+    std::cerr << "curr vec x:" << curr_vector.x() << "\n";
+    std::cerr << "curr vec y:" << curr_vector.y() << "\n";
 
     // if there exists an effective waypoint
     if (getPlaneDistance(
@@ -253,7 +256,14 @@ void PurePursuit::getNextWaypoint()
 
     if (min_distance_satisfied && in_front)
     {
-      prev_travelled_vector_ = curr_vector;
+      tf::Vector3 prev_travelled_vector_tmp(current_pose_.position.x - previous_pose_.position.x, 
+                      current_pose_.position.y - previous_pose_.position.y, 
+                      current_pose_.position.z - previous_pose_.position.z);
+      prev_travelled_vector_tmp.setZ(0);
+      // if current pose did not change, we don't change the previous vector direction
+      // this also handles the case when waypoint is set for the first time, current_pos_ and previous_pos_ are same
+      prev_travelled_vector_ = (prev_travelled_vector_tmp.x() == 0 && prev_travelled_vector_tmp.y() == 0) ? prev_travelled_vector_ : prev_travelled_vector_tmp;
+      previous_pose_ = current_pose_;
       next_waypoint_number_ = i;
       std::cerr << "set next_waypoint to " << i << "\n";
       return;

--- a/core_planning/pure_pursuit/src/pure_pursuit.cpp
+++ b/core_planning/pure_pursuit/src/pure_pursuit.cpp
@@ -240,8 +240,8 @@ int PurePursuit::getNextWaypointNumber()
       ROS_DEBUG_STREAM(">> Would have picked wp at following: x: " << current_waypoints_.at(i).pose.pose.position.x 
                                               << ", y: " << current_waypoints_.at(i).pose.pose.position.y << ", speed: " << current_waypoints_.at(i).twist.twist.linear.x * 2.23694 << "mph");
       ROS_DEBUG_STREAM(">> Where current position is x: " << current_pose_.position.x << ", y: " << current_pose_.position.y);
+      ROS_DEBUG_STREAM(">> Angle degrees: "  << std::abs(tf::tfAngle(curr_vector, prev_travelled_vector_) / M_PI * 180));
     }
-    ROS_DEBUG_STREAM(">> Angle degrees: "  << std::abs(tf::tfAngle(curr_vector, prev_travelled_vector_) / M_PI * 180));
 
     //else we check if trajectory is not turning more than 90 deg instantaneously than its previous direction
     if (std::abs(tf::tfAngle(curr_vector, prev_travelled_vector_)) < M_PI / 2)

--- a/core_planning/pure_pursuit/src/pure_pursuit.cpp
+++ b/core_planning/pure_pursuit/src/pure_pursuit.cpp
@@ -220,7 +220,7 @@ int PurePursuit::getNextWaypointNumber()
       ROS_DEBUG_STREAM(">> Search waypoint reached the last: x: " << current_waypoints_.at(i).pose.pose.position.x 
                                               << ", y: " << current_waypoints_.at(i).pose.pose.position.y << ", speed: " << current_waypoints_.at(i).twist.twist.linear.x * 2.23694 << "mph");
       next_waypoint_number = i;
-      std::cerr << ">> Search waypoint reached the last: x: " << current_waypoints_.at(i).pose.pose.position.x 
+      //std::cerr << ">> Search waypoint reached the last: x: " << current_waypoints_.at(i).pose.pose.position.x 
                                               << ", y: " << current_waypoints_.at(i).pose.pose.position.y << ", speed: " << current_waypoints_.at(i).twist.twist.linear.x * 2.23694 << "mph" <<std::endl;
       ROS_DEBUG_STREAM(">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>");
       return next_waypoint_number;
@@ -252,17 +252,17 @@ int PurePursuit::getNextWaypointNumber()
     ROS_DEBUG_STREAM(">> Where next traj position is x: " << current_waypoints_.at(i ).pose.pose.position.x << ", y: " << current_waypoints_.at(i).pose.pose.position.y);
     ROS_DEBUG_STREAM(">> Angle degrees: "  << std::abs(tf::tfAngle(curr_vector, traj_vector) / M_PI * 180));
 
-    std::cerr << ">> Would have picked wp at following: x: " << current_waypoints_.at(i - 1).pose.pose.position.x 
+    //std::cerr << ">> Would have picked wp at following: x: " << current_waypoints_.at(i - 1).pose.pose.position.x 
                                             << ", y: " << current_waypoints_.at(i - 1).pose.pose.position.y << ", speed: " << current_waypoints_.at(i - 1).twist.twist.linear.x * 2.23694 << "mph" <<std::endl;
-    std::cerr << ">> Where current position is x: " << current_pose_.position.x << ", y: " << current_pose_.position.y <<std::endl;
-    std::cerr << ">> Where next traj position is x: " << current_waypoints_.at(i).pose.pose.position.x << ", y: " << current_waypoints_.at(i).pose.pose.position.y << std::endl;
-    std::cerr << ">> Angle degrees: "  << std::abs(tf::tfAngle(curr_vector, traj_vector) / M_PI * 180) <<std::endl;
+    //std::cerr << ">> Where current position is x: " << current_pose_.position.x << ", y: " << current_pose_.position.y <<std::endl;
+    //std::cerr << ">> Where next traj position is x: " << current_waypoints_.at(i).pose.pose.position.x << ", y: " << current_waypoints_.at(i).pose.pose.position.y << std::endl;
+    //std::cerr << ">> Angle degrees: "  << std::abs(tf::tfAngle(curr_vector, traj_vector) / M_PI * 180) <<std::endl;
 
     // if degree between curr_vector and the direction of the trajectory is more than 90 degrees, we know last point is behind us.
     if (std::abs(tf::tfAngle(curr_vector, traj_vector)) > M_PI / 2)
     {
       ROS_DEBUG_STREAM(">>>>>!!!! Did not satisfy angle requirement!" << std::abs(tf::tfAngle(curr_vector, traj_vector) / M_PI * 180));
-      std::cerr << ">>>>>!!!! Did not satisfy angle requirement!" << std::abs(tf::tfAngle(curr_vector, traj_vector) / M_PI * 180) <<std::endl;
+      //std::cerr << ">>>>>!!!! Did not satisfy angle requirement!" << std::abs(tf::tfAngle(curr_vector, traj_vector) / M_PI * 180) <<std::endl;
       
       closest_distance = current_distance;
       continue;
@@ -271,9 +271,9 @@ int PurePursuit::getNextWaypointNumber()
     ROS_DEBUG_STREAM(">> ***** Following waypoint satisfied all: x: " << current_waypoints_.at(i - 1).pose.pose.position.x 
                                             << ", y: " << current_waypoints_.at(i - 1).pose.pose.position.y << ", speed: " << current_waypoints_.at(i - 1).twist.twist.linear.x * 2.23694 << "mph");
     ROS_DEBUG_STREAM(">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>");
-    std::cerr << ">> ***** Following waypoint satisfied all: x: " << current_waypoints_.at(i - 1).pose.pose.position.x 
+    //std::cerr << ">> ***** Following waypoint satisfied all: x: " << current_waypoints_.at(i - 1).pose.pose.position.x 
                                             << ", y: " << current_waypoints_.at(i - 1).pose.pose.position.y << ", speed: " << current_waypoints_.at(i - 1).twist.twist.linear.x * 2.23694 << "mph" <<std::endl;
-    std::cerr << ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"<<std::endl;
+    //std::cerr << ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"<<std::endl;
     return next_waypoint_number;
   }
   

--- a/core_planning/pure_pursuit/src/pure_pursuit.cpp
+++ b/core_planning/pure_pursuit/src/pure_pursuit.cpp
@@ -253,7 +253,7 @@ int PurePursuit::getNextWaypointNumber()
     ROS_DEBUG_STREAM(">> Angle degrees: "  << std::abs(tf::tfAngle(curr_vector, traj_vector) / M_PI * 180));
 
     //std::cerr << ">> Would have picked wp at following: x: " << current_waypoints_.at(i - 1).pose.pose.position.x 
-                                            << ", y: " << current_waypoints_.at(i - 1).pose.pose.position.y << ", speed: " << current_waypoints_.at(i - 1).twist.twist.linear.x * 2.23694 << "mph" <<std::endl;
+    //                                        << ", y: " << current_waypoints_.at(i - 1).pose.pose.position.y << ", speed: " << current_waypoints_.at(i - 1).twist.twist.linear.x * 2.23694 << "mph" <<std::endl;
     //std::cerr << ">> Where current position is x: " << current_pose_.position.x << ", y: " << current_pose_.position.y <<std::endl;
     //std::cerr << ">> Where next traj position is x: " << current_waypoints_.at(i).pose.pose.position.x << ", y: " << current_waypoints_.at(i).pose.pose.position.y << std::endl;
     //std::cerr << ">> Angle degrees: "  << std::abs(tf::tfAngle(curr_vector, traj_vector) / M_PI * 180) <<std::endl;

--- a/core_planning/pure_pursuit/src/pure_pursuit_core.cpp
+++ b/core_planning/pure_pursuit/src/pure_pursuit_core.cpp
@@ -307,12 +307,7 @@ void PurePursuitNode::callbackFromWayPoints(
   // we skip 0 because it is our current position
   if (next_waypoint_number != -1 && next_waypoint_number + 1 < pp_.getCurrentWaypoints().size())
   {
-    tf::Vector3 curr_vector(current_waypoints_.at(next_waypoint_number + 1).pose.pose.position.x - current_pose_.position.x, 
-                    current_waypoints_.at(next_waypoint_number + 1).pose.pose.position.y - current_pose_.position.y, 
-                    current_waypoints_.at(next_waypoint_number + 1).pose.pose.position.z - current_pose_.position.z);
-    previous_pose_ = current_pose_;
-    curr_vector.setZ(0);
-    prev_travelled_vector_ = curr_vector;
+    pp_.initializeUsingNextWaypoint(next_waypoint_number);
     command_linear_velocity_ =
       (!msg->waypoints.empty()) ? pp_.getCurrentWaypoints().at(next_waypoint_number).twist.twist.linear.x : 0;
   }

--- a/core_planning/pure_pursuit/src/pure_pursuit_core.cpp
+++ b/core_planning/pure_pursuit/src/pure_pursuit_core.cpp
@@ -296,6 +296,7 @@ void PurePursuitNode::callbackFromWayPoints(
     expand_size_ = -expanded_lane.waypoints.size();
     connectVirtualLastWaypoints(&expanded_lane, direction_);
     expand_size_ += expanded_lane.waypoints.size();
+    std::cerr << "set waypoints with min_lookahead:" << minimum_lookahead_distance_ << std::endl;
 
     pp_.setCurrentWaypoints(expanded_lane.waypoints);
   }
@@ -304,6 +305,12 @@ void PurePursuitNode::callbackFromWayPoints(
     pp_.setCurrentWaypoints(msg->waypoints);
   }
   is_waypoint_set_ = true;
+  std::cerr << "Printing current waypoints set!\n";
+  for (auto wp : pp_.getCurrentWaypoints())
+  {
+    std::cerr << wp.pose.pose.position.x << " ";
+  }
+  std::cerr << std::endl;
 }
 
 void PurePursuitNode::connectVirtualLastWaypoints(
@@ -329,10 +336,22 @@ void PurePursuitNode::connectVirtualLastWaypoints(
   }
 }
 
+geometry_msgs::Point PurePursuitNode::getPoseOfNextWaypoint() const
+{
+  return pp_.getPoseOfNextWaypoint();
+}
+
+void PurePursuitNode::getNextWaypoint()
+{
+  pp_.getNextWaypoint();
+}
+
 double convertCurvatureToSteeringAngle(
   const double& wheel_base, const double& kappa)
 {
   return atan(wheel_base * kappa);
 }
+
+
 
 }  // namespace waypoint_follower

--- a/core_planning/pure_pursuit/src/pure_pursuit_core.cpp
+++ b/core_planning/pure_pursuit/src/pure_pursuit_core.cpp
@@ -303,11 +303,8 @@ void PurePursuitNode::callbackFromWayPoints(
   }
   is_waypoint_set_ = true;
   int next_waypoint_number = pp_.getNextWaypointNumber();
-    // check if the point is in front or back
-  // we skip 0 because it is our current position
-  if (next_waypoint_number != -1 && next_waypoint_number + 1 < pp_.getCurrentWaypoints().size())
+  if (next_waypoint_number != -1)
   {
-    pp_.initializeUsingNextWaypoint(next_waypoint_number);
     command_linear_velocity_ =
       (!msg->waypoints.empty()) ? pp_.getCurrentWaypoints().at(next_waypoint_number).twist.twist.linear.x : 0;
   }

--- a/core_planning/pure_pursuit/src/pure_pursuit_core.cpp
+++ b/core_planning/pure_pursuit/src/pure_pursuit_core.cpp
@@ -305,7 +305,9 @@ void PurePursuitNode::callbackFromWayPoints(
   int next_waypoint_number = pp_.getNextWaypointNumber();
   command_linear_velocity_ =
     (!msg->waypoints.empty()) ? pp_.getCurrentWaypoints().at(next_waypoint_number).twist.twist.linear.x : 0;
+  ROS_DEBUG_STREAM("||||||||| Set actual command_linear_velocity_: " << command_linear_velocity_ * 2.23694 << "mph");
 }
+
 
 void PurePursuitNode::connectVirtualLastWaypoints(
   autoware_msgs::Lane* lane, LaneDirection direction)

--- a/core_planning/pure_pursuit/src/pure_pursuit_core.cpp
+++ b/core_planning/pure_pursuit/src/pure_pursuit_core.cpp
@@ -302,7 +302,7 @@ void PurePursuitNode::callbackFromWayPoints(
     pp_.setCurrentWaypoints(msg->waypoints);
   }
   is_waypoint_set_ = true;
-  // lookahead distance is not needed as we are checking waypoint that is at immediate front of the vehicle.
+  // lookahead distance is not needed as we are checking waypoint that is at immediately front of the vehicle.
   int next_waypoint_number = pp_.getNextWaypointNumber(false);
   if (next_waypoint_number != -1)
   {

--- a/core_planning/pure_pursuit/src/pure_pursuit_core.cpp
+++ b/core_planning/pure_pursuit/src/pure_pursuit_core.cpp
@@ -302,7 +302,7 @@ void PurePursuitNode::callbackFromWayPoints(
     pp_.setCurrentWaypoints(msg->waypoints);
   }
   is_waypoint_set_ = true;
-  int next_waypoint_number = pp_.getNextWaypointNumber();
+  int next_waypoint_number = pp_.getNextWaypointNumberForSpeed();
   if (next_waypoint_number != -1)
   {
     command_linear_velocity_ =

--- a/core_planning/pure_pursuit/src/pure_pursuit_core.cpp
+++ b/core_planning/pure_pursuit/src/pure_pursuit_core.cpp
@@ -286,8 +286,7 @@ void PurePursuitNode::callbackFromCurrentVelocity(
 void PurePursuitNode::callbackFromWayPoints(
   const autoware_msgs::LaneConstPtr& msg)
 {
-  command_linear_velocity_ =
-    (!msg->waypoints.empty()) ? msg->waypoints.at(0).twist.twist.linear.x : 0;
+  
   if (add_virtual_end_waypoints_)
   {
     const LaneDirection solved_dir = getLaneDirection(*msg);
@@ -296,8 +295,6 @@ void PurePursuitNode::callbackFromWayPoints(
     expand_size_ = -expanded_lane.waypoints.size();
     connectVirtualLastWaypoints(&expanded_lane, direction_);
     expand_size_ += expanded_lane.waypoints.size();
-    std::cerr << "set waypoints with min_lookahead:" << minimum_lookahead_distance_ << std::endl;
-
     pp_.setCurrentWaypoints(expanded_lane.waypoints);
   }
   else
@@ -305,12 +302,9 @@ void PurePursuitNode::callbackFromWayPoints(
     pp_.setCurrentWaypoints(msg->waypoints);
   }
   is_waypoint_set_ = true;
-  std::cerr << "Printing current waypoints set!\n";
-  for (auto wp : pp_.getCurrentWaypoints())
-  {
-    std::cerr << wp.pose.pose.position.x << " ";
-  }
-  std::cerr << std::endl;
+  int next_waypoint_number = pp_.getNextWaypointNumber();
+  command_linear_velocity_ =
+    (!msg->waypoints.empty()) ? pp_.getCurrentWaypoints().at(next_waypoint_number).twist.twist.linear.x : 0;
 }
 
 void PurePursuitNode::connectVirtualLastWaypoints(
@@ -343,7 +337,8 @@ geometry_msgs::Point PurePursuitNode::getPoseOfNextWaypoint() const
 
 void PurePursuitNode::getNextWaypoint()
 {
-  pp_.getNextWaypoint();
+  int next_waypoint_number = pp_.getNextWaypointNumber();
+  pp_.setNextWaypoint(next_waypoint_number);
 }
 
 double convertCurvatureToSteeringAngle(

--- a/core_planning/pure_pursuit/src/pure_pursuit_core.cpp
+++ b/core_planning/pure_pursuit/src/pure_pursuit_core.cpp
@@ -302,7 +302,8 @@ void PurePursuitNode::callbackFromWayPoints(
     pp_.setCurrentWaypoints(msg->waypoints);
   }
   is_waypoint_set_ = true;
-  int next_waypoint_number = pp_.getNextWaypointNumberForSpeed();
+  // lookahead distance is not needed as we are checking waypoint that is at immediate front of the vehicle.
+  int next_waypoint_number = pp_.getNextWaypointNumber(false);
   if (next_waypoint_number != -1)
   {
     command_linear_velocity_ =
@@ -310,12 +311,9 @@ void PurePursuitNode::callbackFromWayPoints(
   }
   else
   {
-    ROS_ERROR_STREAM("We are putting 0 speed because next_waypoint did not satisfy!!!");
-    ROS_ERROR_STREAM("next wp:" << next_waypoint_number << " wp size: "<< pp_.getCurrentWaypoints().size());
+    ROS_WARN_STREAM("Pure pursuit is applying 0mph speed because it could not find satisfactory next_waypoint");
     command_linear_velocity_ = 0;
   }
-  
-  ROS_DEBUG_STREAM("||||||||| Set actual command_linear_velocity_: " << command_linear_velocity_ * 2.23694 << "mph");
 }
 
 

--- a/core_planning/pure_pursuit/src/pure_pursuit_core.cpp
+++ b/core_planning/pure_pursuit/src/pure_pursuit_core.cpp
@@ -345,7 +345,7 @@ geometry_msgs::Point PurePursuitNode::getPoseOfNextWaypoint() const
   return pp_.getPoseOfNextWaypoint();
 }
 
-void PurePursuitNode::getNextWaypoint()
+void PurePursuitNode::calculateNextWaypoint()
 {
   int next_waypoint_number = pp_.getNextWaypointNumber();
   pp_.setNextWaypoint(next_waypoint_number);

--- a/core_planning/pure_pursuit/test/src/test_pure_pursuit.cpp
+++ b/core_planning/pure_pursuit/test/src/test_pure_pursuit.cpp
@@ -20,6 +20,15 @@
 
 namespace waypoint_follower
 {
+  geometry_msgs::PoseStamped generateCurrentPose(double x, double y, double yaw)
+  {
+    geometry_msgs::PoseStamped pose;
+    pose.pose.position.x = x;
+    pose.pose.position.y = y;
+    tf::Quaternion quaternion = tf::createQuaternionFromRPY(0, 0, yaw);
+    quaternionTFToMsg(quaternion, pose.pose.orientation);
+    return std::move(pose);
+  }
 class PurePursuitNodeTestSuite : public ::testing::Test
 {
 protected:
@@ -65,7 +74,7 @@ public:
   }
   void ASSERT_NEXT_WP_POSE_USING_CURR_POSE(double curr_pose_x, double curr_pose_y, double next_wp_pose_x, double next_wp_pose_y)
   {
-    geometry_msgs::PoseStamped pose = generateCurrentPose(curr_pose_x, curr_pose_y, 0);
+    geometry_msgs::PoseStamped pose = waypoint_follower::generateCurrentPose(curr_pose_x, curr_pose_y, 0);
     geometry_msgs::PoseStampedConstPtr pose_ptr = boost::make_shared<const geometry_msgs::PoseStamped>(pose);
     ppcallbackFromCurrentPose(pose_ptr);
     ppgetNextWaypoint();
@@ -75,15 +84,7 @@ public:
   }
 };
 
-geometry_msgs::PoseStamped generateCurrentPose(double x, double y, double yaw)
-{
-  geometry_msgs::PoseStamped pose;
-  pose.pose.position.x = x;
-  pose.pose.position.y = y;
-  tf::Quaternion quaternion = tf::createQuaternionFromRPY(0, 0, yaw);
-  quaternionTFToMsg(quaternion, pose.pose.orientation);
-  return std::move(pose);
-}
+
 
 TEST_F(PurePursuitNodeTestSuite, inputPositivePath)
 {
@@ -191,10 +192,6 @@ TEST_F(PurePursuitNodeTestSuite, checkWaypointIsAheadOrBehind)
   ASSERT_NEXT_WP_POSE_USING_CURR_POSE(1.9, 0, 2, 0);
 
   ASSERT_NEXT_WP_POSE_USING_CURR_POSE(2.5, 0, 4, 0);
-
-  ASSERT_NEXT_WP_POSE_USING_CURR_POSE()
-
-  ASSERT_NEXT_WP_POSE_USING_CURR_POSE();
 
 }
 

--- a/core_planning/pure_pursuit/test/src/test_pure_pursuit.cpp
+++ b/core_planning/pure_pursuit/test/src/test_pure_pursuit.cpp
@@ -79,6 +79,8 @@ public:
     ppcallbackFromCurrentPose(pose_ptr);
     ppgetNextWaypoint();
     auto next_wp_pose_calculated = ppGetPoseOfNextWaypoint();
+    std::cerr << "current point x:" << curr_pose_x << ",y :" << curr_pose_y <<std::endl;
+    std::cerr << "next point calculated x:" << next_wp_pose_calculated.x << ",y :" << next_wp_pose_calculated.y <<std::endl;
     ASSERT_NEAR(next_wp_pose_calculated.x, next_wp_pose_x, 0.0001);
     ASSERT_NEAR(next_wp_pose_calculated.y, next_wp_pose_y, 0.0001);
   }
@@ -157,16 +159,14 @@ TEST_F(PurePursuitNodeTestSuite, inputNormalLane)
     << "Fail to expand waypoints";
 }
 
-// Waypoints are constantly reset whenever new one is received.
-// On new update, and new car's position, a point already travelled can be selected as next waypoint
-// We simulate that by inserting previously checked point again.
+
 TEST_F(PurePursuitNodeTestSuite, checkWaypointIsAheadOrBehind)
 {  
   /*
   *           2.             |3  x. > x-th waypoint coordinate 
   *                          |2  
   *                          |1
-  *  0. 1.          4.    3. |0
+  *  0. 1.          3.    4. |0
   * ------------------------ y 
   *x 0  1  2  3  4  5  6  7   
   */
@@ -177,8 +177,8 @@ TEST_F(PurePursuitNodeTestSuite, checkWaypointIsAheadOrBehind)
   original_lane.waypoints[1].pose.pose.position.x = 1;
   original_lane.waypoints[2].pose.pose.position.x = 3; 
   original_lane.waypoints[2].pose.pose.position.y = 3; 
-  original_lane.waypoints[3].pose.pose.position.x = 7; 
-  original_lane.waypoints[4].pose.pose.position.x = 5; // forcing invalid trajectory that essentially means U turnsssssss
+  original_lane.waypoints[3].pose.pose.position.x = 5;
+  original_lane.waypoints[4].pose.pose.position.x = 7;  
   original_lane.waypoints[0].pose.pose.orientation =
       tf::createQuaternionMsgFromYaw(0.0);
   original_lane.waypoints[1].pose.pose.orientation =
@@ -199,15 +199,15 @@ TEST_F(PurePursuitNodeTestSuite, checkWaypointIsAheadOrBehind)
   ppCallbackFromWayPoints(lp);
   ppgetNextWaypoint();
 
-  // following simulates the car going straight on x coord
+  // following simulates the car going straight on x coord, 1D
   // despite the waypoint being in 2D to test the angles
   ASSERT_NEAR(ppGetPoseOfNextWaypoint().x, 0, 0.001);
 
   ASSERT_NEAR_NEXT_WP_POSE_USING_CURR_POSE(0.95, 0, 1, 0); // closest next waypoint is 1. (<1,0> 0 degrees ahead): qualified
 
-  ASSERT_NEAR_NEXT_WP_POSE_USING_CURR_POSE(2.95, 0, 3, 3); // closest next waypoint is 2. (<3,3> little less than 90 degrees ahead): qualified
+  ASSERT_NEAR_NEXT_WP_POSE_USING_CURR_POSE(2.95, 0, 5, 0); // closest next waypoint is 2. (<3,3> little less than 90 degrees ahead): qualified
 
-  ASSERT_NEAR_NEXT_WP_POSE_USING_CURR_POSE(3.15, 0, 7, 0); // closest next waypoint is 2. (<3,3> little more than 90 degrees ahead): disqualified
+  ASSERT_NEAR_NEXT_WP_POSE_USING_CURR_POSE(3.15, 0, 5, 0); // closest next waypoint is 2. (<3,3> little more than 90 degrees ahead): disqualified
                                                                                     // so picked 3. (<7,0> 0 degrees ahead): qualified
 
   ASSERT_NEAR_NEXT_WP_POSE_USING_CURR_POSE(6.95, 0, 7, 0); // closest next waypoint is 3. (<7,0> 0 degrees ahead): qualified

--- a/core_planning/pure_pursuit/test/src/test_pure_pursuit.cpp
+++ b/core_planning/pure_pursuit/test/src/test_pure_pursuit.cpp
@@ -64,9 +64,9 @@ public:
   {
     obj_->callbackFromCurrentPose(msg);
   }
-  void ppgetNextWaypoint()
+  void ppcalculateNextWaypoint()
   {
-    obj_->getNextWaypoint();
+    obj_->calculateNextWaypoint();
   }
   geometry_msgs::Point ppGetPoseOfNextWaypoint() const
   {
@@ -77,7 +77,7 @@ public:
     geometry_msgs::PoseStamped pose = waypoint_follower::generateCurrentPose(curr_pose_x, curr_pose_y, 0);
     geometry_msgs::PoseStampedConstPtr pose_ptr = boost::make_shared<const geometry_msgs::PoseStamped>(pose);
     ppcallbackFromCurrentPose(pose_ptr);
-    ppgetNextWaypoint();
+    ppcalculateNextWaypoint();
     auto next_wp_pose_calculated = ppGetPoseOfNextWaypoint();
     ASSERT_NEAR(next_wp_pose_calculated.x, next_wp_pose_x, 0.0001);
     ASSERT_NEAR(next_wp_pose_calculated.y, next_wp_pose_y, 0.0001);
@@ -88,7 +88,7 @@ public:
     geometry_msgs::PoseStamped pose = waypoint_follower::generateCurrentPose(curr_pose_x, curr_pose_y, 0);
     geometry_msgs::PoseStampedConstPtr pose_ptr = boost::make_shared<const geometry_msgs::PoseStamped>(pose);
     ppcallbackFromCurrentPose(pose_ptr);
-    ppgetNextWaypoint();
+    ppcalculateNextWaypoint();
     auto next_wp_pose_calculated = ppGetPoseOfNextWaypoint();
     ASSERT_FALSE(std::abs(next_wp_pose_calculated.x - next_wp_pose_x) < 0.001);
   }
@@ -194,7 +194,7 @@ TEST_F(PurePursuitNodeTestSuite, checkWaypointIsAheadOrBehind)
   const autoware_msgs::LaneConstPtr
     lp(boost::make_shared<autoware_msgs::Lane>(original_lane));
   ppCallbackFromWayPoints(lp);
-  ppgetNextWaypoint();
+  ppcalculateNextWaypoint();
 
   // following simulates the car going straight on x coord, 1D
   // despite the waypoint being in 2D to test the angles

--- a/core_planning/pure_pursuit/test/src/test_pure_pursuit.cpp
+++ b/core_planning/pure_pursuit/test/src/test_pure_pursuit.cpp
@@ -79,8 +79,6 @@ public:
     ppcallbackFromCurrentPose(pose_ptr);
     ppgetNextWaypoint();
     auto next_wp_pose_calculated = ppGetPoseOfNextWaypoint();
-    std::cerr << "current point x:" << curr_pose_x << ",y :" << curr_pose_y <<std::endl;
-    std::cerr << "next point calculated x:" << next_wp_pose_calculated.x << ",y :" << next_wp_pose_calculated.y <<std::endl;
     ASSERT_NEAR(next_wp_pose_calculated.x, next_wp_pose_x, 0.0001);
     ASSERT_NEAR(next_wp_pose_calculated.y, next_wp_pose_y, 0.0001);
   }
@@ -93,7 +91,6 @@ public:
     ppgetNextWaypoint();
     auto next_wp_pose_calculated = ppGetPoseOfNextWaypoint();
     ASSERT_FALSE(std::abs(next_wp_pose_calculated.x - next_wp_pose_x) < 0.001);
-    ASSERT_FALSE(std::abs(next_wp_pose_calculated.y - next_wp_pose_y) < 0.001);
   }
 };
 
@@ -172,7 +169,7 @@ TEST_F(PurePursuitNodeTestSuite, checkWaypointIsAheadOrBehind)
   */
   
   autoware_msgs::Lane original_lane;
-  original_lane.waypoints.resize(8, autoware_msgs::Waypoint());
+  original_lane.waypoints.resize(4, autoware_msgs::Waypoint());
   original_lane.waypoints[0].pose.pose.position.x = 0;
   original_lane.waypoints[1].pose.pose.position.x = 1;
   original_lane.waypoints[2].pose.pose.position.x = 3; 
@@ -205,15 +202,13 @@ TEST_F(PurePursuitNodeTestSuite, checkWaypointIsAheadOrBehind)
 
   ASSERT_NEAR_NEXT_WP_POSE_USING_CURR_POSE(0.95, 0, 1, 0); // closest next waypoint is 1. (<1,0> 0 degrees ahead): qualified
 
-  ASSERT_NEAR_NEXT_WP_POSE_USING_CURR_POSE(2.95, 0, 5, 0); // closest next waypoint is 2. (<3,3> little less than 90 degrees ahead): qualified
+  ASSERT_NEAR_NEXT_WP_POSE_USING_CURR_POSE(2.95, 0, 5, 0); // closest next waypoint is 2. (<3,3> angle is 123.69): disqualified
+                                                                                    // so picked 3. (<5,0> 0 degrees ahead): qualified
+  ASSERT_NEAR_NEXT_WP_POSE_USING_CURR_POSE(3.15, 0, 5, 0); // closest next waypoint is 3. qualified
 
-  ASSERT_NEAR_NEXT_WP_POSE_USING_CURR_POSE(3.15, 0, 5, 0); // closest next waypoint is 2. (<3,3> little more than 90 degrees ahead): disqualified
-                                                                                    // so picked 3. (<7,0> 0 degrees ahead): qualified
+  ASSERT_NEAR_NEXT_WP_POSE_USING_CURR_POSE(6.95, 0, 7, 0); // closest next waypoint is 4. (<7,0> 0 degrees ahead): qualified
 
-  ASSERT_NEAR_NEXT_WP_POSE_USING_CURR_POSE(6.95, 0, 7, 0); // closest next waypoint is 3. (<7,0> 0 degrees ahead): qualified
-
-  ASSERT_NOT_NEAR_NEXT_WP_POSE_USING_CURR_POSE(7.95, 0, 7, 0); //  closest next waypoint is 3. (<7,0> 180 degrees ahead): disqualified
-  ASSERT_NOT_NEAR_NEXT_WP_POSE_USING_CURR_POSE(7.95, 0, 5, 0); //  another next waypoint is 4. (<5,0> 180 degrees ahead): disqualified
+  ASSERT_NOT_NEAR_NEXT_WP_POSE_USING_CURR_POSE(7.95, 0, 7, 0); //  closest next waypoint is 5 (auto generated), not 4
 }
 
 }  // namespace waypoint_follower

--- a/core_planning/pure_pursuit/test/src/test_pure_pursuit.cpp
+++ b/core_planning/pure_pursuit/test/src/test_pure_pursuit.cpp
@@ -162,6 +162,15 @@ TEST_F(PurePursuitNodeTestSuite, inputNormalLane)
 // We simulate that by inserting previously checked point again.
 TEST_F(PurePursuitNodeTestSuite, checkWaypointIsAheadOrBehind)
 {  
+  /*
+  *           2.             |3  x. > x-th waypoint coordinate 
+  *                          |2  
+  *                          |1
+  *  0. 1.          4.    3. |0
+  * ------------------------ y 
+  *x 0  1  2  3  4  5  6  7   
+  */
+  
   autoware_msgs::Lane original_lane;
   original_lane.waypoints.resize(8, autoware_msgs::Waypoint());
   original_lane.waypoints[0].pose.pose.position.x = 0;
@@ -189,18 +198,22 @@ TEST_F(PurePursuitNodeTestSuite, checkWaypointIsAheadOrBehind)
     lp(boost::make_shared<autoware_msgs::Lane>(original_lane));
   ppCallbackFromWayPoints(lp);
   ppgetNextWaypoint();
+
+  // following simulates the car going straight on x coord
+  // despite the waypoint being in 2D to test the angles
   ASSERT_NEAR(ppGetPoseOfNextWaypoint().x, 0, 0.001);
 
-  ASSERT_NEAR_NEXT_WP_POSE_USING_CURR_POSE(0.95, 0, 1, 0);
+  ASSERT_NEAR_NEXT_WP_POSE_USING_CURR_POSE(0.95, 0, 1, 0); // closest next waypoint is 1. (<1,0> 0 degrees ahead): qualified
 
-  ASSERT_NEAR_NEXT_WP_POSE_USING_CURR_POSE(2.95, 0, 3, 3);
+  ASSERT_NEAR_NEXT_WP_POSE_USING_CURR_POSE(2.95, 0, 3, 3); // closest next waypoint is 2. (<3,3> little less than 90 degrees ahead): qualified
 
-  ASSERT_NEAR_NEXT_WP_POSE_USING_CURR_POSE(5.95, 0, 7, 0);
+  ASSERT_NEAR_NEXT_WP_POSE_USING_CURR_POSE(3.15, 0, 7, 0); // closest next waypoint is 2. (<3,3> little more than 90 degrees ahead): disqualified
+                                                                                    // so picked 3. (<7,0> 0 degrees ahead): qualified
 
-  ASSERT_NEAR_NEXT_WP_POSE_USING_CURR_POSE(6.95, 0, 7, 0);
+  ASSERT_NEAR_NEXT_WP_POSE_USING_CURR_POSE(6.95, 0, 7, 0); // closest next waypoint is 3. (<7,0> 0 degrees ahead): qualified
 
-  ASSERT_NOT_NEAR_NEXT_WP_POSE_USING_CURR_POSE(7.95, 0, 7, 0);
-
+  ASSERT_NOT_NEAR_NEXT_WP_POSE_USING_CURR_POSE(7.95, 0, 7, 0); //  closest next waypoint is 3. (<7,0> 180 degrees ahead): disqualified
+  ASSERT_NOT_NEAR_NEXT_WP_POSE_USING_CURR_POSE(7.95, 0, 5, 0); //  another next waypoint is 4. (<5,0> 180 degrees ahead): disqualified
 }
 
 }  // namespace waypoint_follower


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
**carma-platform/pure_pursuit_wrapper:** 
 - (Same as Mike's branch) Uses the same set of functions and equations to derive the speeds back from traj points and time. So there should be no accuracy problem there.
 - (Same as Mike's branch) It was dropping the first point before, which we don't now.
 - Fixed plan_delegator where it was not setting the initial_velocity when it got the service callback from inlanecruising, which was not making the car move.

**autoware.ai/pure_pursuit:**
- getNextWaypointNumber: should give us the next waypoint that's in front of us:
   - it gets a vector from closest next potential waypoint to its next point in the waypoints.
   - it also gets a vector from current_pose to the next potential waypoint's position and get a vector from it. 
   - it compares the two vectors, and if the angle between them is within 90degrees, it picks that waypoint, otherwise it continues to check the following waypoints which increase in distance.
- everytime new waypoints are set, the pure_pursuit uses the above function to get the next-waypoint (which was hardcoded as first point before) and uses that point's speed.

## Related Issue
https://github.com/usdot-fhwa-stol/carma-platform/issues/1015
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
See above issue.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
unit tested and integration tested on black pacifica.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
