### PR TITLE
removing lookahead params at launch purepursuit

### DIFF
--- a/autoware/docs/quick_start/my_motion_planning.launch
+++ b/autoware/docs/quick_start/my_motion_planning.launch
@@ -12,7 +12,7 @@
   <!-- pure_pursuit -->
   <node pkg="rostopic" type="rostopic" name="config_waypoint_follower_rostopic"
         args="pub -l /config/waypoint_follower autoware_msgs/ConfigWaypointFollower
-        '{ header: auto, param_flag: 1, velocity: 5.0, lookahead_distance: 4.0, lookahead_ratio: 2.0, minimum_lookahead_distance: 6.0, displacement_threshold: 0.0, relative_angle_threshold: 0.0 }' "
+        '{ header: auto, param_flag: 1, velocity: 5.0, displacement_threshold: 0.0, relative_angle_threshold: 0.0 }' "
   />
   <include file="$(find waypoint_follower)/launch/pure_pursuit.launch"/>
 

--- a/core_planning/pure_pursuit/include/pure_pursuit/pure_pursuit_core.h
+++ b/core_planning/pure_pursuit/include/pure_pursuit/pure_pursuit_core.h
@@ -80,6 +80,8 @@ private:
 
   // constant
   const int LOOP_RATE_;  // processing frequency
+  const int DEFAULT_VELOCITY_SOURCE_ = 0;
+  const double DEFAULT_CONST_VELOCITY_ = 5.0;
 
   // variables
   bool is_linear_interpolation_, publishes_for_steering_robot_,
@@ -97,8 +99,6 @@ private:
   double minimum_lookahead_distance_;
 
   // callbacks
-  void callbackFromConfig(
-    const autoware_config_msgs::ConfigWaypointFollowerConstPtr& config);
   void callbackFromCurrentPose(const geometry_msgs::PoseStampedConstPtr& msg);
   void callbackFromCurrentVelocity(
     const geometry_msgs::TwistStampedConstPtr& msg);

--- a/core_planning/pure_pursuit/include/pure_pursuit/pure_pursuit_core.h
+++ b/core_planning/pure_pursuit/include/pure_pursuit/pure_pursuit_core.h
@@ -76,7 +76,7 @@ private:
     pub11_, pub12_, pub13_, pub14_, pub15_, pub16_, pub17_, pub18_;
 
   // subscriber
-  ros::Subscriber sub1_, sub2_, sub3_, sub4_;
+  ros::Subscriber sub1_, sub2_, sub3_;
 
   // constant
   const int LOOP_RATE_;  // processing frequency

--- a/core_planning/pure_pursuit/launch/pure_pursuit.launch
+++ b/core_planning/pure_pursuit/launch/pure_pursuit.launch
@@ -7,7 +7,8 @@
   <arg name="const_velocity" default="5.0"/>
   <arg name="lookahead_ratio" default="2.0"/>
   <arg name="minimum_lookahead_distance" default="6.0"/>
-
+  <arg name="vehicle_wheel_base" default="2.79"/>
+  
   <!-- 0 = waypoints, 1 = provided constant velocity -->
   <arg name="velocity_source" default="0"/>
 

--- a/core_planning/pure_pursuit/launch/pure_pursuit.launch
+++ b/core_planning/pure_pursuit/launch/pure_pursuit.launch
@@ -21,5 +21,6 @@
     <param name="lookahead_ratio" value="$(arg lookahead_ratio)"/>
     <param name="minimum_lookahead_distance" value="$(arg minimum_lookahead_distance)"/>
     <param name="velocity_source" value="$(arg velocity_source)"/>
+    <param name="vehicle_wheel_base" value="$(arg vehicle_wheel_base)"/>
   </node>
 </launch>

