### PR TITLE
Add stream operator for traffic light enum

### DIFF
--- a/common/lanelet2_extension/include/lanelet2_extension/regulatory_elements/CarmaTrafficLight.h
+++ b/common/lanelet2_extension/include/lanelet2_extension/regulatory_elements/CarmaTrafficLight.h
@@ -23,13 +23,46 @@
 namespace lanelet
 {
 /**
- * @brief: TrafficLight are divided into 9 states.They are UNAVAILABLE=0,DARK=1,STOP_THEN_PROCEED=2,STOP_AND_REMAIN=3,PRE_MOVEMENT=4,PERMISSIVE_MOVEMENT_ALLOWED=5,PROTECTED_MOVEMENT_ALLOWED=6,PERMISSIVE_CLEARANCE=7,PROTECTED_CLEARANCE=8,CAUTION_CONFLICTING_TRAFFIC=9
+ * @brief: Enum representing Traffic Light States. 
+ * These states match the SAE J2735 PhaseState definitions used for SPaT messages
+ * 
+ * UNAVAILABLE : No data available
+ * DARK : Light is non-functional
+ * STOP_THEN_PROCEED : Flashing Red
+ * STOP_AND_REMAIN : Solid Red
+ * PRE_MOVEMENT : Yellow to Red transition (Found only in the EU)
+ * PERMISSIVE_MOVEMENT_ALLOWED : Solid Green there could be conflict traffic
+ * PROTECTED_MOVEMENT_ALLOWED : Solid Green no chance of conflict traffic (normally used with arrows)
+ * PERMISSIVE_CLEARANCE : Yellow Solid there is a chance of conflicting traffic
+ * PROTECTED_CLEARANCE : Yellow Solid no chance of conflicting traffic (normally used with arrows)
+ * CAUTION_CONFLICTING_TRAFFIC : Yellow Flashing
  *
+ */
+enum class CarmaTrafficLightState {
+  UNAVAILABLE=0,
+  DARK=1,
+  STOP_THEN_PROCEED=2,
+  STOP_AND_REMAIN=3,
+  PRE_MOVEMENT=4,
+  PERMISSIVE_MOVEMENT_ALLOWED=5,
+  PROTECTED_MOVEMENT_ALLOWED=6,
+  PERMISSIVE_CLEARANCE=7,
+  PROTECTED_CLEARANCE=8,
+  CAUTION_CONFLICTING_TRAFFIC=9
+};
+
+/**
+ * \brief Stream operator for CarmaTrafficLightState enum.
+ */
+std::ostream& operator<<(std::ostream& os, CarmaTrafficLightState s);
+
+/**
+ * @brief: Class representing a known timing traffic light.
+ *         Normally the traffic light timing information is provided by SAE J2735 SPaT messages although alternative data sources can be supported
+ * 
  * @ingroup RegulatoryElementPrimitives
  * @ingroup Primitives
  */
-
-enum class CarmaTrafficLightState {UNAVAILABLE=0,DARK=1,STOP_THEN_PROCEED=2,STOP_AND_REMAIN=3,PRE_MOVEMENT=4,PERMISSIVE_MOVEMENT_ALLOWED=5,PROTECTED_MOVEMENT_ALLOWED=6,PERMISSIVE_CLEARANCE=7,PROTECTED_CLEARANCE=8,CAUTION_CONFLICTING_TRAFFIC=9};
 
 class CarmaTrafficLight : public lanelet::RegulatoryElement
 {

--- a/common/lanelet2_extension/lib/CarmaTrafficLight.cpp
+++ b/common/lanelet2_extension/lib/CarmaTrafficLight.cpp
@@ -14,6 +14,7 @@
  * the License.
  */
 
+#include <ostream>
 #include <lanelet2_extension/regulatory_elements/CarmaTrafficLight.h>
 #include "RegulatoryHelpers.h"
 
@@ -23,6 +24,25 @@ namespace lanelet
 #if __cplusplus < 201703L
 constexpr char CarmaTrafficLight::RuleName[];  // instantiate string in cpp file
 #endif
+
+std::ostream& operator<<(std::ostream& os, CarmaTrafficLightState s)
+{
+  switch (s)
+  {  // clang-format off
+    case CarmaTrafficLightState::UNAVAILABLE   : os << "CarmaTrafficLightState::UNAVAILABLE"; break;
+    case CarmaTrafficLightState::DARK: os << "CarmaTrafficLightState::DARK"; break;
+    case CarmaTrafficLightState::STOP_THEN_PROCEED : os << "CarmaTrafficLightState::STOP_THEN_PROCEED"; break;
+    case CarmaTrafficLightState::STOP_AND_REMAIN  : os << "CarmaTrafficLightState::STOP_AND_REMAIN"; break;
+    case CarmaTrafficLightState::PRE_MOVEMENT  : os << "CarmaTrafficLightState::PRE_MOVEMENT"; break;
+    case CarmaTrafficLightState::PERMISSIVE_MOVEMENT_ALLOWED  : os << "CarmaTrafficLightState::PERMISSIVE_MOVEMENT_ALLOWED"; break;
+    case CarmaTrafficLightState::PROTECTED_MOVEMENT_ALLOWED  : os << "CarmaTrafficLightState::PROTECTED_MOVEMENT_ALLOWED"; break;
+    case CarmaTrafficLightState::PERMISSIVE_CLEARANCE  : os << "CarmaTrafficLightState::PERMISSIVE_CLEARANCE"; break;
+    case CarmaTrafficLightState::PROTECTED_CLEARANCE  : os << "CarmaTrafficLightState::PROTECTED_CLEARANCE"; break;
+    case CarmaTrafficLightState::CAUTION_CONFLICTING_TRAFFIC  : os << "CarmaTrafficLightState::CAUTION_CONFLICTING_TRAFFIC"; break;
+    default: os.setstate(std::ios_base::failbit);
+  }  // clang-format on
+  return os;
+}
 
 ConstLineStrings3d CarmaTrafficLight::stopLine() const
 {


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
This PR adds a stream operator to the enum used for traffic light states to improve simplicity of printing the enum. The PR also adds some clarifying comments. 
<!--- Describe your changes in detail -->

## Related Issue
Supports https://github.com/usdot-fhwa-stol/carma-platform/issues/1363
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Enum's can be a hassle to print in c++ without a stream operator defined. Therefore this is meant to simplify usage for world model users. 
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.