### PR TITLE
traffic predict state

### DIFF
--- a/common/lanelet2_extension/CMakeLists.txt
+++ b/common/lanelet2_extension/CMakeLists.txt
@@ -77,6 +77,7 @@ add_library( lanelet2_extension_lib
   lib/utilities.cpp
   lib/visualization.cpp
   lib/CarmaUSTrafficRules.cpp
+  lib/CarmaTrafficLight.cpp
   lib/PassingControlLine.cpp
   lib/StopRule.cpp
   lib/DigitalSpeedLimit.cpp

--- a/common/lanelet2_extension/CMakeLists.txt
+++ b/common/lanelet2_extension/CMakeLists.txt
@@ -145,6 +145,7 @@ if(CATKIN_ENABLE_TESTING)
   test/src/CarmaUSTrafficRulesTest.cpp
   test/src/MapLoadingTest.cpp
   test/src/test_local_projector.cpp
+  test/src/CarmaTrafficTest.cpp
   WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/test # Add test directory as working directory for unit tests
  )
 

--- a/common/lanelet2_extension/include/lanelet2_extension/regulatory_elements/CarmaTrafficLight.h
+++ b/common/lanelet2_extension/include/lanelet2_extension/regulatory_elements/CarmaTrafficLight.h
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2021 LEIDOS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+#ifndef LANELET2_EXTENSION_REGULATORY_ELEMENTS_CARMA_TRAFFIC_LIGHT_H
+#define LANELET2_EXTENSION_REGULATORY_ELEMENTS_CARMA_TRAFFIC_LIGHT_H
+
+#include <lanelet2_core/primitives/RegulatoryElement.h>
+#include <ros/ros.h>
+
+namespace lanelet
+{
+/**
+ * @brief TODO: TrafficLight
+ *
+ * @ingroup RegulatoryElementPrimitives
+ * @ingroup Primitives
+ */
+
+enum class CarmaTrafficLightState {UNAVAILABLE=0,DARK=1,STOP_THEN_PROCEED=2,STOP_AND_REMAIN=3,PRE_MOVEMENT=4,PERMISSIVE_MOVEMENT_ALLOWED=5,PROTECTED_MOVEMENT_ALLOWED=6,PERMISSIVE_CLEARANCE=7,PROTECTED_CLEARANCE=8,CAUTION_CONFLICTING_TRAFFIC=9};
+
+class CarmaTrafficLight : public lanelet::RegulatoryElement
+{
+public:
+  static constexpr char RuleName[] = "carma_traffic_light";
+  int revision_ = 0; //indicates when was this last modified
+  ros::Duration fixed_cycle_duration;
+  std::vector<std::pair<ros::Time, CarmaTrafficLightState>> recorded_time_stamps;
+  // TODO: sorts it automatically
+  void setStates(std::vector<std::pair<ros::Time, CarmaTrafficLightState>> input_time_steps, int revision);
+  // TODO: return current, ros::Time::now
+  CarmaTrafficLightState getState();
+  // TODO: assumes sorted, fixed time, so guaranteed to give you one
+  CarmaTrafficLightState predictState(ros::Time time_stamp);
+  ConstLineStrings3d stopLine() const;
+  LineStrings3d stopLine();
+
+  explicit CarmaTrafficLight(const lanelet::RegulatoryElementDataPtr& data);
+  /**
+   * @brief TODO: Creating one is not directly usable unless setStates is called Static helper function that creates a stop line data object based on the provided inputs
+   *
+   * @param id The lanelet::Id of this element
+   * @param traffic_light The line strings which represent this regularoty elements geometry
+   *
+   * @return RegulatoryElementData containing all the necessary information to construct a stop rule
+   */
+  static std::unique_ptr<lanelet::RegulatoryElementData> buildData(Id id, LineStrings3d stop_line, Lanelets lanelets,
+                                                                Areas areas);
+
+private:
+  // the following lines are required so that lanelet2 can create this object
+  // when loading a map with this regulatory element
+  friend class lanelet::RegisterRegulatoryElement<CarmaTrafficLight>;
+};
+
+
+// Convenience Ptr Declarations
+using CarmaTrafficLightPtr = std::shared_ptr<CarmaTrafficLight>;
+using CarmaTrafficLightConstPtr = std::shared_ptr<const CarmaTrafficLight>;
+
+}  // namespace lanelet
+
+#endif  // LANELET2_EXTENSION_REGULATORY_ELEMENTS_CARMA_TRAFFIC_LIGHT_H

