### PR TITLE
Remove `COLCON_IGNORE` from `vector_map_msgs`

### DIFF
--- a/common/amathutils_lib/CMakeLists.txt
+++ b/common/amathutils_lib/CMakeLists.txt
@@ -22,6 +22,7 @@ find_package(catkin REQUIRED COMPONENTS
   roslint
   tf
   tf2
+  tf2_geometry_msgs
 )
 
 set(CMAKE_CXX_FLAGS "-O2 -Wall ${CMAKE_CXX_FLAGS}")
@@ -33,6 +34,7 @@ catkin_package(
     autoware_msgs
     tf
     tf2
+    tf2_geometry_msgs
 )
 
 include_directories(

--- a/common/amathutils_lib/package.xml
+++ b/common/amathutils_lib/package.xml
@@ -15,6 +15,7 @@
   <depend>roscpp</depend>
   <depend>roslint</depend>
   <depend>tf2</depend>
+  <depend>tf2_geometry_msgs</depend>
   <depend>tf</depend>
   <depend>eigen</depend>
 </package>


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
This PR removes the `COLCON_IGNORE` file from the `vector_map_msgs` package, which was causing `colcon` and `catkin_make` to ignore the package. This then prevented the `map_file` package from building when trying to build from source (including dependencies).

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes usdot-fhwa-stol/carma-platform#1380

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
In instances where packages and their dependencies need to be built from source (e.g., C1T Docker deployment), the `COLCON_IGNORE` file was preventing the builds from completing.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The `map_file` package was successfully built using the proposed changes.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.