### PR TITLE
Resolve a typo in the rule name for the minimum gap regulatory element

### DIFF
--- a/common/lanelet2_extension/docs/RegulatoryElements.md
+++ b/common/lanelet2_extension/docs/RegulatoryElements.md
@@ -15,7 +15,7 @@ Minimum Gap can be set dynamically either through a V2V or V2X communications se
 
 | **Key** | **Value Type** | **description**                |
 |-------------|--------------|----------------------------------|
-| **subtype** | **digital_minimun_gap**    | Subtype name |
+| **subtype** | **digital_minimum_gap**    | Subtype name |
 | **mingap** | **double**    | The minimum gap to set. In an osm file units must be meters |
 | **participant:XXX** | **yes/no**    | The participant type this applies to |
 
@@ -42,7 +42,7 @@ To support multiple types of participants a new attribute should be added for ea
 <relation id='45217' visible='true' version='1'>
   <member type='lanelet' ref='1349' role='refers' />
   <tag k='mingap' v='13' /> <!-- Minimum gap value is of unit meter-->
-  <tag k='subtype' v='digital_minimun_gap' />
+  <tag k='subtype' v='digital_minimum_gap' />
   <tag k='type' v='regulatory_element' />
   <tag k='participant:vehicle' v='yes' />
 </relation>

--- a/common/lanelet2_extension/include/lanelet2_extension/regulatory_elements/DigitalMinimumGap.h
+++ b/common/lanelet2_extension/include/lanelet2_extension/regulatory_elements/DigitalMinimumGap.h
@@ -36,7 +36,7 @@ namespace lanelet
 class DigitalMinimumGap : public RegulatoryElement
 {
 public:
-  static constexpr char RuleName[] = "digital_minimun_gap";
+  static constexpr char RuleName[] = "digital_minimum_gap";
   static constexpr char MinGap[] = "mingap";
   double min_gap_ = 0;
   std::unordered_set<std::string> participants_;


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
This PR fixes a small typo in the digital minimum gap regulatory element. 
It is in support of the map update bug fixes PR https://github.com/usdot-fhwa-stol/carma-platform/pull/1232
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Regulatory element type can be properly extracted based on rule name. Typo's make this more difficult. 
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.