### PR TITLE
Make the timestamps for the pose, twist, and TF consistent from the EKF

### DIFF
--- a/core_perception/ekf_localizer/src/ekf_localizer.cpp
+++ b/core_perception/ekf_localizer/src/ekf_localizer.cpp
@@ -178,7 +178,7 @@ void EKFLocalizer::setCurrentResult()
   tf2::convert(q_tf, current_ekf_pose_.pose.orientation);
 
   current_ekf_twist_.header.frame_id = child_frame_id_;
-  current_ekf_twist_.header.stamp = ros::Time::now();
+  current_ekf_twist_.header.stamp = current_ekf_pose_.header.stamp; // Twist time stamp should exactly match pose timestamp since they were computed in the same EKF step
   current_ekf_twist_.twist.linear.x = ekf_.getXelement(IDX::VX);
   current_ekf_twist_.twist.angular.z = ekf_.getXelement(IDX::WZ);
 }
@@ -192,7 +192,7 @@ void EKFLocalizer::timerTFCallback(const ros::TimerEvent& e)
     return;
 
   geometry_msgs::TransformStamped transformStamped;
-  transformStamped.header.stamp = ros::Time::now();
+  transformStamped.header.stamp = current_ekf_pose_.header.stamp; // Transform stamp should exactly match the same of the data it is set from
   transformStamped.header.frame_id = current_ekf_pose_.header.frame_id;
   transformStamped.child_frame_id = child_frame_id_;
   transformStamped.transform.translation.x = current_ekf_pose_.pose.position.x;


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
This PR updates the EKF node to use the same timestamp between the common reports for twist/pose/transform. 
Since the data source is the same the timestamps should also be consistent. 
<!--- Describe your changes in detail -->

## Related Issue
https://github.com/usdot-fhwa-stol/carma-platform/issues/1217
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
See issue
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.