### PR TITLE
Add reason to speed regulatory

### DIFF
--- a/common/lanelet2_extension/include/lanelet2_extension/regulatory_elements/DigitalSpeedLimit.h
+++ b/common/lanelet2_extension/include/lanelet2_extension/regulatory_elements/DigitalSpeedLimit.h
@@ -38,6 +38,9 @@ class DigitalSpeedLimit : public RegulatoryElement
 public:
   static constexpr char RuleName[] = "digital_speed_limit";
   static constexpr char Limit[] = "limit";
+  static constexpr char Reason[] = "reason";
+
+  std::string reason_ = "NA";
   Velocity speed_limit_ = 0;
   std::unordered_set<std::string> participants_;
 
@@ -62,6 +65,13 @@ public:
    */
   Velocity getSpeedLimit() const;
 
+   /**
+   * @brief Returns the reason for this rule
+   *
+   * @return The reason for this rule
+   */
+  std::string getReason();
+
   /**
    * @brief Returns true if the given participant must follow this speed limit
    *
@@ -78,11 +88,12 @@ public:
    * @param lanelets The lanelets this speed limit applies to
    * @param areas The areas this speed limit applies to
    * @param participants The set of participants which this speed limit will apply to
+   * @param reason The reason
    *
    * @return RegulatoryElementData containing all the necessary information to construct a speed limit element
    */
   static std::unique_ptr<lanelet::RegulatoryElementData> buildData(Id id, Velocity speed_limit, Lanelets lanelets, Areas areas,
-                                                     std::vector<std::string> participants);
+                                                     std::vector<std::string> participants, const std::string& reason="NA");
 
   /**
    * @brief Constructor required for compatability with lanlet2 loading

--- a/common/lanelet2_extension/include/lanelet2_extension/regulatory_elements/RegionAccessRule.h
+++ b/common/lanelet2_extension/include/lanelet2_extension/regulatory_elements/RegionAccessRule.h
@@ -80,6 +80,7 @@ public:
    * @param lanelets The lanelets impacted by this regulation
    * @param areas The areas impacted by this regulation
    * @param participants The participants which can access the provided lanelets and areas
+   * @param reason The reason
    *
    * @return RegulatoryElementData containing all the necessary information to construct a region access rule object
    */

--- a/common/lanelet2_extension/lib/DigitalSpeedLimit.cpp
+++ b/common/lanelet2_extension/lib/DigitalSpeedLimit.cpp
@@ -25,6 +25,8 @@ namespace lanelet
 // Forward declare static constexpr
 constexpr char DigitalSpeedLimit::RuleName[];  // instantiate string in cpp file
 constexpr char DigitalSpeedLimit::Limit[];
+constexpr char DigitalSpeedLimit::Reason[];
+
 #endif
 
 ConstLanelets DigitalSpeedLimit::getLanelets() const
@@ -40,6 +42,17 @@ ConstAreas DigitalSpeedLimit::getAreas() const
 Velocity DigitalSpeedLimit::getSpeedLimit() const
 {
   return speed_limit_;
+}
+
+std::string DigitalSpeedLimit::getReason()
+{  
+  if (hasAttribute(Reason))
+  {
+    auto optional_reason = attribute(Reason).value();
+    reason_ = optional_reason;
+  }       
+  
+  return reason_;
 }
 
 bool DigitalSpeedLimit::appliesTo(const std::string& participant) const
@@ -65,7 +78,7 @@ DigitalSpeedLimit::DigitalSpeedLimit(const lanelet::RegulatoryElementDataPtr& da
 }
 
 std::unique_ptr<lanelet::RegulatoryElementData> DigitalSpeedLimit::buildData(Id id, Velocity speed_limit, Lanelets lanelets,
-                                                               Areas areas, std::vector<std::string> participants)
+                                                               Areas areas, std::vector<std::string> participants, const std::string& reason)
 {
   // Add parameters
   RuleParameterMap rules;
@@ -77,7 +90,8 @@ std::unique_ptr<lanelet::RegulatoryElementData> DigitalSpeedLimit::buildData(Id 
   // Add attributes
   AttributeMap attribute_map({ { AttributeNamesString::Type, AttributeValueString::RegulatoryElement },
                                { AttributeNamesString::Subtype, RuleName },
-                               { Limit, Attribute(speed_limit).value() } });
+                               { Limit, Attribute(speed_limit).value() },
+                               { Reason, Attribute(reason).value() } });
 
   for (auto participant : participants)
   {

--- a/common/lanelet2_extension/test/src/DigitalSpeedLimitTest.cpp
+++ b/common/lanelet2_extension/test/src/DigitalSpeedLimitTest.cpp
@@ -75,6 +75,7 @@ TEST(DigitalSpeedLimit, digitalSpeedLimit)
   ASSERT_FALSE(dsl.appliesTo(lanelet::Participants::Vehicle));
   ASSERT_TRUE(dsl.appliesTo(lanelet::Participants::VehicleCar));
   ASSERT_TRUE(dsl.appliesTo(lanelet::Participants::VehicleCarElectric));  // Test acceptance of sub type
+  ASSERT_EQ(dsl.getReason(), "NA");
 
   ASSERT_EQ(5_kmh, dsl.getSpeedLimit());
 }


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
Add reason field to speed limit regulatory element so that UI can detect workzone area

## Related Issue
https://github.com/usdot-fhwa-stol/carma-platform/pull/1403

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
See above
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Integration tested on Fusion
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.