--- a/common/lanelet2_extension/include/lanelet2_extension/regulatory_elements/CarmaTrafficLight.h
+++ b/common/lanelet2_extension/include/lanelet2_extension/regulatory_elements/CarmaTrafficLight.h
@@ -23,7 +23,7 @@
 namespace lanelet
 {
 /**
- * @brief TODO: TrafficLight
+ * @brief: TrafficLight are divided into 9 states.They are UNAVAILABLE=0,DARK=1,STOP_THEN_PROCEED=2,STOP_AND_REMAIN=3,PRE_MOVEMENT=4,PERMISSIVE_MOVEMENT_ALLOWED=5,PROTECTED_MOVEMENT_ALLOWED=6,PERMISSIVE_CLEARANCE=7,PROTECTED_CLEARANCE=8,CAUTION_CONFLICTING_TRAFFIC=9
  *
  * @ingroup RegulatoryElementPrimitives
  * @ingroup Primitives
@@ -38,18 +38,30 @@ public:
   int revision_ = 0; //indicates when was this last modified
   ros::Duration fixed_cycle_duration;
   std::vector<std::pair<ros::Time, CarmaTrafficLightState>> recorded_time_stamps;
-  // TODO: sorts it automatically
+  /**
+   * @brief setStates function sorts states automatically
+   *
+   * @param data The data to initialize this regulation with
+   */
   void setStates(std::vector<std::pair<ros::Time, CarmaTrafficLightState>> input_time_steps, int revision);
-  // TODO: return current, ros::Time::now
+  /**
+   * @brief getState get the current state
+   *
+   * @return return current, ros::Time::now
+   */
   boost::optional<CarmaTrafficLightState> getState();
-  // TODO: assumes sorted, fixed time, so guaranteed to give you one
+  /**
+   * @brief prefictState assumes sorted, fixed time, so guaranteed to give you one final state
+   *
+   * @param time_stamp ros::Time of the event happening
+   */
   boost::optional<CarmaTrafficLightState> predictState(ros::Time time_stamp);
   ConstLineStrings3d stopLine() const;
   LineStrings3d stopLine();
 
   explicit CarmaTrafficLight(const lanelet::RegulatoryElementDataPtr& data);
   /**
-   * @brief TODO: Creating one is not directly usable unless setStates is called Static helper function that creates a stop line data object based on the provided inputs
+   * @brief: Creating one is not directly usable unless setStates is called Static helper function that creates a stop line data object based on the provided inputs
    *
    * @param id The lanelet::Id of this element
    * @param stop_line The line string which represent the stop line of the traffic light

--- a/common/lanelet2_extension/include/lanelet2_extension/regulatory_elements/CarmaTrafficLight.h
+++ b/common/lanelet2_extension/include/lanelet2_extension/regulatory_elements/CarmaTrafficLight.h
@@ -41,9 +41,9 @@ public:
   // TODO: sorts it automatically
   void setStates(std::vector<std::pair<ros::Time, CarmaTrafficLightState>> input_time_steps, int revision);
   // TODO: return current, ros::Time::now
-  CarmaTrafficLightState getState();
+  boost::optional<CarmaTrafficLightState> getState();
   // TODO: assumes sorted, fixed time, so guaranteed to give you one
-  CarmaTrafficLightState predictState(ros::Time time_stamp);
+  boost::optional<CarmaTrafficLightState> predictState(ros::Time time_stamp);
   ConstLineStrings3d stopLine() const;
   LineStrings3d stopLine();
 
@@ -52,12 +52,11 @@ public:
    * @brief TODO: Creating one is not directly usable unless setStates is called Static helper function that creates a stop line data object based on the provided inputs
    *
    * @param id The lanelet::Id of this element
-   * @param traffic_light The line strings which represent this regularoty elements geometry
+   * @param stop_line The line string which represent the stop line of the traffic light
    *
    * @return RegulatoryElementData containing all the necessary information to construct a stop rule
    */
-  static std::unique_ptr<lanelet::RegulatoryElementData> buildData(Id id, LineStrings3d stop_line, Lanelets lanelets,
-                                                                Areas areas);
+  static std::unique_ptr<lanelet::RegulatoryElementData> buildData(Id id, LineString3d stop_line);
 
 private:
   // the following lines are required so that lanelet2 can create this object

--- a/common/lanelet2_extension/lib/CarmaTrafficLight.cpp
+++ b/common/lanelet2_extension/lib/CarmaTrafficLight.cpp
@@ -1,0 +1,137 @@
+/*
+ * Copyright (C) 2020-2021 LEIDOS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+#include <lanelet2_extension/regulatory_elements/CarmaTrafficLight.h>
+#include "RegulatoryHelpers.h"
+
+namespace lanelet
+{
+// C++ 14 vs 17 parameter export
+#if __cplusplus < 201703L
+constexpr char CarmaTrafficLight::RuleName[];  // instantiate string in cpp file
+#endif
+
+ConstLineStrings3d CarmaTrafficLight::stopLine() const
+{
+  return getParameters<ConstLineString3d>(RoleName::RefLine);
+}
+
+LineStrings3d CarmaTrafficLight::stopLine()
+{
+  return getParameters<LineString3d>(RoleName::RefLine);
+}
+
+CarmaTrafficLight::CarmaTrafficLight(const lanelet::RegulatoryElementDataPtr& data) : RegulatoryElement(data)
+{}
+
+std::unique_ptr<lanelet::RegulatoryElementData> CarmaTrafficLight::buildData(Id id, LineStrings3d stop_line, Lanelets lanelets,
+                                                                Areas areas)
+{
+  for (auto ls : stop_line)
+  {
+    if (ls.empty()) throw lanelet::InvalidInputError("Empty linestring was passed into CarmaTrafficLight buildData function");
+  }
+  
+  // Add parameters
+  RuleParameterMap rules;
+
+  rules[lanelet::RoleNameString::RefLine].insert(rules[lanelet::RoleNameString::RefLine].end(), stop_line.begin(),
+                                                 stop_line.end());
+
+  // Add attributes
+  AttributeMap attribute_map({
+      { AttributeNamesString::Type, AttributeValueString::RegulatoryElement },
+      { AttributeNamesString::Subtype, RuleName },
+  });
+
+  return std::make_unique<RegulatoryElementData>(id, rules, attribute_map);
+}
+
+CarmaTrafficLightState CarmaTrafficLight::getState()
+{
+  return predictState(ros::Time::now());
+}
+
+CarmaTrafficLightState CarmaTrafficLight::predictState(ros::Time time_stamp)
+{
+  if (recorded_time_stamps.empty())
+  {
+    throw::lanelet::InvalidObjectStateError("CarmaTrafficLight doesn't have any recorded states of traffic lights");
+  }
+  if (recorded_time_stamps.size() == 1) // if only 1 timestamp recorded, this signal doesn't change
+  {
+    return recorded_time_stamps.front().second;
+  }
+  // shift starting time to the future or to the past to fit input into a valid cycle
+  ros::Duration accumulated_offset_duration;
+  double offset_duration_dir = recorded_time_stamps.front().first > time_stamp ? -1.0 : 1.0; // -1 if past, +1 if time_stamp is in future
+
+  if (offset_duration_dir < 0) 
+  {
+    while (recorded_time_stamps.front().first - accumulated_offset_duration > time_stamp)
+    {
+      accumulated_offset_duration += fixed_cycle_duration;
+    }
+  }
+  else
+  {
+    while (recorded_time_stamps.front().first + accumulated_offset_duration < time_stamp)
+    {
+      accumulated_offset_duration += fixed_cycle_duration;
+    }
+  }
+  
+  // iterate through states in the cycle to get the signal
+  for (int i = 0; i < recorded_time_stamps.size(); i++)
+  {
+    if (recorded_time_stamps[i].first.toSec() + offset_duration_dir * accumulated_offset_duration.toSec() >= time_stamp.toSec())
+    { 
+      return recorded_time_stamps[i].second;
+    }
+  }
+}
+
+void CarmaTrafficLight::setStates(std::vector<std::pair<ros::Time, CarmaTrafficLightState>> input_time_steps, int revision)
+{
+  if (input_time_steps.empty())
+  {
+    ROS_ERROR_STREAM("Given states for the CarmaTrafficLight Id: " << id() << " is empty. Returning...");
+    return;
+  }
+
+  std::sort(input_time_steps.begin(), input_time_steps.end());
+
+  //extract a cycle and trim the rest from the states
+  if (input_time_steps.size() > 2)
+  {
+    int idx = 2;
+    while (idx + 1 < input_time_steps.size() && input_time_steps[idx] != input_time_steps[0] && input_time_steps[idx + 1] != input_time_steps[1])
+    {
+      idx ++;
+    }
+    input_time_steps.resize(idx + 1);
+  }
+  
+  recorded_time_stamps = input_time_steps;
+  fixed_cycle_duration = recorded_time_stamps.back().first - recorded_time_stamps.front().first; // it is okay if size is only 1, case is handled in predictState
+  revision_ = revision;
+}
+namespace
+{
+// this object actually does the registration work for us
+lanelet::RegisterRegulatoryElement<lanelet::CarmaTrafficLight> reg;
+}  // namespace
+
+}  // namespace lanelet

--- a/common/lanelet2_extension/test/src/CarmaTrafficTest.cpp
+++ b/common/lanelet2_extension/test/src/CarmaTrafficTest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 LEIDOS.
+ * Copyright (C) 2021 LEIDOS.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/common/lanelet2_extension/test/src/CarmaTrafficTest.cpp
+++ b/common/lanelet2_extension/test/src/CarmaTrafficTest.cpp
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2019-2021 LEIDOS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+/*
+#include <gmock/gmock.h>
+#include <iostream>
+#include <lanelet2_extension/regulatory_elements/StopRule.h>
+#include <lanelet2_core/geometry/LineString.h>
+#include <lanelet2_traffic_rules/TrafficRulesFactory.h>
+#include <lanelet2_core/Attribute.h>
+#include "TestHelpers.h"
+#include <CarmaTrafficLight.h>
+
+using ::testing::_;
+using ::testing::A;
+using ::testing::DoAll;
+using ::testing::InSequence;
+using ::testing::Return;
+using ::testing::ReturnArg;
+
+namespace lanelet
+{
+
+TEST(CarmaTrafficLightTest, CarmaTrafficLight)
+{
+  auto pl1 = carma_wm::getPoint(0, 0, 0);
+  auto pl2 = carma_wm::getPoint(0, 1, 0);
+  auto pl3 = carma_wm::getPoint(0, 2, 0);
+  auto pr1 = carma_wm::getPoint(1, 0, 0);
+  auto pr2 = carma_wm::getPoint(1, 1, 0);
+  auto pr3 = carma_wm::getPoint(1, 2, 0);
+  std::vector<lanelet::Point3d> left_1 = { pl1, pl2, pl3 };
+  std::vector<lanelet::Point3d> right_1 = { pr1, pr2, pr3 };
+  auto ll_1 = carma_wm::getLanelet(left_1, right_1, lanelet::AttributeValueString::SolidDashed,lanelet::AttributeValueString::Dashed);
+  lanelet::Id traffic_light_id = utils::getId();
+  LineString3d virtual_stop_line(traffic_light_id, {pl2, pr2});
+  // Creat passing control line for solid dashed line
+  std::shared_ptr<CarmaTrafficLight> traffic_light(new CarmaTrafficLight(CarmaTrafficLight::buildData(lanelet::utils::getId(), { virtual_stop_line }, {ll_1}, {})));
+  ll_1.addRegulatoryElement(traffic_light);
+
+  std::vector<std::pair<ros::Time, CarmaTrafficLightState>> input_time_steps;
+  input_time_steps.push_back(make_pair(0,1));
+  //ll_1.setStates(std::vector<std::pair<ros::Time, CarmaTrafficLightState>> input_time_steps, int revision);
+  ll_1.setStates(input_time_steps, 0);
+
+  ASSERT_EQ(1,ll_1.recorded_time_stamps);
+  ASSERT_EQ(1,ll_1.fixed_cycle_duration);
+  ASSERT_EQ(1,ll_1.revision_);
+  ASSERT_EQ(1,ll_1.getState());
+  ASSERT_EQ(1,ll_1.predictState(0));
+}
+
+} // namespace lanelet
+*/

--- a/common/lanelet2_extension/test/src/CarmaTrafficTest.cpp
+++ b/common/lanelet2_extension/test/src/CarmaTrafficTest.cpp
@@ -13,7 +13,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-/*
+
 #include <gmock/gmock.h>
 #include <iostream>
 #include <lanelet2_extension/regulatory_elements/StopRule.h>
@@ -21,7 +21,7 @@
 #include <lanelet2_traffic_rules/TrafficRulesFactory.h>
 #include <lanelet2_core/Attribute.h>
 #include "TestHelpers.h"
-#include <CarmaTrafficLight.h>
+#include <lanelet2_extension/regulatory_elements/CarmaTrafficLight.h>
 
 using ::testing::_;
 using ::testing::A;
@@ -47,20 +47,28 @@ TEST(CarmaTrafficLightTest, CarmaTrafficLight)
   lanelet::Id traffic_light_id = utils::getId();
   LineString3d virtual_stop_line(traffic_light_id, {pl2, pr2});
   // Creat passing control line for solid dashed line
-  std::shared_ptr<CarmaTrafficLight> traffic_light(new CarmaTrafficLight(CarmaTrafficLight::buildData(lanelet::utils::getId(), { virtual_stop_line }, {ll_1}, {})));
+  std::shared_ptr<CarmaTrafficLight> traffic_light(new CarmaTrafficLight(CarmaTrafficLight::buildData(lanelet::utils::getId(), { virtual_stop_line })));
   ll_1.addRegulatoryElement(traffic_light);
 
   std::vector<std::pair<ros::Time, CarmaTrafficLightState>> input_time_steps;
-  input_time_steps.push_back(make_pair(0,1));
-  //ll_1.setStates(std::vector<std::pair<ros::Time, CarmaTrafficLightState>> input_time_steps, int revision);
-  ll_1.setStates(input_time_steps, 0);
 
-  ASSERT_EQ(1,ll_1.recorded_time_stamps);
-  ASSERT_EQ(1,ll_1.fixed_cycle_duration);
-  ASSERT_EQ(1,ll_1.revision_);
-  ASSERT_EQ(1,ll_1.getState());
-  ASSERT_EQ(1,ll_1.predictState(0));
+  input_time_steps.push_back(std::make_pair(ros::Time(1),static_cast<lanelet::CarmaTrafficLightState>(0)));
+  input_time_steps.push_back(std::make_pair(ros::Time(2),static_cast<lanelet::CarmaTrafficLightState>(1)));
+  input_time_steps.push_back(std::make_pair(ros::Time(3),static_cast<lanelet::CarmaTrafficLightState>(2)));
+  input_time_steps.push_back(std::make_pair(ros::Time(4),static_cast<lanelet::CarmaTrafficLightState>(3)));
+  input_time_steps.push_back(std::make_pair(ros::Time(5),static_cast<lanelet::CarmaTrafficLightState>(4)));
+
+  traffic_light->setStates(input_time_steps,0);
+
+  ASSERT_EQ(5,traffic_light->recorded_time_stamps.size());
+  ASSERT_EQ(ros::Duration(4),traffic_light->fixed_cycle_duration);
+  ASSERT_EQ(0,traffic_light->revision_);
+  
+  ros::Time::init();
+  ros::Time::setNow(ros::Time(1.5));
+
+  ASSERT_EQ(static_cast<lanelet::CarmaTrafficLightState>(1),traffic_light->getState().get());
+  ASSERT_EQ(static_cast<lanelet::CarmaTrafficLightState>(0),traffic_light->predictState(ros::Time(1)).get());
 }
 
 } // namespace lanelet
-*/


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
The DSRC spat message is picked up by the WM interface and the map is updated with the traffic light data with real time update. The map should be updated at a higher frequency to accurately track the traffic light. The map is updated and then send to the guidance. When the guidance sees the stop sign. The stop and wait manure is invoked with the help of a strategic plugin. When the light turns green, the intersection transit manure is invoked. Note: we already have the lane keeping straight which just needs to be replaced with intersection transit. At the exit, the guidance will just switch to lane following or any plugin based on the situation. 
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added any new packages to the sonar-scanner.properties file
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.