### PR TITLE
Fix/reduce control latency

### DIFF
--- a/core_perception/lidar_localizer/nodes/ndt_matching/ndt_matching.cpp
+++ b/core_perception/lidar_localizer/nodes/ndt_matching/ndt_matching.cpp
@@ -1679,18 +1679,13 @@ int main(int argc, char** argv)
   //  ros::Subscriber map_sub = nh.subscribe("points_map", 1, map_callback);
   ros::Subscriber initialpose_sub = nh.subscribe("initialpose", _queue_size, initialpose_callback);
   ros::Subscriber points_sub = nh.subscribe("filtered_points", _queue_size, points_callback);
-  ros::Subscriber odom_sub = nh.subscribe("/vehicle/odom", _queue_size, odom_callback);
-  ros::Subscriber imu_sub = nh.subscribe(_imu_topic.c_str(), _queue_size, imu_callback);
+  ros::Subscriber odom_sub = nh.subscribe("/vehicle/odom", _queue_size * 10, odom_callback);
+  ros::Subscriber imu_sub = nh.subscribe(_imu_topic.c_str(), _queue_size * 10, imu_callback);
 
   pthread_t thread;
   pthread_create(&thread, NULL, thread_func, NULL);
 
-  ros::Rate r(10);
-  while (nh.ok())
-  {
-    ros::spinOnce();
-    r.sleep();
-  }
+  ros::spin();
 
   return 0;
 }

--- a/core_planning/pure_pursuit/src/pure_pursuit_core.cpp
+++ b/core_planning/pure_pursuit/src/pure_pursuit_core.cpp
@@ -93,7 +93,7 @@ void PurePursuitNode::run()
   ROS_INFO_STREAM("pure pursuit start");
   ros::Rate loop_rate(LOOP_RATE_);
 
