### PR TITLE
1339 - Add `tf2_geometry_msgs` as `amathutils_lib` package dependency

### DIFF
--- a/common/amathutils_lib/CMakeLists.txt
+++ b/common/amathutils_lib/CMakeLists.txt
@@ -22,6 +22,7 @@ find_package(catkin REQUIRED COMPONENTS
   roslint
   tf
   tf2
+  tf2_geometry_msgs
 )
 
 set(CMAKE_CXX_FLAGS "-O2 -Wall ${CMAKE_CXX_FLAGS}")
@@ -33,6 +34,7 @@ catkin_package(
     autoware_msgs
     tf
     tf2
+    tf2_geometry_msgs
 )
 
 include_directories(

--- a/common/amathutils_lib/package.xml
+++ b/common/amathutils_lib/package.xml
@@ -15,6 +15,7 @@
   <depend>roscpp</depend>
   <depend>roslint</depend>
   <depend>tf2</depend>
+  <depend>tf2_geometry_msgs</depend>
   <depend>tf</depend>
   <depend>eigen</depend>
 </package>


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->

Add the `tf2_geometry_msgs` package as a dependency for the `amathutils_lib` package. The `amathutils_lib` package can now be built using either the binary version of `tf2_geometry_msgs` (e.g., installed through `apt`) or the source version.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Closes usdot-fhwa-stol/carma-platform#1339

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Without the dependency listed, the `amathutils_lib` package would only successfully build if `tf2_geometry_msgs` package was already installed. If a developer wanted to use the source version of `tf2_geometry_msgs`, `amathutils_lib` would not build.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

`amathutils_lib` package was built in a new ROS workspace with only the `tf2_geometry_msgs` repository added. Binaries of any package dependencies (excluding `ros-noetic-tf2-geometry-msgs`) were installed with `rosdep`.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.