### PR TITLE
Add controlled lanelets to traffic light

### DIFF
--- a/common/lanelet2_extension/include/lanelet2_extension/regulatory_elements/CarmaTrafficLight.h
+++ b/common/lanelet2_extension/include/lanelet2_extension/regulatory_elements/CarmaTrafficLight.h
@@ -44,6 +44,11 @@ public:
    * @param data The data to initialize this regulation with
    */
   void setStates(std::vector<std::pair<ros::Time, CarmaTrafficLightState>> input_time_steps, int revision);
+
+  /**
+   * @brief getControlledLanelets function returns lanelets this element controls
+   */
+  lanelet::ConstLanelets getControlledLanelets() const;
   /**
    * @brief getState get the current state
    *
@@ -64,11 +69,12 @@ public:
    * @brief: Creating one is not directly usable unless setStates is called Static helper function that creates a stop line data object based on the provided inputs
    *
    * @param id The lanelet::Id of this element
+   * @param lanelets List of lanelets this element controls.
    * @param stop_line The line string which represent the stop line of the traffic light
    *
    * @return RegulatoryElementData containing all the necessary information to construct a stop rule
    */
-  static std::unique_ptr<lanelet::RegulatoryElementData> buildData(Id id, LineString3d stop_line);
+  static std::unique_ptr<lanelet::RegulatoryElementData> buildData(Id id, LineString3d stop_line, Lanelets lanelets);
 
 private:
   // the following lines are required so that lanelet2 can create this object

--- a/common/lanelet2_extension/lib/CarmaTrafficLight.cpp
+++ b/common/lanelet2_extension/lib/CarmaTrafficLight.cpp
@@ -37,13 +37,14 @@ LineStrings3d CarmaTrafficLight::stopLine()
 CarmaTrafficLight::CarmaTrafficLight(const lanelet::RegulatoryElementDataPtr& data) : RegulatoryElement(data)
 {}
 
-std::unique_ptr<lanelet::RegulatoryElementData> CarmaTrafficLight::buildData(Id id, LineString3d stop_line)
+std::unique_ptr<lanelet::RegulatoryElementData> CarmaTrafficLight::buildData(Id id, LineString3d stop_line, Lanelets lanelets)
 {
 
   if (stop_line.empty()) throw lanelet::InvalidInputError("Empty linestring was passed into CarmaTrafficLight buildData function");
   // Add parameters
   RuleParameterMap rules;
-
+  rules[lanelet::RoleNameString::Refers].insert(rules[lanelet::RoleNameString::Refers].end(), lanelets.begin(),
+                                                lanelets.end());
   rules[lanelet::RoleNameString::RefLine].insert(rules[lanelet::RoleNameString::RefLine].end(), stop_line);
 
   // Add attributes
@@ -99,6 +100,11 @@ boost::optional<CarmaTrafficLightState> CarmaTrafficLight::predictState(ros::Tim
     }
   }
 }
+
+lanelet::ConstLanelets CarmaTrafficLight::getControlledLanelets() const
+{
+  return getParameters<lanelet::ConstLanelet>(RoleName::Refers);
+} 
 
 void CarmaTrafficLight::setStates(std::vector<std::pair<ros::Time, CarmaTrafficLightState>> input_time_steps, int revision)
 {

--- a/common/lanelet2_extension/test/src/CarmaTrafficTest.cpp
+++ b/common/lanelet2_extension/test/src/CarmaTrafficTest.cpp
@@ -43,11 +43,15 @@ TEST(CarmaTrafficLightTest, CarmaTrafficLight)
   auto pr3 = carma_wm::getPoint(1, 2, 0);
   std::vector<lanelet::Point3d> left_1 = { pl1, pl2, pl3 };
   std::vector<lanelet::Point3d> right_1 = { pr1, pr2, pr3 };
+  std::vector<lanelet::Point3d> left_2 = { pl1, pl2, pl3 };
+  std::vector<lanelet::Point3d> right_2 = { pr1, pr2, pr3 };
   auto ll_1 = carma_wm::getLanelet(left_1, right_1, lanelet::AttributeValueString::SolidDashed,lanelet::AttributeValueString::Dashed);
+  auto ll_2 = carma_wm::getLanelet(left_1, right_1, lanelet::AttributeValueString::SolidDashed,lanelet::AttributeValueString::Dashed);
+  
   lanelet::Id traffic_light_id = utils::getId();
   LineString3d virtual_stop_line(traffic_light_id, {pl2, pr2});
   // Creat passing control line for solid dashed line
-  std::shared_ptr<CarmaTrafficLight> traffic_light(new CarmaTrafficLight(CarmaTrafficLight::buildData(lanelet::utils::getId(), { virtual_stop_line })));
+  std::shared_ptr<CarmaTrafficLight> traffic_light(new CarmaTrafficLight(CarmaTrafficLight::buildData(lanelet::utils::getId(), { virtual_stop_line }, {ll_1, ll_2})));
   ll_1.addRegulatoryElement(traffic_light);
 
   std::vector<std::pair<ros::Time, CarmaTrafficLightState>> input_time_steps;
@@ -69,6 +73,9 @@ TEST(CarmaTrafficLightTest, CarmaTrafficLight)
 
   ASSERT_EQ(static_cast<lanelet::CarmaTrafficLightState>(1),traffic_light->getState().get());
   ASSERT_EQ(static_cast<lanelet::CarmaTrafficLightState>(0),traffic_light->predictState(ros::Time(1)).get());
+  ASSERT_EQ(traffic_light->getControlledLanelets().size(), 2);
+  ASSERT_EQ(traffic_light->getControlledLanelets().back().id(), ll_2.id());
+  
 }
 
 } // namespace lanelet


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
Added controlled lanelet parameters to traffic light. 

Currently the lanelets are not guaranteed to be sorted. And just simply returns in the order in which the list is originally set.
Therefore, if these lanelets are used to determine the end of workzone area, one must either make sure to set it in the correct order from the beginning, or sort it using route downtrack after calling the getControlledLanelet()

Observed behavior of this parameter when sent to map update is shown below:
`lanelet_map_->update(llt, regem)` will only add `regem` to the given `llt`. But it will not add the `regem` to its parameter `parameter_llts` that are in the map indirectly during map update which is what we want.
So that only the lanelet that physically holds the `regem` will have the regem returned by `llt.regulatoryElementsAs<lanelet::CarmaTrafficLight>()` but the lanelets who are controlled by the `regem` won't have the `regem` returned in that manner. 

## Related Issue
supports https://github.com/usdot-fhwa-stol/carma-platform/issues/1363
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
See above.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
unit tested
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.