-  ros::Timer command_pub_timer = nh.createTimer( // Create a ros timer to publish commands at the expected loop rate
+  ros::Timer command_pub_timer = nh_.createTimer( // Create a ros timer to publish commands at the expected loop rate
     loop_rate.expectedCycleTime(),
     
     [this](const auto&) { 
@@ -101,17 +101,17 @@ void PurePursuitNode::run()
       if (!is_pose_set_ || !is_waypoint_set_ || !is_velocity_set_) // One time check on desired input data
       {
         ROS_WARN("Necessary topics are not subscribed yet ... ");
-        continue;
+        return;
       }
 
-      pp_.setLookaheadDistance(computeLookaheadDistance());
+      pp_.setLookaheadDistance(this->computeLookaheadDistance());
       pp_.setMinimumLookaheadDistance(minimum_lookahead_distance_);
 
       double kappa = 0;
       bool can_get_curvature = pp_.canGetCurvature(&kappa);
 
-      publishTwistStamped(can_get_curvature, kappa);
-      publishControlCommandStamped(can_get_curvature, kappa);
+      this->publishTwistStamped(can_get_curvature, kappa);
+      this->publishControlCommandStamped(can_get_curvature, kappa);
       health_checker_ptr_->NODE_ACTIVATE();
       health_checker_ptr_->CHECK_RATE("topic_rate_vehicle_cmd_slow", 8, 5, 1,
         "topic vehicle_cmd publish rate slow.");
@@ -130,10 +130,10 @@ void PurePursuitNode::run()
       }
       std_msgs::Float32 angular_gravity_msg;
       angular_gravity_msg.data =
-        computeAngularGravity(computeCommandVelocity(), kappa);
+        this->computeAngularGravity(this->computeCommandVelocity(), kappa);
       pub16_.publish(angular_gravity_msg);
 
-      publishDeviationCurrentPosition(
+      this->publishDeviationCurrentPosition(
         pp_.getCurrentPose().position, pp_.getCurrentWaypoints());
 
     }

--- a/core_planning/pure_pursuit/src/pure_pursuit_core.cpp
+++ b/core_planning/pure_pursuit/src/pure_pursuit_core.cpp
@@ -92,54 +92,54 @@ void PurePursuitNode::run()
 {
   ROS_INFO_STREAM("pure pursuit start");
   ros::Rate loop_rate(LOOP_RATE_);
-  while (ros::ok())
-  {
-    ros::spinOnce();
-    if (!is_pose_set_ || !is_waypoint_set_ || !is_velocity_set_)
-    {
-      ROS_WARN("Necessary topics are not subscribed yet ... ");
-      loop_rate.sleep();
-      continue;
+
+  ros::Timer command_pub_timer = nh.createTimer( // Create a ros timer to publish commands at the expected loop rate
+    loop_rate.expectedCycleTime(),
+    
+    [this](const auto&) { 
+
+      if (!is_pose_set_ || !is_waypoint_set_ || !is_velocity_set_) // One time check on desired input data
+      {
+        ROS_WARN("Necessary topics are not subscribed yet ... ");
+        continue;
+      }
+
+      pp_.setLookaheadDistance(computeLookaheadDistance());
+      pp_.setMinimumLookaheadDistance(minimum_lookahead_distance_);
+
+      double kappa = 0;
+      bool can_get_curvature = pp_.canGetCurvature(&kappa);
+
+      publishTwistStamped(can_get_curvature, kappa);
+      publishControlCommandStamped(can_get_curvature, kappa);
+      health_checker_ptr_->NODE_ACTIVATE();
+      health_checker_ptr_->CHECK_RATE("topic_rate_vehicle_cmd_slow", 8, 5, 1,
+        "topic vehicle_cmd publish rate slow.");
+      // for visualization with Rviz
+      pub11_.publish(displayNextWaypoint(pp_.getPoseOfNextWaypoint()));
+      pub13_.publish(displaySearchRadius(
+        pp_.getCurrentPose().position, pp_.getLookaheadDistance()));
+      pub12_.publish(displayNextTarget(pp_.getPoseOfNextTarget()));
+      pub15_.publish(displayTrajectoryCircle(
+          waypoint_follower::generateTrajectoryCircle(
+            pp_.getPoseOfNextTarget(), pp_.getCurrentPose())));
+      if (add_virtual_end_waypoints_)
+      {
+        pub18_.publish(
+          displayExpandWaypoints(pp_.getCurrentWaypoints(), expand_size_));
+      }
+      std_msgs::Float32 angular_gravity_msg;
+      angular_gravity_msg.data =
+        computeAngularGravity(computeCommandVelocity(), kappa);
+      pub16_.publish(angular_gravity_msg);
+
+      publishDeviationCurrentPosition(
+        pp_.getCurrentPose().position, pp_.getCurrentWaypoints());
+
     }
+  );
 
-    pp_.setLookaheadDistance(computeLookaheadDistance());
-    pp_.setMinimumLookaheadDistance(minimum_lookahead_distance_);
-
-    double kappa = 0;
-    bool can_get_curvature = pp_.canGetCurvature(&kappa);
-
-    publishTwistStamped(can_get_curvature, kappa);
-    publishControlCommandStamped(can_get_curvature, kappa);
-    health_checker_ptr_->NODE_ACTIVATE();
-    health_checker_ptr_->CHECK_RATE("topic_rate_vehicle_cmd_slow", 8, 5, 1,
-      "topic vehicle_cmd publish rate slow.");
-    // for visualization with Rviz
-    pub11_.publish(displayNextWaypoint(pp_.getPoseOfNextWaypoint()));
-    pub13_.publish(displaySearchRadius(
-      pp_.getCurrentPose().position, pp_.getLookaheadDistance()));
-    pub12_.publish(displayNextTarget(pp_.getPoseOfNextTarget()));
-    pub15_.publish(displayTrajectoryCircle(
-        waypoint_follower::generateTrajectoryCircle(
-          pp_.getPoseOfNextTarget(), pp_.getCurrentPose())));
-    if (add_virtual_end_waypoints_)
-    {
-      pub18_.publish(
-        displayExpandWaypoints(pp_.getCurrentWaypoints(), expand_size_));
-    }
-    std_msgs::Float32 angular_gravity_msg;
-    angular_gravity_msg.data =
-      computeAngularGravity(computeCommandVelocity(), kappa);
-    pub16_.publish(angular_gravity_msg);
-
-    publishDeviationCurrentPosition(
-      pp_.getCurrentPose().position, pp_.getCurrentWaypoints());
-
-    is_pose_set_ = false;
-    is_velocity_set_ = false;
-    is_waypoint_set_ = false;
-
-    loop_rate.sleep();
-  }
+  ros::spin();
 }
 
 void PurePursuitNode::publishTwistStamped(

--- a/core_planning/twist_gate/CMakeLists.txt
+++ b/core_planning/twist_gate/CMakeLists.txt
@@ -1,31 +1,22 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(twist_gate)
 
+find_package(autoware_build_flags REQUIRED)
 find_package(
   catkin REQUIRED COMPONENTS
-    autoware_build_flags
     autoware_config_msgs
     autoware_health_checker
     autoware_msgs
     geometry_msgs
+    ros_observer
     roscpp
-    rostest
-    rosunit
     roslint
     std_msgs
     tablet_socket_msgs
-    ros_observer
 )
 
 catkin_package(
   INCLUDE_DIRS include
-  CATKIN_DEPENDS
-    autoware_config_msgs
-    autoware_health_checker
-    autoware_msgs
-    geometry_msgs
-    std_msgs
-    tablet_socket_msgs
 )
 
 SET(CMAKE_CXX_FLAGS "-O2 -g -Wall ${CMAKE_CXX_FLAGS}")

--- a/core_planning/twist_gate/include/twist_gate/twist_gate.h
+++ b/core_planning/twist_gate/include/twist_gate/twist_gate.h
@@ -31,50 +31,31 @@
 
 #include "autoware_config_msgs/ConfigTwistFilter.h"
 #include "autoware_msgs/ControlCommandStamped.h"
-#include "autoware_msgs/RemoteCmd.h"
 #include "autoware_msgs/VehicleCmd.h"
+#include "autoware_msgs/Gear.h"
 
-#include "tablet_socket_msgs/gear_cmd.h"
-#include "tablet_socket_msgs/mode_cmd.h"
-
-// headers in Autowae Health Checker
 #include <autoware_health_checker/health_checker/health_checker.h>
 
-#define CMD_GEAR_D 1
-#define CMD_GEAR_R 2
-#define CMD_GEAR_B 3
-#define CMD_GEAR_N 4
-#define CMD_GEAR_P 5
 
 class TwistGate
 {
-  using remote_msgs_t = autoware_msgs::RemoteCmd;
   using vehicle_cmd_msg_t = autoware_msgs::VehicleCmd;
 
   friend class TwistGateTestClass;
 
 public:
   TwistGate(const ros::NodeHandle& nh, const ros::NodeHandle& private_nh);
-  ~TwistGate();
 
 private:
-  void check_state();
-  void watchdog_timer();
-  void remote_cmd_callback(const remote_msgs_t::ConstPtr& input_msg);
-  void auto_cmd_twist_cmd_callback(const geometry_msgs::TwistStamped::ConstPtr& input_msg);
-  void mode_cmd_callback(const tablet_socket_msgs::mode_cmd::ConstPtr& input_msg);
-  void gear_cmd_callback(const tablet_socket_msgs::gear_cmd::ConstPtr& input_msg);
-  void accel_cmd_callback(const autoware_msgs::AccelCmd::ConstPtr& input_msg);
-  void steer_cmd_callback(const autoware_msgs::SteerCmd::ConstPtr& input_msg);
-  void brake_cmd_callback(const autoware_msgs::BrakeCmd::ConstPtr& input_msg);
-  void lamp_cmd_callback(const autoware_msgs::LampCmd::ConstPtr& input_msg);
-  void ctrl_cmd_callback(const autoware_msgs::ControlCommandStamped::ConstPtr& input_msg);
-  void state_callback(const std_msgs::StringConstPtr& input_msg);
-  void emergency_cmd_callback(const vehicle_cmd_msg_t::ConstPtr& input_msg);
-  void timer_callback(const ros::TimerEvent& e);
-  void config_callback(const autoware_config_msgs::ConfigTwistFilter& msg);
+  void twistCmdCallback(const geometry_msgs::TwistStamped::ConstPtr& input_msg);
+  void ctrlCmdCallback(const autoware_msgs::ControlCommandStamped::ConstPtr& input_msg);
+  void lampCmdCallback(const autoware_msgs::LampCmd::ConstPtr& input_msg);
+  void stateCallback(const std_msgs::StringConstPtr& input_msg);
+  void emergencyCmdCallback(const vehicle_cmd_msg_t::ConstPtr& input_msg);
+  void updateEmergencyState();
 
-  void reset_vehicle_cmd_msg();
+  void updateStateAndPublish();
+  void configCallback(const autoware_config_msgs::ConfigTwistFilter& msg);
 
   // spinOnce for test
   void spinOnce() { ros::spinOnce(); }
@@ -84,33 +65,17 @@ private:
   std::shared_ptr<autoware_health_checker::HealthChecker> health_checker_ptr_;
   ros::Publisher control_command_pub_;
   ros::Publisher vehicle_cmd_pub_;
-  ros::Subscriber remote_cmd_sub_;
   ros::Subscriber config_sub_;
   std::map<std::string, ros::Subscriber> auto_cmd_sub_stdmap_;
-  ros::Timer timer_;
 
-  vehicle_cmd_msg_t twist_gate_msg_;
+  vehicle_cmd_msg_t output_msg_;
   std_msgs::Bool emergency_stop_msg_;
-  ros::Time remote_cmd_time_, emergency_handling_time_;
-  ros::Time state_time_;
+  ros::Time emergency_handling_time_;
   ros::Duration timeout_period_;
-  double loop_rate_;
-
-  std::thread watchdog_timer_thread_;
-  bool is_alive;
-
-  enum class CommandMode
-  {
-    AUTO = 1,
-    REMOTE = 2
-  }
-  command_mode_,
-
-  previous_command_mode_;
-  std_msgs::String command_mode_topic_;
 
   bool is_state_drive_ = false;
   bool use_decision_maker_ = false;
+  bool use_lgsim_ = false;
 
   bool emergency_handling_active_ = false;
 };

--- a/core_planning/twist_gate/include/twist_gate/twist_gate.h
+++ b/core_planning/twist_gate/include/twist_gate/twist_gate.h
@@ -78,6 +78,8 @@ private:
   bool use_lgsim_ = false;
 
   bool emergency_handling_active_ = false;
+
+  bool use_twist_ = false; // If true then the twist topic will be forwarded as the vehicle command. If false then the ctrl topic will be forwarded as the vehicle command
 };
 
 #endif  // TWIST_GATE_TWIST_GATE_H

--- a/core_planning/twist_gate/src/twist_gate.cpp
+++ b/core_planning/twist_gate/src/twist_gate.cpp
@@ -171,6 +171,7 @@ void TwistGate::updateEmergencyState()
   // Reset emergency handling
   if (emergency_handling_active_)
   {
+    ROS_ERROR_STREAM("EMERGENCY HANDLING IS ACTIVE");
     // If no emergency message received for more than timeout_period_
     if ((ros::Time::now() - emergency_handling_time_) > timeout_period_)
     {

--- a/core_planning/twist_gate/src/twist_gate.cpp
+++ b/core_planning/twist_gate/src/twist_gate.cpp
@@ -41,268 +41,93 @@ TwistGate::TwistGate(const ros::NodeHandle& nh, const ros::NodeHandle& private_n
   : nh_(nh)
   , private_nh_(private_nh)
   , timeout_period_(10.0)
-  , command_mode_(CommandMode::AUTO)
-  , previous_command_mode_(CommandMode::AUTO)
 {
-  private_nh_.param<double>("loop_rate", loop_rate_, 30.0);
   private_nh_.param<bool>("use_decision_maker", use_decision_maker_, false);
+  private_nh_.param<bool>("use_lgsim", use_lgsim_, false);
 
   health_checker_ptr_ = std::make_shared<autoware_health_checker::HealthChecker>(nh_, private_nh_);
   control_command_pub_ = nh_.advertise<std_msgs::String>("/ctrl_mode", 1);
   vehicle_cmd_pub_ = nh_.advertise<vehicle_cmd_msg_t>("/vehicle_cmd", 1, true);
-  remote_cmd_sub_ = nh_.subscribe("/remote_cmd", 1, &TwistGate::remote_cmd_callback, this);
-  config_sub_ = nh_.subscribe("config/twist_filter", 1, &TwistGate::config_callback, this);
+  config_sub_ = nh_.subscribe("config/twist_filter", 1, &TwistGate::configCallback, this);
 
-  timer_ = nh_.createTimer(ros::Duration(1.0 / loop_rate_), &TwistGate::timer_callback, this);
-
-  auto_cmd_sub_stdmap_["twist_cmd"] = nh_.subscribe("/twist_cmd", 1, &TwistGate::auto_cmd_twist_cmd_callback, this);
-  auto_cmd_sub_stdmap_["mode_cmd"] = nh_.subscribe("/mode_cmd", 1, &TwistGate::mode_cmd_callback, this);
-  auto_cmd_sub_stdmap_["gear_cmd"] = nh_.subscribe("/gear_cmd", 1, &TwistGate::gear_cmd_callback, this);
-  auto_cmd_sub_stdmap_["accel_cmd"] = nh_.subscribe("/accel_cmd", 1, &TwistGate::accel_cmd_callback, this);
-  auto_cmd_sub_stdmap_["steer_cmd"] = nh_.subscribe("/steer_cmd", 1, &TwistGate::steer_cmd_callback, this);
-  auto_cmd_sub_stdmap_["brake_cmd"] = nh_.subscribe("/brake_cmd", 1, &TwistGate::brake_cmd_callback, this);
-  auto_cmd_sub_stdmap_["lamp_cmd"] = nh_.subscribe("/lamp_cmd", 1, &TwistGate::lamp_cmd_callback, this);
-  auto_cmd_sub_stdmap_["ctrl_cmd"] = nh_.subscribe("/ctrl_cmd", 1, &TwistGate::ctrl_cmd_callback, this);
-  auto_cmd_sub_stdmap_["state"] = nh_.subscribe("/decision_maker/state", 1, &TwistGate::state_callback, this);
+  auto_cmd_sub_stdmap_["twist_cmd"] = nh_.subscribe("/twist_cmd", 1, &TwistGate::twistCmdCallback, this);
+  auto_cmd_sub_stdmap_["ctrl_cmd"] = nh_.subscribe("/ctrl_cmd", 1, &TwistGate::ctrlCmdCallback, this);
+  auto_cmd_sub_stdmap_["lamp_cmd"] = nh_.subscribe("/lamp_cmd", 1, &TwistGate::lampCmdCallback, this);
+  auto_cmd_sub_stdmap_["state"] = nh_.subscribe("/decision_maker/state", 1, &TwistGate::stateCallback, this);
   auto_cmd_sub_stdmap_["emergency_velocity"] =
-      nh_.subscribe("emergency_velocity", 1, &TwistGate::emergency_cmd_callback, this);
+      nh_.subscribe("emergency_velocity", 1, &TwistGate::emergencyCmdCallback, this);
 
-  twist_gate_msg_.header.seq = 0;
+  output_msg_.header.seq = 0;
   emergency_stop_msg_.data = false;
   health_checker_ptr_->ENABLE();
   health_checker_ptr_->NODE_ACTIVATE();
 
-  remote_cmd_time_ = ros::Time::now();
   emergency_handling_time_ = ros::Time::now();
-  state_time_ = ros::Time::now();
-  watchdog_timer_thread_ = std::thread(&TwistGate::watchdog_timer, this);
-  is_alive = true;
 }
 
-TwistGate::~TwistGate()
-{
-  is_alive = false;
-  watchdog_timer_thread_.join();
-}
-
-void TwistGate::reset_vehicle_cmd_msg()
-{
-  twist_gate_msg_.twist_cmd.twist.linear.x = 0;
-  twist_gate_msg_.twist_cmd.twist.angular.z = 0;
-  twist_gate_msg_.mode = 0;
-  twist_gate_msg_.gear = 0;
-  twist_gate_msg_.lamp_cmd.l = 0;
-  twist_gate_msg_.lamp_cmd.r = 0;
-  twist_gate_msg_.accel_cmd.accel = 0;
-  twist_gate_msg_.brake_cmd.brake = 0;
-  twist_gate_msg_.steer_cmd.steer = 0;
-  twist_gate_msg_.ctrl_cmd.linear_velocity = -1;
-  twist_gate_msg_.ctrl_cmd.steering_angle = 0;
-  twist_gate_msg_.emergency = 0;
-}
-
-void TwistGate::check_state()
-{
-  const double state_msg_timeout = 0.5;
-  double state_time_diff = ros::Time::now().toSec() - state_time_.toSec();
-
-  if (use_decision_maker_ && (!is_state_drive_ || state_time_diff >= state_msg_timeout) )
-  {
-    twist_gate_msg_.twist_cmd.twist = geometry_msgs::Twist();
-    twist_gate_msg_.ctrl_cmd = autoware_msgs::ControlCommand();
-  }
-}
-
-void TwistGate::watchdog_timer()
-{
-  ShmVitalMonitor shm_vmon("TwistGate", 100);
-
-  while (is_alive)
-  {
-    ros::Time now_time = ros::Time::now();
-
-    // check command mode
-    if (previous_command_mode_ != command_mode_)
-    {
-      if (command_mode_ == CommandMode::AUTO)
-      {
-        command_mode_topic_.data = "AUTO";
-      }
-      else if (command_mode_ == CommandMode::REMOTE)
-      {
-        command_mode_topic_.data = "REMOTE";
-      }
-      else
-      {
-        command_mode_topic_.data = "UNDEFINED";
-      }
-
-      control_command_pub_.publish(command_mode_topic_);
-      previous_command_mode_ = command_mode_;
-    }
-
-    shm_vmon.run();
-
-    // check lost Communication
-    if (command_mode_ == CommandMode::REMOTE)
-    {
-      const double dt = (now_time - remote_cmd_time_).toSec() * 1000;
-      health_checker_ptr_->CHECK_MAX_VALUE("remote_cmd_interval", dt, 700, 1000, 1500, "remote cmd interval is too "
-                                                                                       "long.");
-    }
-
-    // check push emergency stop button
-    const int level = (emergency_stop_msg_.data) ? AwDiagStatus::ERROR : AwDiagStatus::OK;
-    health_checker_ptr_->CHECK_TRUE("emergency_stop_button", emergency_stop_msg_.data, level, "emergency stop button "
-                                                                                              "is pushed.");
-
-    // if no emergency message received for more than timeout_period_
-    if ((now_time - emergency_handling_time_) > timeout_period_)
-    {
-      emergency_handling_active_ = false;
-    }
-
-    std::this_thread::sleep_for(std::chrono::milliseconds(10));
-  }
-}
-
-void TwistGate::remote_cmd_callback(const remote_msgs_t::ConstPtr& input_msg)
-{
-  remote_cmd_time_ = ros::Time::now();
-  command_mode_ = static_cast<CommandMode>(input_msg->control_mode);
-  emergency_stop_msg_.data = static_cast<bool>(input_msg->vehicle_cmd.emergency);
-
-  // Update Emergency Mode
-  twist_gate_msg_.emergency = input_msg->vehicle_cmd.emergency;
-  if (command_mode_ == CommandMode::REMOTE && emergency_stop_msg_.data == false)
-  {
-    twist_gate_msg_.header.frame_id = input_msg->vehicle_cmd.header.frame_id;
-    twist_gate_msg_.header.stamp = input_msg->vehicle_cmd.header.stamp;
-    twist_gate_msg_.header.seq++;
-    twist_gate_msg_.twist_cmd.twist = input_msg->vehicle_cmd.twist_cmd.twist;
-    twist_gate_msg_.ctrl_cmd = input_msg->vehicle_cmd.ctrl_cmd;
-    twist_gate_msg_.accel_cmd = input_msg->vehicle_cmd.accel_cmd;
-    twist_gate_msg_.brake_cmd = input_msg->vehicle_cmd.brake_cmd;
-    twist_gate_msg_.steer_cmd = input_msg->vehicle_cmd.steer_cmd;
-    twist_gate_msg_.gear = input_msg->vehicle_cmd.gear;
-    twist_gate_msg_.lamp_cmd = input_msg->vehicle_cmd.lamp_cmd;
-    twist_gate_msg_.mode = input_msg->vehicle_cmd.mode;
-  }
-}
-
-void TwistGate::auto_cmd_twist_cmd_callback(const geometry_msgs::TwistStamped::ConstPtr& input_msg)
+void TwistGate::twistCmdCallback(const geometry_msgs::TwistStamped::ConstPtr& input_msg)
 {
   health_checker_ptr_->CHECK_RATE("topic_rate_twist_cmd_slow", 8, 5, 1, "topic twist_cmd subscribe rate slow.");
   health_checker_ptr_->CHECK_MAX_VALUE("twist_cmd_linear_high", input_msg->twist.linear.x,
     DBL_MAX, DBL_MAX, DBL_MAX, "linear twist_cmd is too high");
 
-  if (command_mode_ == CommandMode::AUTO && !emergency_handling_active_)
+  updateEmergencyState();
+  if (!emergency_handling_active_)
   {
-    twist_gate_msg_.header.frame_id = input_msg->header.frame_id;
-    twist_gate_msg_.header.stamp = input_msg->header.stamp;
-    twist_gate_msg_.header.seq++;
-    twist_gate_msg_.twist_cmd.twist = input_msg->twist;
+    output_msg_.header.frame_id = input_msg->header.frame_id;
+    output_msg_.header.stamp = input_msg->header.stamp;
+    output_msg_.header.seq++;
+    output_msg_.twist_cmd.twist = input_msg->twist;
 
-    check_state();
+    updateStateAndPublish();
   }
 }
 
-void TwistGate::mode_cmd_callback(const tablet_socket_msgs::mode_cmd::ConstPtr& input_msg)
+void TwistGate::ctrlCmdCallback(const autoware_msgs::ControlCommandStamped::ConstPtr& input_msg)
 {
-  if (command_mode_ == CommandMode::AUTO && !emergency_handling_active_)
+  updateEmergencyState();
+  if (!emergency_handling_active_)
   {
-    // TODO(unknown): check this if statement
-    if (input_msg->mode == -1 || input_msg->mode == 0)
+    output_msg_.header.frame_id = input_msg->header.frame_id;
+    output_msg_.header.stamp = input_msg->header.stamp;
+    output_msg_.header.seq++;
+    output_msg_.ctrl_cmd = input_msg->cmd;
+
+    updateStateAndPublish();
+  }
+}
+
+void TwistGate::lampCmdCallback(const autoware_msgs::LampCmd::ConstPtr& input_msg)
+{
+  updateEmergencyState();
+  if (!emergency_handling_active_)
+  {
+    output_msg_.lamp_cmd.l = input_msg->l;
+    output_msg_.lamp_cmd.r = input_msg->r;
+  }
+}
+
+void TwistGate::stateCallback(const std_msgs::StringConstPtr& input_msg)
+{
+  if (!emergency_handling_active_)
+  {
+    // Set gear based on motion states
+    if (input_msg->data.find("WaitEngage") != std::string::npos ||
+        input_msg->data.find("WaitDriveReady") != std::string::npos)
     {
-      reset_vehicle_cmd_msg();
-    }
-    twist_gate_msg_.header.frame_id = input_msg->header.frame_id;
-    twist_gate_msg_.header.stamp = input_msg->header.stamp;
-    twist_gate_msg_.header.seq++;
-    twist_gate_msg_.mode = input_msg->mode;
-  }
-}
-
-void TwistGate::gear_cmd_callback(const tablet_socket_msgs::gear_cmd::ConstPtr& input_msg)
-{
-  if (command_mode_ == CommandMode::AUTO && !emergency_handling_active_)
-  {
-    twist_gate_msg_.gear = input_msg->gear;
-  }
-}
-
-void TwistGate::accel_cmd_callback(const autoware_msgs::AccelCmd::ConstPtr& input_msg)
-{
-  if (command_mode_ == CommandMode::AUTO && !emergency_handling_active_)
-  {
-    twist_gate_msg_.header.frame_id = input_msg->header.frame_id;
-    twist_gate_msg_.header.stamp = input_msg->header.stamp;
-    twist_gate_msg_.header.seq++;
-    twist_gate_msg_.accel_cmd.accel = input_msg->accel;
-  }
-}
-
-void TwistGate::steer_cmd_callback(const autoware_msgs::SteerCmd::ConstPtr& input_msg)
-{
-  if (command_mode_ == CommandMode::AUTO && !emergency_handling_active_)
-  {
-    twist_gate_msg_.header.frame_id = input_msg->header.frame_id;
-    twist_gate_msg_.header.stamp = input_msg->header.stamp;
-    twist_gate_msg_.header.seq++;
-    twist_gate_msg_.steer_cmd.steer = input_msg->steer;
-  }
-}
-
-void TwistGate::brake_cmd_callback(const autoware_msgs::BrakeCmd::ConstPtr& input_msg)
-{
-  if (command_mode_ == CommandMode::AUTO && !emergency_handling_active_)
-  {
-    twist_gate_msg_.header.frame_id = input_msg->header.frame_id;
-    twist_gate_msg_.header.stamp = input_msg->header.stamp;
-    twist_gate_msg_.header.seq++;
-    twist_gate_msg_.brake_cmd.brake = input_msg->brake;
-  }
-}
-
-void TwistGate::lamp_cmd_callback(const autoware_msgs::LampCmd::ConstPtr& input_msg)
-{
-  if (command_mode_ == CommandMode::AUTO && !emergency_handling_active_)
-  {
-    twist_gate_msg_.header.frame_id = input_msg->header.frame_id;
-    twist_gate_msg_.header.stamp = input_msg->header.stamp;
-    twist_gate_msg_.header.seq++;
-    twist_gate_msg_.lamp_cmd.l = input_msg->l;
-    twist_gate_msg_.lamp_cmd.r = input_msg->r;
-  }
-}
-
-void TwistGate::ctrl_cmd_callback(const autoware_msgs::ControlCommandStamped::ConstPtr& input_msg)
-{
-  if (command_mode_ == CommandMode::AUTO && !emergency_handling_active_)
-  {
-    twist_gate_msg_.header.frame_id = input_msg->header.frame_id;
-    twist_gate_msg_.header.stamp = input_msg->header.stamp;
-    twist_gate_msg_.header.seq++;
-    twist_gate_msg_.ctrl_cmd = input_msg->cmd;
-
-    check_state();
-  }
-}
-
-void TwistGate::state_callback(const std_msgs::StringConstPtr& input_msg)
-{
-  state_time_ = ros::Time::now();
-  if (command_mode_ == CommandMode::AUTO && !emergency_handling_active_)
-  {
-    // Set Parking Gear
-    if (input_msg->data.find("WaitOrder") != std::string::npos)
-    {
-      twist_gate_msg_.gear = CMD_GEAR_P;
+      output_msg_.gear_cmd.gear = autoware_msgs::Gear::PARK;
     }
     // Set Drive Gear
     else
     {
-      twist_gate_msg_.gear = CMD_GEAR_D;
+      if (use_lgsim_)
+      {
+        output_msg_.gear_cmd.gear = autoware_msgs::Gear::NONE;
+      }
+      else
+      {
+        output_msg_.gear_cmd.gear = autoware_msgs::Gear::DRIVE;
+      }
     }
 
     // get drive state
@@ -324,19 +149,42 @@ void TwistGate::state_callback(const std_msgs::StringConstPtr& input_msg)
   }
 }
 
-void TwistGate::emergency_cmd_callback(const vehicle_cmd_msg_t::ConstPtr& input_msg)
+void TwistGate::emergencyCmdCallback(const vehicle_cmd_msg_t::ConstPtr& input_msg)
 {
   emergency_handling_time_ = ros::Time::now();
   emergency_handling_active_ = true;
-  twist_gate_msg_ = *input_msg;
+  output_msg_ = *input_msg;
+
+  updateStateAndPublish();
 }
 
-void TwistGate::timer_callback(const ros::TimerEvent& e)
+void TwistGate::updateEmergencyState()
 {
-  vehicle_cmd_pub_.publish(twist_gate_msg_);
+  // Reset emergency handling
+  if (emergency_handling_active_)
+  {
+    // If no emergency message received for more than timeout_period_
+    if ((ros::Time::now() - emergency_handling_time_) > timeout_period_)
+    {
+      emergency_handling_active_ = false;
+    }
+  }
 }
 
-void TwistGate::config_callback(const autoware_config_msgs::ConfigTwistFilter& msg)
+void TwistGate::updateStateAndPublish()
+{
+  // Clear commands if we aren't in drive state
+  // ssc_interface will handle autonomy disengagements if the control commands timeout
+  if (use_decision_maker_ && (!is_state_drive_))
+  {
+    output_msg_.twist_cmd.twist = geometry_msgs::Twist();
+    output_msg_.ctrl_cmd = autoware_msgs::ControlCommand();
+  }
+
+  vehicle_cmd_pub_.publish(output_msg_);
+}
+
+void TwistGate::configCallback(const autoware_config_msgs::ConfigTwistFilter& msg)
 {
   use_decision_maker_ = msg.use_decision_maker;
 }

--- a/core_planning/twist_gate/test/src/test_twist_gate.cpp
+++ b/core_planning/twist_gate/test/src/test_twist_gate.cpp
@@ -37,43 +37,6 @@ protected:
   virtual void TearDown() { delete test_obj_.tg; }
 };
 
-TEST_F(TwistGateTestSuite, resetVehicelCmd)
-{
-  double d_value = 1.5;
-  int i_value = 1;
-
-  autoware_msgs::VehicleCmd msg = test_obj_.setTgTwistGateMsg(d_value, i_value);
-
-  ASSERT_EQ(d_value, msg.twist_cmd.twist.linear.x);
-  ASSERT_EQ(d_value, msg.twist_cmd.twist.angular.z);
-  ASSERT_EQ(i_value, msg.mode);
-  ASSERT_EQ(i_value, msg.gear);
-  ASSERT_EQ(i_value, msg.lamp_cmd.l);
-  ASSERT_EQ(i_value, msg.lamp_cmd.r);
-  ASSERT_EQ(i_value, msg.accel_cmd.accel);
-  ASSERT_EQ(i_value, msg.brake_cmd.brake);
-  ASSERT_EQ(i_value, msg.steer_cmd.steer);
-  ASSERT_EQ(i_value, msg.ctrl_cmd.linear_velocity);
-  ASSERT_EQ(i_value, msg.ctrl_cmd.steering_angle);
-  ASSERT_EQ(i_value, msg.emergency);
-
-  test_obj_.tgResetVehicleCmdMsg();
-  msg = test_obj_.getTgTwistGateMsg();
-
-  ASSERT_EQ(0, msg.twist_cmd.twist.linear.x);
-  ASSERT_EQ(0, msg.twist_cmd.twist.angular.z);
-  ASSERT_EQ(0, msg.mode);
-  ASSERT_EQ(0, msg.gear);
-  ASSERT_EQ(0, msg.lamp_cmd.l);
-  ASSERT_EQ(0, msg.lamp_cmd.r);
-  ASSERT_EQ(0, msg.accel_cmd.accel);
-  ASSERT_EQ(0, msg.brake_cmd.brake);
-  ASSERT_EQ(0, msg.steer_cmd.steer);
-  ASSERT_EQ(-1, msg.ctrl_cmd.linear_velocity);
-  ASSERT_EQ(0, msg.ctrl_cmd.steering_angle);
-  ASSERT_EQ(0, msg.emergency);
-}
-
 TEST_F(TwistGateTestSuite, twistCmdCallback)
 {
   double linear_x = 5.0;
@@ -111,155 +74,21 @@ TEST_F(TwistGateTestSuite, controlCmdCallback)
   ASSERT_EQ(steer_angle, test_obj_.cb_vehicle_cmd.ctrl_cmd.steering_angle);
 }
 
-TEST_F(TwistGateTestSuite, remoteCmdCallback)
-{
-  autoware_msgs::RemoteCmd remote_cmd;
-  remote_cmd.vehicle_cmd.header.frame_id = "/test_frame";
-  remote_cmd.vehicle_cmd.header.stamp = ros::Time::now();
-  remote_cmd.vehicle_cmd.twist_cmd.twist.linear.x = 5.0;
-  remote_cmd.vehicle_cmd.twist_cmd.twist.angular.z = 0.785;
-  remote_cmd.vehicle_cmd.ctrl_cmd.linear_velocity = 4.0;
-  remote_cmd.vehicle_cmd.ctrl_cmd.linear_acceleration = 3.0;
-  remote_cmd.vehicle_cmd.ctrl_cmd.steering_angle = 0.393;
-  remote_cmd.vehicle_cmd.accel_cmd.accel = 10;
-  remote_cmd.vehicle_cmd.brake_cmd.brake = 20;
-  remote_cmd.vehicle_cmd.steer_cmd.steer = 30;
-  remote_cmd.vehicle_cmd.gear = CMD_GEAR_P;
-  remote_cmd.vehicle_cmd.lamp_cmd.l = 1;
-  remote_cmd.vehicle_cmd.lamp_cmd.r = 1;
-  remote_cmd.vehicle_cmd.mode = 6;
-  remote_cmd.vehicle_cmd.emergency = 0;
-  remote_cmd.control_mode = 2;
-
-  test_obj_.publishRemoteCmd(remote_cmd);
-  ros::WallDuration(0.1).sleep();
-  test_obj_.tgSpinOnce();
-  for (int i = 0; i < 3; i++)
-  {
-    ros::WallDuration(0.1).sleep();
-    ros::spinOnce();
-  }
-
-  ASSERT_EQ(remote_cmd.vehicle_cmd.header.frame_id
-      , test_obj_.cb_vehicle_cmd.header.frame_id);
-  ASSERT_EQ(remote_cmd.vehicle_cmd.header.stamp
-      , test_obj_.cb_vehicle_cmd.header.stamp);
-  ASSERT_EQ(remote_cmd.vehicle_cmd.twist_cmd.twist.linear.x
-      , test_obj_.cb_vehicle_cmd.twist_cmd.twist.linear.x);
-  ASSERT_EQ(remote_cmd.vehicle_cmd.twist_cmd.twist.angular.z
-      , test_obj_.cb_vehicle_cmd.twist_cmd.twist.angular.z);
-  ASSERT_EQ(remote_cmd.vehicle_cmd.ctrl_cmd.linear_velocity
-      , test_obj_.cb_vehicle_cmd.ctrl_cmd.linear_velocity);
-  ASSERT_EQ(remote_cmd.vehicle_cmd.ctrl_cmd.linear_acceleration
-      , test_obj_.cb_vehicle_cmd.ctrl_cmd.linear_acceleration);
-  ASSERT_EQ(remote_cmd.vehicle_cmd.ctrl_cmd.steering_angle
-      , test_obj_.cb_vehicle_cmd.ctrl_cmd.steering_angle);
-  ASSERT_EQ(remote_cmd.vehicle_cmd.accel_cmd.accel
-      , test_obj_.cb_vehicle_cmd.accel_cmd.accel);
-  ASSERT_EQ(remote_cmd.vehicle_cmd.brake_cmd.brake
-      , test_obj_.cb_vehicle_cmd.brake_cmd.brake);
-  ASSERT_EQ(remote_cmd.vehicle_cmd.steer_cmd.steer
-      , test_obj_.cb_vehicle_cmd.steer_cmd.steer);
-  ASSERT_EQ(remote_cmd.vehicle_cmd.gear
-      , test_obj_.cb_vehicle_cmd.gear);
-  ASSERT_EQ(remote_cmd.vehicle_cmd.lamp_cmd.l
-      , test_obj_.cb_vehicle_cmd.lamp_cmd.l);
-  ASSERT_EQ(remote_cmd.vehicle_cmd.lamp_cmd.r
-      , test_obj_.cb_vehicle_cmd.lamp_cmd.r);
-  ASSERT_EQ(remote_cmd.vehicle_cmd.mode
-      , test_obj_.cb_vehicle_cmd.mode);
-}
-
-TEST_F(TwistGateTestSuite, modeCmdCallback)
-{
-  int mode = 8;
-
-  test_obj_.publishModeCmd(mode);
-  ros::WallDuration(0.1).sleep();
-  test_obj_.tgSpinOnce();
-  for (int i = 0; i < 3; i++)
-  {
-    ros::WallDuration(0.1).sleep();
-    ros::spinOnce();
-  }
-
-
-  ASSERT_EQ(mode, test_obj_.cb_vehicle_cmd.mode);
-}
-
-TEST_F(TwistGateTestSuite, gearCmdCallback)
-{
-  int gear = CMD_GEAR_D;
-
-  test_obj_.publishGearCmd(gear);
-  ros::WallDuration(0.1).sleep();
-  test_obj_.tgSpinOnce();
-  for (int i = 0; i < 3; i++)
-  {
-    ros::WallDuration(0.1).sleep();
-    ros::spinOnce();
-  }
-
-
-  ASSERT_EQ(gear, test_obj_.cb_vehicle_cmd.gear);
-}
-
-TEST_F(TwistGateTestSuite, accelCmdCallback)
-{
-  int accel = 100;
-
-  test_obj_.publishAccelCmd(accel);
-  ros::WallDuration(0.1).sleep();
-  test_obj_.tgSpinOnce();
-  for (int i = 0; i < 3; i++)
-  {
-    ros::WallDuration(0.1).sleep();
-    ros::spinOnce();
-  }
-
-  ASSERT_EQ(accel, test_obj_.cb_vehicle_cmd.accel_cmd.accel);
-}
-
-TEST_F(TwistGateTestSuite, steerCmdCallback)
-{
-  int steer = 100;
-
-  test_obj_.publishSteerCmd(steer);
-  ros::WallDuration(0.1).sleep();
-  test_obj_.tgSpinOnce();
-  for (int i = 0; i < 3; i++)
-  {
-    ros::WallDuration(0.1).sleep();
-    ros::spinOnce();
-  }
-
-
-  ASSERT_EQ(steer, test_obj_.cb_vehicle_cmd.steer_cmd.steer);
-}
-
-TEST_F(TwistGateTestSuite, brakeCmdCallback)
-{
-  int brake = 100;
-
-  test_obj_.publishBrakeCmd(brake);
-  ros::WallDuration(0.1).sleep();
-  test_obj_.tgSpinOnce();
-  for (int i = 0; i < 3; i++)
-  {
-    ros::WallDuration(0.1).sleep();
-    ros::spinOnce();
-  }
-
-
-  ASSERT_EQ(brake, test_obj_.cb_vehicle_cmd.brake_cmd.brake);
-}
-
 TEST_F(TwistGateTestSuite, lampCmdCallback)
 {
   int lamp_l = 1;
   int lamp_r = 1;
 
+  double linear_vel = 5.0;
+  double linear_acc = 1.5;
+  double steer_angle = 1.57;
+
   test_obj_.publishLampCmd(lamp_l, lamp_r);
+  ros::WallDuration(0.1).sleep();
+  test_obj_.tgSpinOnce();
+
+  // Lamp commands are only updated when new control command is published
+  test_obj_.publishControlCmd(linear_vel, linear_acc, steer_angle);
   ros::WallDuration(0.1).sleep();
   test_obj_.tgSpinOnce();
   for (int i = 0; i < 3; i++)
@@ -274,12 +103,15 @@ TEST_F(TwistGateTestSuite, lampCmdCallback)
 
 TEST_F(TwistGateTestSuite, emergencyVehicleCmdCallback)
 {
-  int lamp_l_pre = 0;
-  int lamp_r_pre = 0;
+  double linear_vel = 5.0;
+  double linear_acc = 1.5;
+  double steer_angle = 1.57;
   int emergency = 1;
+  double emergency_vel = 0.5;
 
-  test_obj_.publishLampCmd(lamp_l_pre, lamp_r_pre);
-  test_obj_.publishEmergencyVehicleCmd(emergency);
+  // Trigger emergency
+  test_obj_.publishControlCmd(linear_vel, linear_acc, steer_angle);
+  test_obj_.publishEmergencyVehicleCmd(emergency, emergency_vel);
   ros::WallDuration(0.1).sleep();
   test_obj_.tgSpinOnce();
 
@@ -289,11 +121,10 @@ TEST_F(TwistGateTestSuite, emergencyVehicleCmdCallback)
     ros::spinOnce();
   }
 
+  // Make sure emergency mode was triggered
   ASSERT_EQ(emergency, test_obj_.cb_vehicle_cmd.emergency);
 
-  int lamp_l = 1;
-  int lamp_r = 1;
-  test_obj_.publishLampCmd(lamp_l, lamp_r);
+  test_obj_.publishControlCmd(linear_vel, linear_acc, steer_angle);
   ros::WallDuration(0.1).sleep();
   test_obj_.tgSpinOnce();
 
@@ -303,12 +134,14 @@ TEST_F(TwistGateTestSuite, emergencyVehicleCmdCallback)
     ros::spinOnce();
   }
 
-  ASSERT_EQ(lamp_l_pre, test_obj_.cb_vehicle_cmd.lamp_cmd.l);
-  ASSERT_EQ(lamp_r_pre, test_obj_.cb_vehicle_cmd.lamp_cmd.r);
+  // Make sure emergency mode still active and emergency cmds being used.
+  ASSERT_EQ(emergency, test_obj_.cb_vehicle_cmd.emergency);
+  ASSERT_EQ(emergency_vel, test_obj_.cb_vehicle_cmd.ctrl_cmd.linear_velocity);
 
+  // Clear emergency mode
   std::this_thread::sleep_for(std::chrono::milliseconds(10000));
 
-  test_obj_.publishLampCmd(lamp_l, lamp_r);
+  test_obj_.publishControlCmd(linear_vel, linear_acc, steer_angle);
   ros::WallDuration(0.1).sleep();
   test_obj_.tgSpinOnce();
 
@@ -318,8 +151,10 @@ TEST_F(TwistGateTestSuite, emergencyVehicleCmdCallback)
     ros::spinOnce();
   }
 
-  ASSERT_EQ(lamp_l, test_obj_.cb_vehicle_cmd.lamp_cmd.l);
-  ASSERT_EQ(lamp_r, test_obj_.cb_vehicle_cmd.lamp_cmd.r);
+  // Make sure emergency mode was cleared
+  ASSERT_EQ(linear_vel, test_obj_.cb_vehicle_cmd.ctrl_cmd.linear_velocity);
+  ASSERT_EQ(linear_acc, test_obj_.cb_vehicle_cmd.ctrl_cmd.linear_acceleration);
+  ASSERT_EQ(steer_angle, test_obj_.cb_vehicle_cmd.ctrl_cmd.steering_angle);
 }
 
 TEST_F(TwistGateTestSuite, stateCallback)
@@ -330,7 +165,7 @@ TEST_F(TwistGateTestSuite, stateCallback)
   ros::spinOnce();
 
   autoware_msgs::VehicleCmd tg_msg = test_obj_.getTwistGateMsg();
-  ASSERT_EQ(CMD_GEAR_P, tg_msg.gear);
+  ASSERT_EQ(autoware_msgs::Gear::PARK, tg_msg.gear_cmd.gear);
   ASSERT_EQ(false, test_obj_.getIsStateDriveFlag());
 
   test_obj_.publishDecisionMakerState("VehicleReady\nDriving\nDrive\n");
@@ -339,7 +174,7 @@ TEST_F(TwistGateTestSuite, stateCallback)
   ros::spinOnce();
 
   tg_msg = test_obj_.getTwistGateMsg();
-  ASSERT_EQ(CMD_GEAR_D, tg_msg.gear);
+  ASSERT_EQ(autoware_msgs::Gear::DRIVE, tg_msg.gear_cmd.gear);
   ASSERT_EQ(true, test_obj_.getIsStateDriveFlag());
 }
 

--- a/core_planning/twist_gate/test/src/test_twist_gate.hpp
+++ b/core_planning/twist_gate/test/src/test_twist_gate.hpp
@@ -28,12 +28,6 @@ public:
         nh.advertise<autoware_msgs::ControlCommandStamped>("ctrl_cmd", 0);
     decision_maker_state_publisher =
         nh.advertise<std_msgs::String>("decision_maker/state", 0);
-    remote_cmd_publisher = nh.advertise<autoware_msgs::RemoteCmd>("remote_cmd", 0);
-    mode_cmd_publisher = nh.advertise<tablet_socket_msgs::mode_cmd>("mode_cmd", 0);
-    gear_cmd_publisher = nh.advertise<tablet_socket_msgs::gear_cmd>("gear_cmd", 0);
-    accel_cmd_publisher = nh.advertise<autoware_msgs::AccelCmd>("accel_cmd", 0);
-    steer_cmd_publisher = nh.advertise<autoware_msgs::SteerCmd>("steer_cmd", 0);
-    brake_cmd_publisher = nh.advertise<autoware_msgs::BrakeCmd>("brake_cmd", 0);
     lamp_cmd_publisher = nh.advertise<autoware_msgs::LampCmd>("lamp_cmd", 0);
     emergency_vehicle_cmd_publisher = nh.advertise<autoware_msgs::VehicleCmd>("emergency_velocity", 0);
     vehicle_cmd_subscriber = nh.subscribe(
@@ -49,26 +43,24 @@ public:
 
   void tgSpinOnce() { tg->spinOnce(); }
 
-  void tgResetVehicleCmdMsg() { tg->reset_vehicle_cmd_msg(); }
-
   autoware_msgs::VehicleCmd setTgTwistGateMsg(double d_value, int i_value) {
-    tg->twist_gate_msg_.twist_cmd.twist.linear.x = d_value;
-    tg->twist_gate_msg_.twist_cmd.twist.angular.z = d_value;
-    tg->twist_gate_msg_.mode = i_value;
-    tg->twist_gate_msg_.gear = i_value;
-    tg->twist_gate_msg_.lamp_cmd.l = i_value;
-    tg->twist_gate_msg_.lamp_cmd.r = i_value;
-    tg->twist_gate_msg_.accel_cmd.accel = i_value;
-    tg->twist_gate_msg_.brake_cmd.brake = i_value;
-    tg->twist_gate_msg_.steer_cmd.steer = i_value;
-    tg->twist_gate_msg_.ctrl_cmd.linear_velocity = i_value;
-    tg->twist_gate_msg_.ctrl_cmd.steering_angle = i_value;
-    tg->twist_gate_msg_.emergency = i_value;
+    tg->output_msg_.twist_cmd.twist.linear.x = d_value;
+    tg->output_msg_.twist_cmd.twist.angular.z = d_value;
+    tg->output_msg_.mode = i_value;
+    tg->output_msg_.gear_cmd.gear = i_value;
+    tg->output_msg_.lamp_cmd.l = i_value;
+    tg->output_msg_.lamp_cmd.r = i_value;
+    tg->output_msg_.accel_cmd.accel = i_value;
+    tg->output_msg_.brake_cmd.brake = i_value;
+    tg->output_msg_.steer_cmd.steer = i_value;
+    tg->output_msg_.ctrl_cmd.linear_velocity = i_value;
+    tg->output_msg_.ctrl_cmd.steering_angle = i_value;
+    tg->output_msg_.emergency = i_value;
 
-    return tg->twist_gate_msg_;
+    return tg->output_msg_;
   }
 
-  autoware_msgs::VehicleCmd getTgTwistGateMsg() {return tg->twist_gate_msg_;}
+  autoware_msgs::VehicleCmd getTgTwistGateMsg() {return tg->output_msg_;}
 
   void publishTwistCmd(double linear_x, double angular_z) {
     geometry_msgs::TwistStamped msg;
@@ -90,50 +82,6 @@ public:
     control_cmd_publisher.publish(msg);
   }
 
-  void publishRemoteCmd(autoware_msgs::RemoteCmd remote_cmd){
-    remote_cmd_publisher.publish(remote_cmd);
-  }
-
-  void publishModeCmd(int mode){
-    tablet_socket_msgs::mode_cmd msg;
-    msg.header.stamp = ros::Time::now();
-    msg.mode = mode;
-
-    mode_cmd_publisher.publish(msg);
-  }
-
-  void publishGearCmd(int gear){
-    tablet_socket_msgs::gear_cmd msg;
-    msg.header.stamp = ros::Time::now();
-    msg.gear = gear;
-
-    gear_cmd_publisher.publish(msg);
-  }
-
-  void publishAccelCmd(int accel){
-    autoware_msgs::AccelCmd msg;
-    msg.header.stamp = ros::Time::now();
-    msg.accel = accel;
-
-    accel_cmd_publisher.publish(msg);
-  }
-
-  void publishSteerCmd(int steer){
-    autoware_msgs::SteerCmd msg;
-    msg.header.stamp = ros::Time::now();
-    msg.steer = steer;
-
-    steer_cmd_publisher.publish(msg);
-  }
-
-  void publishBrakeCmd(int brake){
-    autoware_msgs::BrakeCmd msg;
-    msg.header.stamp = ros::Time::now();
-    msg.brake = brake;
-
-    brake_cmd_publisher.publish(msg);
-  }
-
   void publishLampCmd(int lamp_l, int lamp_r){
     autoware_msgs::LampCmd msg;
     msg.header.stamp = ros::Time::now();
@@ -143,10 +91,11 @@ public:
     lamp_cmd_publisher.publish(msg);
   }
 
-  void publishEmergencyVehicleCmd(int emergency){
+  void publishEmergencyVehicleCmd(int emergency, double linear_vel){
     autoware_msgs::VehicleCmd msg;
     msg.header.stamp = ros::Time::now();
     msg.emergency = emergency;
+    msg.ctrl_cmd.linear_velocity = linear_vel;
 
     emergency_vehicle_cmd_publisher.publish(msg);
   }
@@ -162,7 +111,7 @@ public:
     cb_vehicle_cmd = msg;
   }
 
-  autoware_msgs::VehicleCmd getTwistGateMsg() { return tg->twist_gate_msg_; }
+  autoware_msgs::VehicleCmd getTwistGateMsg() { return tg->output_msg_; }
 
   bool getIsStateDriveFlag() { return tg->is_state_drive_; }
 };

--- a/drivers/as/launch/ssc_interface.launch
+++ b/drivers/as/launch/ssc_interface.launch
@@ -4,6 +4,7 @@
 	<arg name="use_adaptive_gear_ratio" default="true"/>
 	<arg name="command_timeout" default="1000"/>
 	<arg name="loop_rate" default="30.0"/>
+	<arg name="status_pub_rate" default="30.0" doc="The default publication rate in hz of the vehicle status information. If no new messages are available then a timestep will be skipped"/>
 	<arg name="wheel_base" default="2.79"/>
 	<arg name="tire_radius" default="0.39"/>
 	<arg name="acceleration_limit" default="3.0"/>

--- a/drivers/as/launch/ssc_interface.launch
+++ b/drivers/as/launch/ssc_interface.launch
@@ -11,7 +11,7 @@
 	<arg name="deceleration_limit" default="3.0"/>
 	<arg name="max_curvature_rate" default="0.75"/>
 
-	<node pkg="as" type="ssc_interface" name="ssc_interface" output="screen">
+	<node pkg="as" type="ssc_interface" name="ssc_interface">
 		<param name="use_adaptive_gear_ratio" value="$(arg use_adaptive_gear_ratio)" />
 		<param name="command_timeout" value="$(arg command_timeout)" />
 		<param name="loop_rate" value="$(arg loop_rate)" />

--- a/drivers/as/launch/ssc_interface.launch
+++ b/drivers/as/launch/ssc_interface.launch
@@ -15,6 +15,7 @@
 		<param name="use_adaptive_gear_ratio" value="$(arg use_adaptive_gear_ratio)" />
 		<param name="command_timeout" value="$(arg command_timeout)" />
 		<param name="loop_rate" value="$(arg loop_rate)" />
+		<param name="status_pub_rate" value="$(arg status_pub_rate)" />
 		<param name="wheel_base" value="$(arg wheel_base)" />
 		<param name="tire_radius" value="$(arg tire_radius)" />
 		<param name="acceleration_limit" value="$(arg acceleration_limit)" />

--- a/drivers/as/nodes/ssc_interface/ssc_interface.cpp
+++ b/drivers/as/nodes/ssc_interface/ssc_interface.cpp
@@ -239,10 +239,9 @@ void SSCInterface::callbackFromSSCFeedbacks(const automotive_platform_msgs::Velo
 
 void SSCInterface::publishCommand()
 {
-  if (!command_initialized_)
-  {
-    return;
-  }
+  // 
+  // This method will publish 0 commands until the vehicle_cmd has actually been populated with non-zeros
+  // When the vehicle_cmd_ becomes populated it will start to forward that instead
 
   ros::Time stamp = ros::Time::now();
 
@@ -302,7 +301,7 @@ void SSCInterface::publishCommand()
 
   // Override desired speed to ZERO by emergency/timeout
   bool emergency = (vehicle_cmd_.emergency == 1);
-  bool timeouted = (((ros::Time::now() - command_time_).toSec() * 1000) > command_timeout_);
+  bool timeouted = command_initialized_ && (((ros::Time::now() - command_time_).toSec() * 1000) > command_timeout_);
 
   if (emergency || timeouted)
   {

--- a/drivers/as/nodes/ssc_interface/ssc_interface.cpp
+++ b/drivers/as/nodes/ssc_interface/ssc_interface.cpp
@@ -99,7 +99,7 @@ void SSCInterface::run()
   ros::Timer command_pub_timer = nh_.createTimer( // Create a ros timer to publish commands at the ssc expected loop rate
     rate_.expectedCycleTime(),
     
-    [this, &shm_ASvmon, &shm_ROvmon, &shm_HAvmon](const auto&) { 
+    [this](const auto&) { 
       
       ROS_DEBUG_STREAM("Command Timer Triggered");
 

--- a/drivers/as/nodes/ssc_interface/ssc_interface.h
+++ b/drivers/as/nodes/ssc_interface/ssc_interface.h
@@ -121,7 +121,7 @@ private:
   cav_msgs::GuidanceState guidance_state_;
   autoware_msgs::VehicleCmd vehicle_cmd_;
   automotive_navigation_msgs::ModuleState module_states_;
-  ros::Rate* rate_;
+  ros::Rate rate_;
   ros::Rate status_pub_rate_; // Rate of vehicle status publications
 
   // Flag to indicate whether the ssc should shift the vehicle to park

--- a/drivers/as/nodes/ssc_interface/ssc_interface.h
+++ b/drivers/as/nodes/ssc_interface/ssc_interface.h
@@ -116,12 +116,17 @@ private:
   autoware_msgs::VehicleCmd vehicle_cmd_;
   automotive_navigation_msgs::ModuleState module_states_;
   ros::Rate* rate_;
+  ros::Rate status_pub_rate_; // Rate of vehicle status publications
 
   // Flag to indicate whether the ssc should shift the vehicle to park
   bool shift_to_park_{false};
 
   //A small static value for comparing doubles
   static constexpr double epsilon_ = 0.001;
+
+  bool have_vehicle_status_ = false; // Flag to show if the vehicle status messages have been populated with new information
+  geometry_msgs::TwistStamped current_twist_msg_; // Current twist message recieved from ssc
+  autoware_msgs::VehicleStatus current_status_msg_; // Current status message recieved from ssc
 
   // callbacks
   void callbackFromGuidanceState(const cav_msgs::GuidanceStateConstPtr& msg);
@@ -136,6 +141,10 @@ private:
                                 const automotive_platform_msgs::SteeringFeedbackConstPtr& msg_steering_wheel);
   // functions
   void publishCommand();
+  /**
+   * \brief Publishes the current_twist_msg_ and current_status_msg_. Meant to be called at fixed frequency as the SSC does not provide uniform velocity publication frequency between cars
+   */ 
+  void publishVehicleStatus();
 };
 
 #endif  // SSC_INTERFACE_H

--- a/messages/autoware_msgs/CMakeLists.txt
+++ b/messages/autoware_msgs/CMakeLists.txt
@@ -53,7 +53,7 @@ add_message_files(
             VehicleStatus.msg
             TrafficLightResult.msg
             TrafficLightResultArray.msg
-
+            Gear.msg
             AccelCmd.msg
             AdjustXY.msg
             BrakeCmd.msg

--- a/messages/autoware_msgs/msg/Gear.msg
+++ b/messages/autoware_msgs/msg/Gear.msg
@@ -1,0 +1,7 @@
+uint8 NONE=0
+uint8 PARK=1
+uint8 REVERSE=2
+uint8 NEUTRAL=3
+uint8 DRIVE=4
+uint8 LOW=5
+uint8 gear

--- a/messages/autoware_msgs/msg/VehicleCmd.msg
+++ b/messages/autoware_msgs/msg/VehicleCmd.msg
@@ -3,7 +3,7 @@ autoware_msgs/SteerCmd steer_cmd
 autoware_msgs/AccelCmd accel_cmd
 autoware_msgs/BrakeCmd brake_cmd
 autoware_msgs/LampCmd lamp_cmd
-int32 gear
+autoware_msgs/Gear gear_cmd
 int32 mode
 geometry_msgs/TwistStamped twist_cmd
 autoware_msgs/ControlCommand ctrl_cmd

--- a/utilities/calibration_publisher/CMakeLists.txt
+++ b/utilities/calibration_publisher/CMakeLists.txt
@@ -11,7 +11,9 @@ find_package(catkin REQUIRED COMPONENTS
         cv_bridge
         image_transport
         autoware_msgs
-        tf
+        tf2
+        tf2_ros
+        geometry_msgs
         )
 
 find_package(OpenCV REQUIRED)
@@ -24,7 +26,9 @@ catkin_package(
         cv_bridge
         image_transport
         autoware_msgs
-        tf
+        tf2
+        tf2_ros
+        geometry_msgs
 )
 
 include_directories(

--- a/utilities/calibration_publisher/package.xml
+++ b/utilities/calibration_publisher/package.xml
@@ -17,5 +17,7 @@
   <depend>roscpp</depend>
   <depend>sensor_msgs</depend>
   <depend>std_msgs</depend>
-  <depend>tf</depend>
+  <depend>tf2</depend>
+  <depend>tf2_ros</depend>
+  <depend>geometry_msgs</depend>
 </package>

--- a/utilities/calibration_publisher/src/calibration_publisher.cpp
+++ b/utilities/calibration_publisher/src/calibration_publisher.cpp
@@ -21,7 +21,6 @@
 #include <tf2/LinearMath/Quaternion.h>
 #include <tf2/LinearMath/Matrix3x3.h>
 #include <tf2/LinearMath/Vector3.h>
-#include <tf/transform_datatypes.h>
 #include <opencv2/core/core.hpp>
 #include <opencv2/highgui/highgui.hpp>
 #include <sensor_msgs/Image.h>


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
This PR attempts to reduce planning system latency by making autoware components use ros::spin instead of spinOnce. This is basically the same approach taken in this PR https://github.com/usdot-fhwa-stol/carma-platform/pull/1216
The change set is as follows:
* ssc_interface updated to use ros::spin(). 
* ssc_interface updated to do fixed rate publication of vehicle/twist. Analysis of SSCs on different vehicles showed that they exhibit different velocity publication frequencies with the Lexus publishing at ~30Hz and the Ford Fusion publishing at ~100Hz. Since the localization EKF requires a parameter defining the input frequency of the velocity input it is important that we fix this value. Therefore the ssc_interface was fixed at a 30Hz publication rate. There is the posibility for some latency on the lexus due to its 30Hz output however, I don't want to reduce below 30Hz as the pure_pursuit node is meant to operate at 30Hz and the SSC itself expects a 30Hz command input. 
* twist_gate has been updated to use ros::spin(). Rather than do this update myself I have elected to copy wholesale the same update performed on the AStuff autoware.ai fork. Since AStuff tests using the same vehicles I expect this should be ok. I also feel their changes improve the logic of this component. A small change was made to the autoware_msgs/VehicleCmd message to support this change. As far as I can tell this will have no impact on the rest of our system as it was an unused field that got changed. 
* twist_gate has been updated with a use_twist parameter to toggle between forwarding ctrl and twist commands to prevent duplication of vehicle command message publication
* pure_pursuit was updated to use ros::spin() and publish commands at 30Hz. Additionally, the node no longer requires that new information be available before publishing new commands. This is because its important we maintain the input frequency required by the SSC speed controller. I considered leaving this responsibility to twist_gate, but that would have introduced additional latency due to multiple same frequency publishers in the command signal chain. 
*  The calibration_publisher used for camera/lidar calibration was updated to publish the relevant transform to /tf_static. Previously it had been spamming this constant transform onto the /tf topic which is unnecessary bandwidth usage. 
* Added the autoware_msgs/Gear.msg as required by the AStuff twist_gate updates. 
* Reverts an earlier change to NDT Matching which introduced additional latency when lidar messages are out of phase with the ndt spin rate. NDT has been changed back to event driven

<!--- Describe your changes in detail -->

## Related Issue
https://github.com/usdot-fhwa-stol/carma-platform/issues/1211
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Reduce latency in the CARMA Platform planning stack by using event driven callbacks in as many nodes as is practical
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Tested on Ford Fusion at TFHRC
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.