### PR TITLE
Fix/unified gps conversion

### DIFF
--- a/common/lanelet2_extension/include/lanelet2_extension/projection/local_frame_projector.h
+++ b/common/lanelet2_extension/include/lanelet2_extension/projection/local_frame_projector.h
@@ -46,7 +46,7 @@ public:
   /**
    * [LocalFrameProjector::projectECEF projects between WGS-84 ECEF and local map]
    * @param  ecef_point             [point with x,y,z in ecef information]
-   * @param  proj_dir               [1 for forward -1 for reverse]
+   * @param  proj_dir               [1 for forward (output is in ecef) -1 for reverse (output is in map)]
    * @return                        [projected point in local map coordinate]
    * @throw  std::invalid_argument  [if direction is neither of 1 (forward) or -1 (reverse)]
    */
@@ -59,14 +59,15 @@ public:
    */
   GPSPoint reverse(const BasicPoint3d& p) const override;
 
+  // The PROJ string used to define a WGS-84 ECEF frame
+  static constexpr char ECEF_PROJ_STR[] = "+proj=geocent +ellps=WGS84 +datum=WGS84 +units=m +no_defs";
+
 private:
   
   PJ *P_;
 
   const std::string map_proj_string_;
 
-  // The PROJ string used to define a WGS-84 ECEF frame
-  static constexpr char ECEF_PROJ_STR[] = "+proj=geocent +ellps=WGS84 +datum=WGS84 +units=m +no_defs";
 };
 
 }  // namespace projection

--- a/common/map_file/launch/map_param_loader.launch
+++ b/common/map_file/launch/map_param_loader.launch
@@ -13,7 +13,12 @@ the License.
 
 <launch>
  <arg name="file_name"/>	
+ <arg name="broadcast_earth_frame" default="false"
+  doc="If true this node will attempt to compute a homogenious transformation matrix between earth and the map frame origin. 
+       NOTE: Not all projections can be linearly described in this way and such a transformation may be inaccurate."/>
+
  <node pkg="map_file" type="map_param_loader" name="map_param_loader">  
   <param name = "file_name" value = "$(arg file_name)"/>
+  <param name = "broadcast_earth_frame" value = "$(arg broadcast_earth_frame)"/>
  </node>
 </launch>

--- a/common/map_file/nodes/map_param_loader/map_param_loader.cpp
+++ b/common/map_file/nodes/map_param_loader/map_param_loader.cpp
@@ -78,16 +78,21 @@ int main(int argc, char **argv)
   int projector_type = 1; // default value
   std::string target_frame, lanelet2_filename;
   private_nh.param<std::string>("file_name", lanelet2_filename, "");
+  
+  bool broadcast_earth_frame = false;
+  private_nh.param<bool>("broadcast_earth_frame", broadcast_earth_frame, broadcast_earth_frame);
 
   
   // Parse geo reference info from the lanelet map (.osm)
   lanelet::io_handlers::AutowareOsmParser::parseMapParams(lanelet2_filename, &projector_type, &target_frame);
 
-  // Get the transform to ecef (when parsed target_frame is map_frame)
-  tf2::Transform tf = map_param_loader::getTransform(target_frame);
+  if (broadcast_earth_frame) {
+    // Get the transform to ecef (when parsed target_frame is map_frame)
+    tf2::Transform tf = map_param_loader::getTransform(target_frame);
 
-  // Broadcast the transform
-  map_param_loader::broadcastTransform(tf);
+    // Broadcast the transform
+    map_param_loader::broadcastTransform(tf);
+  }
 
   // Broadcast the georeference
   ros::Publisher georef_pub = private_nh.advertise<std_msgs::String>("georeference", 1, true);


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
This PR is in support of https://github.com/usdot-fhwa-stol/carma-platform/issues/1285
This pr adds an argument to map_param_loader to enable or disable the publication of the ECEF to map transform. The default is set to false as this transform is not currently needed in the system per the above issue. Additionally, this PR adds some clarifying comments to the local_frame_projector and makes the ECEF frame string public for easy access as needed by the mobility path handling logic in carma-platform. 
<!--- Describe your changes in detail -->

## Related Issue
https://github.com/usdot-fhwa-stol/carma-platform/issues/1285
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
See issue
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
In blue lexus
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.