### PR TITLE
Shift to Park at End of Route

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ jobs:
           name: Pull Deps
           command: |
             source ${INIT_ENV}
-            ./autoware.ai/docker/checkout.bash ${PWD}
+            ./autoware.ai/docker/checkout.bash -r ${PWD}
       - run:
           name: Build autoware.ai
           command: |

--- a/docker/checkout.bash
+++ b/docker/checkout.bash
@@ -1,10 +1,41 @@
 #!/bin/bash
 
+#  Copyright (C) 2018-2021 LEIDOS.
+# 
+#  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+#  use this file except in compliance with the License. You may obtain a copy of
+#  the License at
+# 
+#  http://www.apache.org/licenses/LICENSE-2.0
+# 
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations under
+#  the License.
+
 set -exo pipefail
 
 dir=~
-if [[ -n ${1} ]]; then
-      dir=${1}
-fi
+while [[ $# -gt 0 ]]; do
+      arg="$1"
+      case $arg in
+            -d|--develop)
+                  BRANCH=develop
+                  shift
+            ;;
+            -r|--root)
+                  dir=$2
+                  shift
+                  shift
+            ;;
+      esac
+done
 
-# NO OP
+cd ${dir}/autoware.ai
+
+if [[ "$BRANCH" = "carma-develop" ]]; then
+      git clone --depth=1 https://github.com/usdot-fhwa-stol/carma-msgs.git --branch $BRANCH
+else
+      git clone --depth=1 https://github.com/usdot-fhwa-stol/carma-msgs.git --branch hotfix/end_of_route_park
+fi

--- a/docker/checkout.bash
+++ b/docker/checkout.bash
@@ -37,5 +37,5 @@ cd ${dir}/autoware.ai
 if [[ "$BRANCH" = "carma-develop" ]]; then
       git clone --depth=1 https://github.com/usdot-fhwa-stol/carma-msgs.git --branch develop
 else
-      git clone --depth=1 https://github.com/usdot-fhwa-stol/carma-msgs.git --branch develop
+      git clone --depth=1 https://github.com/usdot-fhwa-stol/carma-msgs.git --branch release/vanden-plas
 fi

--- a/docker/checkout.bash
+++ b/docker/checkout.bash
@@ -38,3 +38,4 @@ if [[ "$BRANCH" = "carma-develop" ]]; then
       git clone --depth=1 https://github.com/usdot-fhwa-stol/carma-msgs.git --branch develop
 else
       git clone --depth=1 https://github.com/usdot-fhwa-stol/carma-msgs.git --branch develop
+fi

--- a/docker/checkout.bash
+++ b/docker/checkout.bash
@@ -35,7 +35,6 @@ done
 cd ${dir}/autoware.ai
 
 if [[ "$BRANCH" = "carma-develop" ]]; then
-      git clone --depth=1 https://github.com/usdot-fhwa-stol/carma-msgs.git --branch $BRANCH
+      git clone --depth=1 https://github.com/usdot-fhwa-stol/carma-msgs.git --branch develop
 else
-      git clone --depth=1 https://github.com/usdot-fhwa-stol/carma-msgs.git --branch hotfix/end_of_route_park
-fi
+      git clone --depth=1 https://github.com/usdot-fhwa-stol/carma-msgs.git --branch develop