--- a/core_planning/pure_pursuit/src/pure_pursuit_core.cpp
+++ b/core_planning/pure_pursuit/src/pure_pursuit_core.cpp
@@ -239,10 +239,7 @@ void PurePursuitNode::callbackFromConfig(
   const autoware_config_msgs::ConfigWaypointFollowerConstPtr& config)
 {
   velocity_source_ = config->param_flag;
-  const_lookahead_distance_ = config->lookahead_distance;
   const_velocity_ = config->velocity;
-  lookahead_distance_ratio_ = config->lookahead_ratio;
-  minimum_lookahead_distance_ = config->minimum_lookahead_distance;
 }
 
 void PurePursuitNode::publishDeviationCurrentPosition(

--- a/core_planning/pure_pursuit/src/pure_pursuit_core.cpp
+++ b/core_planning/pure_pursuit/src/pure_pursuit_core.cpp
@@ -68,9 +68,7 @@ void PurePursuitNode::initForROS()
     &PurePursuitNode::callbackFromWayPoints, this);
   sub2_ = nh_.subscribe("current_pose", 10,
     &PurePursuitNode::callbackFromCurrentPose, this);
-  sub3_ = nh_.subscribe("config/waypoint_follower", 10,
-    &PurePursuitNode::callbackFromConfig, this);
-  sub4_ = nh_.subscribe("current_velocity", 10,
+  sub3_ = nh_.subscribe("current_velocity", 10,
     &PurePursuitNode::callbackFromCurrentVelocity, this);
 
   // setup publisher

--- a/core_planning/pure_pursuit/src/pure_pursuit_core.cpp
+++ b/core_planning/pure_pursuit/src/pure_pursuit_core.cpp
@@ -30,9 +30,9 @@ PurePursuitNode::PurePursuitNode()
   , current_linear_velocity_(0)
   , command_linear_velocity_(0)
   , direction_(LaneDirection::Forward)
-  , velocity_source_(-1)
+  , velocity_source_(DEFAULT_VELOCITY_SOURCE_)
   , const_lookahead_distance_(4.0)
-  , const_velocity_(5.0)
+  , const_velocity_(DEFAULT_CONST_VELOCITY_)
   , lookahead_distance_ratio_(2.0)
   , minimum_lookahead_distance_(6.0)
 {
@@ -52,18 +52,16 @@ PurePursuitNode::~PurePursuitNode()
 void PurePursuitNode::initForROS()
 {
   // ros parameter settings
-  private_nh_.param("velocity_source", velocity_source_, 0);
   private_nh_.param("is_linear_interpolation", is_linear_interpolation_, true);
   private_nh_.param(
     "publishes_for_steering_robot", publishes_for_steering_robot_, false);
   private_nh_.param(
     "add_virtual_end_waypoints", add_virtual_end_waypoints_, false);
   private_nh_.param("const_lookahead_distance", const_lookahead_distance_, 4.0);
-  private_nh_.param("const_velocity", const_velocity_, 5.0);
   private_nh_.param("lookahead_ratio", lookahead_distance_ratio_, 2.0);
   private_nh_.param(
     "minimum_lookahead_distance", minimum_lookahead_distance_, 6.0);
-  nh_.param("vehicle_info/wheel_base", wheel_base_, 2.7);
+  private_nh_.param("vehicle_wheel_base", wheel_base_, 2.7);
 
   // setup subscriber
   sub1_ = nh_.subscribe("final_waypoints", 10,
@@ -235,12 +233,6 @@ double PurePursuitNode::computeAngularGravity(
   return (velocity * velocity) / (1.0 / kappa * gravity);
 }
 
-void PurePursuitNode::callbackFromConfig(
-  const autoware_config_msgs::ConfigWaypointFollowerConstPtr& config)
-{
-  velocity_source_ = config->param_flag;
-  const_velocity_ = config->velocity;
-}
 
 void PurePursuitNode::publishDeviationCurrentPosition(
   const geometry_msgs::Point& point,


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
This PR removes the lookahead config params for pure pursuit, from the launch file. It is now loaded from the vehicle calibration folder.
## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.