### PR TITLE
fix

### DIFF
--- a/common/lanelet2_extension/include/lanelet2_extension/regulatory_elements/CarmaTrafficLight.h
+++ b/common/lanelet2_extension/include/lanelet2_extension/regulatory_elements/CarmaTrafficLight.h
@@ -42,6 +42,7 @@ public:
    * @brief setStates function sorts states automatically
    *
    * @param data The data to initialize this regulation with
+   * NOTE: to extract full cycle, first and last state should match in input_time_steps
    */
   void setStates(std::vector<std::pair<ros::Time, CarmaTrafficLightState>> input_time_steps, int revision);
   /**

--- a/common/lanelet2_extension/lib/CarmaTrafficLight.cpp
+++ b/common/lanelet2_extension/lib/CarmaTrafficLight.cpp
@@ -114,6 +114,8 @@ boost::optional<CarmaTrafficLightState> CarmaTrafficLight::predictState(ros::Tim
       return recorded_time_stamps[i].second;
     }
   }
+
+  throw lanelet::InvalidInputError("Reached unreachable code block. Implies duplicate phase is not provided. Unable to determine fixed cycle duration");
 }
 
 lanelet::ConstLanelets CarmaTrafficLight::getControlledLanelets() const

--- a/common/lanelet2_extension/lib/CarmaTrafficLight.cpp
+++ b/common/lanelet2_extension/lib/CarmaTrafficLight.cpp
@@ -115,7 +115,12 @@ void CarmaTrafficLight::setStates(std::vector<std::pair<ros::Time, CarmaTrafficL
     }
     input_time_steps.resize(idx + 1);
   }
-  
+  // throw where the duplicate phase is not provided
+  if (input_time_steps.back().second != input_time_steps.front().second)
+  {
+    throw lanelet::InvalidInputError("Duplicate phase is not provided. Unable to determine fixed cycle duration");
+  }
+
   recorded_time_stamps = input_time_steps;
   fixed_cycle_duration = recorded_time_stamps.back().first - recorded_time_stamps.front().first; // it is okay if size is only 1, case is handled in predictState
   revision_ = revision;

--- a/common/lanelet2_extension/lib/CarmaTrafficLight.cpp
+++ b/common/lanelet2_extension/lib/CarmaTrafficLight.cpp
@@ -75,6 +75,9 @@ boost::optional<CarmaTrafficLightState> CarmaTrafficLight::predictState(ros::Tim
   ros::Duration accumulated_offset_duration;
   double offset_duration_dir = recorded_time_stamps.front().first > time_stamp ? -1.0 : 1.0; // -1 if past, +1 if time_stamp is in future
 
+  int num_of_cycles = std::abs((recorded_time_stamps.front().first - time_stamp).toSec()/ fixed_cycle_duration.toSec());
+  accumulated_offset_duration = ros::Duration( num_of_cycles * fixed_cycle_duration.toSec());
+  
   if (offset_duration_dir < 0) 
   {
     while (recorded_time_stamps.front().first - accumulated_offset_duration > time_stamp)
@@ -82,14 +85,6 @@ boost::optional<CarmaTrafficLightState> CarmaTrafficLight::predictState(ros::Tim
       accumulated_offset_duration += fixed_cycle_duration;
     }
   }
-  else
-  {
-    while (recorded_time_stamps.back().first + accumulated_offset_duration < time_stamp)
-    {
-      accumulated_offset_duration += fixed_cycle_duration;
-    }
-  }
-  
   // iterate through states in the cycle to get the signal
   for (size_t i = 0; i < recorded_time_stamps.size(); i++)
   {

--- a/common/lanelet2_extension/test/src/CarmaTrafficTest.cpp
+++ b/common/lanelet2_extension/test/src/CarmaTrafficTest.cpp
@@ -52,23 +52,25 @@ TEST(CarmaTrafficLightTest, CarmaTrafficLight)
 
   std::vector<std::pair<ros::Time, CarmaTrafficLightState>> input_time_steps;
 
-  input_time_steps.push_back(std::make_pair(ros::Time(1),static_cast<lanelet::CarmaTrafficLightState>(0)));
-  input_time_steps.push_back(std::make_pair(ros::Time(2),static_cast<lanelet::CarmaTrafficLightState>(1)));
-  input_time_steps.push_back(std::make_pair(ros::Time(3),static_cast<lanelet::CarmaTrafficLightState>(2)));
-  input_time_steps.push_back(std::make_pair(ros::Time(4),static_cast<lanelet::CarmaTrafficLightState>(3)));
-  input_time_steps.push_back(std::make_pair(ros::Time(5),static_cast<lanelet::CarmaTrafficLightState>(4)));
+  input_time_steps.push_back(std::make_pair(ros::Time(1001),static_cast<lanelet::CarmaTrafficLightState>(0)));
+  input_time_steps.push_back(std::make_pair(ros::Time(1002),static_cast<lanelet::CarmaTrafficLightState>(1)));
+  input_time_steps.push_back(std::make_pair(ros::Time(1003),static_cast<lanelet::CarmaTrafficLightState>(2)));
+  input_time_steps.push_back(std::make_pair(ros::Time(1004),static_cast<lanelet::CarmaTrafficLightState>(3)));
+  input_time_steps.push_back(std::make_pair(ros::Time(1005),static_cast<lanelet::CarmaTrafficLightState>(4)));
+  input_time_steps.push_back(std::make_pair(ros::Time(1006),static_cast<lanelet::CarmaTrafficLightState>(0)));
 
   traffic_light->setStates(input_time_steps,0);
 
-  ASSERT_EQ(5,traffic_light->recorded_time_stamps.size());
-  ASSERT_EQ(ros::Duration(4),traffic_light->fixed_cycle_duration);
+  ASSERT_EQ(6,traffic_light->recorded_time_stamps.size());
+  ASSERT_EQ(ros::Duration(5),traffic_light->fixed_cycle_duration);
   ASSERT_EQ(0,traffic_light->revision_);
   
   ros::Time::init();
   ros::Time::setNow(ros::Time(1.5));
 
   ASSERT_EQ(static_cast<lanelet::CarmaTrafficLightState>(1),traffic_light->getState().get());
-  ASSERT_EQ(static_cast<lanelet::CarmaTrafficLightState>(0),traffic_light->predictState(ros::Time(1)).get());
+  ASSERT_EQ(static_cast<lanelet::CarmaTrafficLightState>(1),traffic_light->predictState(ros::Time(6.5)).get());
+  ASSERT_EQ(static_cast<lanelet::CarmaTrafficLightState>(0),traffic_light->predictState(ros::Time(5.5)).get());
 }
 
 } // namespace lanelet

--- a/common/lanelet2_extension/test/src/CarmaTrafficTest.cpp
+++ b/common/lanelet2_extension/test/src/CarmaTrafficTest.cpp
@@ -57,6 +57,9 @@ TEST(CarmaTrafficLightTest, CarmaTrafficLight)
   input_time_steps.push_back(std::make_pair(ros::Time(1003),static_cast<lanelet::CarmaTrafficLightState>(2)));
   input_time_steps.push_back(std::make_pair(ros::Time(1004),static_cast<lanelet::CarmaTrafficLightState>(3)));
   input_time_steps.push_back(std::make_pair(ros::Time(1005),static_cast<lanelet::CarmaTrafficLightState>(4)));
+
+  EXPECT_THROW(traffic_light->setStates(input_time_steps,0), lanelet::InvalidInputError);
+
   input_time_steps.push_back(std::make_pair(ros::Time(1006),static_cast<lanelet::CarmaTrafficLightState>(0)));
 
   traffic_light->setStates(input_time_steps,0);


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
The DSRC spat message is picked up by the WM interface and the map is updated with the traffic light data with real time update. The map should be updated at a higher frequency to accurately track the traffic light. The map is updated and then send to the guidance. When the guidance sees the stop sign. The stop and wait manure is invoked with the help of a strategic plugin. When the light turns green, the intersection transit manure is invoked. Note: we already have the lane keeping straight which just needs to be replaced with intersection transit. At the exit, the guidance will just switch to lane following or any plugin based on the situation. 
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added any new packages to the sonar-scanner.properties file
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.