--- a/drivers/as/CMakeLists.txt
+++ b/drivers/as/CMakeLists.txt
@@ -3,6 +3,7 @@ project(as)
 
 find_package(
   catkin REQUIRED COMPONENTS
+  cav_msgs
   autoware_build_flags
   roscpp
   message_filters
@@ -23,6 +24,7 @@ catkin_package(
   automotive_platform_msgs
   automotive_navigation_msgs
   autoware_msgs
+  cav_msgs
 )
 
 include_directories(

--- a/drivers/as/launch/ssc_interface.launch
+++ b/drivers/as/launch/ssc_interface.launch
@@ -20,7 +20,7 @@
 		<param name="deceleration_limit" value="$(arg deceleration_limit)" />
 		<param name="max_curvature_rate" value="$(arg max_curvature_rate)" />
 
-		<remap from="/guidance_state" to="guidance_state" />
+		<remap from="/state" to="state" />
 	</node>
 
 </launch>

--- a/drivers/as/launch/ssc_interface.launch
+++ b/drivers/as/launch/ssc_interface.launch
@@ -19,6 +19,8 @@
 		<param name="acceleration_limit" value="$(arg acceleration_limit)" />
 		<param name="deceleration_limit" value="$(arg deceleration_limit)" />
 		<param name="max_curvature_rate" value="$(arg max_curvature_rate)" />
+
+		<remap from="/guidance_state" to="guidance_state" />
 	</node>
 
 </launch>

--- a/drivers/as/launch/ssc_interface.launch
+++ b/drivers/as/launch/ssc_interface.launch
@@ -20,7 +20,7 @@
 		<param name="deceleration_limit" value="$(arg deceleration_limit)" />
 		<param name="max_curvature_rate" value="$(arg max_curvature_rate)" />
 
-		<remap from="/state" to="state" />
+		<remap from="/state" to="/guidance/state" />
 	</node>
 
 </launch>

--- a/drivers/as/nodes/ssc_interface/ssc_interface.cpp
+++ b/drivers/as/nodes/ssc_interface/ssc_interface.cpp
@@ -234,11 +234,11 @@ void SSCInterface::publishCommand()
 
   if (engage_) 
   {
-    if (guidance_state_ == cav_msgs::GuidanceState::ENTER_PARK || shift_to_park_) 
+    if (shift_to_park_) 
     {
       desired_gear_ = automotive_platform_msgs::Gear::PARK;
     }
-    else if (guidance_state_ == cav_msgs:GuidanceState::ENGAGE || !shift_to_park_)
+    else
     {
       desired_gear_ = automotive_platform_msgs::Gear::DRIVE;
     }

--- a/drivers/as/nodes/ssc_interface/ssc_interface.cpp
+++ b/drivers/as/nodes/ssc_interface/ssc_interface.cpp
@@ -36,7 +36,7 @@ SSCInterface::SSCInterface() : nh_(), private_nh_("~"), engage_(false), command_
   rate_ = new ros::Rate(loop_rate_);
 
   // subscribers from CARMA
-  guidance_state_sub_ = nh_.subscribe("state", 1, &SSCInterface::callbackFromGuidanceState, this);
+  guidance_state_sub_ = nh_.subscribe("/state", 1, &SSCInterface::callbackFromGuidanceState, this);
 
   // subscribers from autoware
   vehicle_cmd_sub_ = nh_.subscribe("vehicle_cmd", 1, &SSCInterface::callbackFromVehicleCmd, this);

--- a/drivers/as/nodes/ssc_interface/ssc_interface.cpp
+++ b/drivers/as/nodes/ssc_interface/ssc_interface.cpp
@@ -148,7 +148,7 @@ void SSCInterface::callbackFromSSCFeedbacks(const automotive_platform_msgs::Velo
                          (msg_curvature->curvature) :
                          std::tan(msg_steering_wheel->steering_wheel_angle/ adaptive_gear_ratio_) / wheel_base_;
 
-  // Set current_velocity_ variable [km/s]
+  // Set current_velocity_ variable [m/s]
   current_velocity_ = msg_velocity->velocity;
 
   // as_current_velocity (geometry_msgs::TwistStamped)

--- a/drivers/as/nodes/ssc_interface/ssc_interface.cpp
+++ b/drivers/as/nodes/ssc_interface/ssc_interface.cpp
@@ -102,13 +102,11 @@ void SSCInterface::run()
 
 void SSCInterface::callbackFromGuidanceState(const cav_msgs::GuidanceStateConstPtr& msg)
 {
-  guidance_state_ = msg->state;
-
-  if (guidance_state_ == cav_msgs::GuidanceState::ENGAGE)
+  if (msg->state == cav_msgs::GuidanceState::ENGAGED)
   {
     shift_to_park_ = false;
   }
-  else if (guidance_state == cav_msgs::GuidanceState::ENTER_PARK)
+  else if (msg->state == cav_msgs::GuidanceState::ENTER_PARK)
   {
     shift_to_park_ = true;
   }
@@ -230,22 +228,22 @@ void SSCInterface::publishCommand()
   double desired_curvature = std::tan(desired_steering_angle) / wheel_base_;
 
   // Gear (TODO: Use vehicle_cmd.gear)
-  unsigned char desired_gear = automotive_platform_msgs::Gear:NONE;
+  unsigned char desired_gear = automotive_platform_msgs::Gear::NONE;
 
   if (engage_) 
   {
     if (shift_to_park_) 
     {
-      desired_gear_ = automotive_platform_msgs::Gear::PARK;
+      desired_gear = automotive_platform_msgs::Gear::PARK;
     }
     else
     {
-      desired_gear_ = automotive_platform_msgs::Gear::DRIVE;
+      desired_gear = automotive_platform_msgs::Gear::DRIVE;
     }
   }
   else
   {
-    desired_gear_ = automotive_platform_msgs::Gear::NONE;
+    desired_gear = automotive_platform_msgs::Gear::NONE;
   }
 
   // Turn signal

--- a/drivers/as/nodes/ssc_interface/ssc_interface.cpp
+++ b/drivers/as/nodes/ssc_interface/ssc_interface.cpp
@@ -100,7 +100,7 @@ void SSCInterface::run()
   }
 }
 
-void SSCInterface::callbackFromGuidanceState(const cav_msgs::GuidanceStatePtr& msg)
+void SSCInterface::callbackFromGuidanceState(const cav_msgs::GuidanceStateConstPtr& msg)
 {
   guidance_state_ = msg->state;
 

--- a/drivers/as/nodes/ssc_interface/ssc_interface.cpp
+++ b/drivers/as/nodes/ssc_interface/ssc_interface.cpp
@@ -148,6 +148,9 @@ void SSCInterface::callbackFromSSCFeedbacks(const automotive_platform_msgs::Velo
                          (msg_curvature->curvature) :
                          std::tan(msg_steering_wheel->steering_wheel_angle/ adaptive_gear_ratio_) / wheel_base_;
 
+  // Set current_velocity_ variable [km/s]
+  double current_velocity_ = msg_velocity->velocity;
+
   // as_current_velocity (geometry_msgs::TwistStamped)
   geometry_msgs::TwistStamped twist;
   twist.header.frame_id = BASE_FRAME_ID;
@@ -234,7 +237,9 @@ void SSCInterface::publishCommand()
   {
     if (shift_to_park_) 
     {
-      desired_gear = automotive_platform_msgs::Gear::PARK;
+      if (current_velocity_ < epsilon_){
+        desired_gear = automotive_platform_msgs::Gear::PARK;
+      }
     }
     else
     {

--- a/drivers/as/nodes/ssc_interface/ssc_interface.cpp
+++ b/drivers/as/nodes/ssc_interface/ssc_interface.cpp
@@ -149,7 +149,7 @@ void SSCInterface::callbackFromSSCFeedbacks(const automotive_platform_msgs::Velo
                          std::tan(msg_steering_wheel->steering_wheel_angle/ adaptive_gear_ratio_) / wheel_base_;
 
   // Set current_velocity_ variable [km/s]
-  double current_velocity_ = msg_velocity->velocity;
+  current_velocity_ = msg_velocity->velocity;
 
   // as_current_velocity (geometry_msgs::TwistStamped)
   geometry_msgs::TwistStamped twist;

--- a/drivers/as/nodes/ssc_interface/ssc_interface.h
+++ b/drivers/as/nodes/ssc_interface/ssc_interface.h
@@ -109,6 +109,7 @@ private:
   // variables
   bool engage_;
   bool command_initialized_;
+  double current_velocity_;
   double adaptive_gear_ratio_;
   ros::Time command_time_;
   cav_msgs::GuidanceState guidance_state_;
@@ -118,6 +119,9 @@ private:
 
   // Flag to indicate whether the ssc should shift the vehicle to park
   bool shift_to_park_{false};
+
+  //A small static value for comparing doubles
+  static constexpr double epsilon_ = 0.001;
 
   // callbacks
   void callbackFromGuidanceState(const cav_msgs::GuidanceStateConstPtr& msg);

--- a/drivers/as/nodes/ssc_interface/ssc_interface.h
+++ b/drivers/as/nodes/ssc_interface/ssc_interface.h
@@ -116,8 +116,8 @@ private:
   automotive_navigation_msgs::ModuleState module_states_;
   ros::Rate* rate_;
 
-  // bool flag indicates the ssc should set the vehicle shifter to park
-  bool shift_to_park_;
+  // Flag to indicate whether the ssc should shift the vehicle to park
+  bool shift_to_park_{false};
 
   // callbacks
   void callbackFromGuidanceState(const cav_msgs::GuidanceStatePtr& msg);

--- a/drivers/as/nodes/ssc_interface/ssc_interface.h
+++ b/drivers/as/nodes/ssc_interface/ssc_interface.h
@@ -120,7 +120,7 @@ private:
   bool shift_to_park_{false};
 
   // callbacks
-  void callbackFromGuidanceState(const cav_msgs::GuidanceStatePtr& msg);
+  void callbackFromGuidanceState(const cav_msgs::GuidanceStateConstPtr& msg);
   void callbackFromVehicleCmd(const autoware_msgs::VehicleCmdConstPtr& msg);
   void callbackFromEngage(const std_msgs::BoolConstPtr& msg);
   void callbackFromSSCModuleStates(const automotive_navigation_msgs::ModuleStateConstPtr& msg);

--- a/drivers/as/nodes/ssc_interface/ssc_interface.h
+++ b/drivers/as/nodes/ssc_interface/ssc_interface.h
@@ -42,6 +42,8 @@
 #include <autoware_msgs/VehicleCmd.h>
 #include <autoware_msgs/VehicleStatus.h>
 
+#include <cav_msgs/GuidanceState.h>
+
 static const std::string BASE_FRAME_ID = "base_link";
 
 class SSCInterface
@@ -64,6 +66,7 @@ private:
   ros::NodeHandle private_nh_;
 
   // subscribers
+  ros::Subscriber guidance_state_sub_;
   ros::Subscriber vehicle_cmd_sub_;
   ros::Subscriber engage_sub_;
   ros::Subscriber module_states_sub_;
@@ -108,11 +111,16 @@ private:
   bool command_initialized_;
   double adaptive_gear_ratio_;
   ros::Time command_time_;
+  cav_msgs::GuidanceState guidance_state_;
   autoware_msgs::VehicleCmd vehicle_cmd_;
   automotive_navigation_msgs::ModuleState module_states_;
   ros::Rate* rate_;
 
+  // bool flag indicates the ssc should set the vehicle shifter to park
+  bool shift_to_park_;
+
   // callbacks
+  void callbackFromGuidanceState(const cav_msgs::GuidanceStatePtr& msg);
   void callbackFromVehicleCmd(const autoware_msgs::VehicleCmdConstPtr& msg);
   void callbackFromEngage(const std_msgs::BoolConstPtr& msg);
   void callbackFromSSCModuleStates(const automotive_navigation_msgs::ModuleStateConstPtr& msg);

--- a/drivers/as/package.xml
+++ b/drivers/as/package.xml
@@ -19,4 +19,5 @@
   <depend>roscpp</depend>
   <depend>std_msgs</depend>
   <depend>ros_observer</depend>  
+  <depend>cav_msgs</depend>
 </package>

--- a/hooks/pre_build
+++ b/hooks/pre_build
@@ -8,4 +8,7 @@ elif [[ "$SOURCE_BRANCH" =~ ^release/.*$ ]]; then
     # update image dependencies
     sed -i "s|usdotfhwastol|usdotfhwastolcandidate|g; s|:[0-9]*\.[0-9]*\.[0-9]*|:candidate|g" \
         Dockerfile
+    # swap checkout branch in checkout.bash to release branch
+    sed -i "s|--branch .*|--branch $SOURCE_BRANCH|g" \
+        docker/checkout.bash
 fi


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
This PR includes updates to the ssc_interface package by making it aware of carma's guidance state machine. When the guidance state is 'ENTER_PARK', the ssc_interface will set a flag to shift to park. Once verifying that the vehicle has stopped, a command will be published to shift the vehicle to park. For this PR, related changes have been made on branch hotfix/end_of_route_park in carma-platform and hotfix/end_of_route_park in carma-msgs.

Additionally, updates were made to the docker/checkout.bash script in order to clone the carma-msgs repo during the image build process in order to build the cav_msgs package required for these updates.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
[Issue 1069: Guidance state machine does not keep the vehicle stopped after completing a route](https://github.com/usdot-fhwa-stol/carma-platform/issues/1069)

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Prior to this change, when the vehicle came to a stop at the end of the route and a 'Route Completed' event occurred, there was no specific behavior that shifted the vehicle to Park and kept the vehicle stationary. With guidance state machine updates in carma-platform to create a new 'ENTER_PARK' state, additional updates were required in the ssc_interface package of autoware.ai in order to be aware of this specific state and command a gearshift to Park when necessary.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This has been integration tested on the Blue Lexus.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.