### PR TITLE
Fix the ray ground filter point size calculation

### DIFF
--- a/core_perception/points_preprocessor/launch/ray_ground_filter.launch
+++ b/core_perception/points_preprocessor/launch/ray_ground_filter.launch
@@ -14,7 +14,7 @@
   <arg name="ground_point_topic" default="points_ground" />
 
   <!-- rosrun points_preprocessor ray_ground_filter -->
-  <node pkg="points_preprocessor" type="ray_ground_filter" name="ray_ground_filter" output="log">
+  <node pkg="points_preprocessor" type="ray_ground_filter" name="ray_ground_filter">
     <param name="input_point_topic" value="$(arg input_point_topic)" />
     <param name="base_frame" value="$(arg base_frame)" />
     <param name="clipping_height" value="$(arg clipping_height)" />

--- a/core_perception/points_preprocessor/nodes/ray_ground_filter/ray_ground_filter.cpp
+++ b/core_perception/points_preprocessor/nodes/ray_ground_filter/ray_ground_filter.cpp
@@ -104,7 +104,12 @@ void RayGroundFilter::filterROSMsg(const sensor_msgs::PointCloud2ConstPtr in_ori
                    const std::vector<void*>& in_selector,
                    const sensor_msgs::PointCloud2::Ptr out_filtered_msg)
 {
-  size_t point_size = in_origin_cloud->row_step/in_origin_cloud->width;  // in Byte
+  size_t point_size = in_origin_cloud->point_step;  // in Byte
+
+  if (point_size == 0) {
+    ROS_WARN_THROTTLE(5, "Cloud point_step of zero, can't filter message");
+    return;
+  }
 
   // TODO(yoan picchi) I fear this may do a lot of cache miss because it is sorted in the radius
   // and no longer sorted in the original pointer. One thing to try is that, given
@@ -263,7 +268,13 @@ void RayGroundFilter::ConvertAndTrim(const sensor_msgs::PointCloud2::Ptr in_tran
                       std::vector<void*>* out_no_ground_ptrs)
 {
   // --- Clarify some of the values used to access the binary blob
-  size_t point_size = in_transformed_cloud->row_step/in_transformed_cloud->width;  // in Byte
+  size_t point_size = in_transformed_cloud->point_step;  // in Byte
+
+  if (point_size == 0) {
+    ROS_WARN_THROTTLE(5, "Cloud point_step of zero, can't filter message");
+    return;
+  }
+
   size_t cloud_count = in_transformed_cloud->width*in_transformed_cloud->height;
 
   const uint offset_not_set = ~0;
@@ -328,7 +339,7 @@ void RayGroundFilter::ConvertAndTrim(const sensor_msgs::PointCloud2::Ptr in_tran
       z = ReverseFloat(z);
     }
     // ---
-
+    
     if (z > in_clip_height)
     {
       out_no_ground_ptrs->push_back(point_start_ptr);


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
This PR fixes a bug present in Autoware. v1.14 where the ray_ground_filter incorrectly calculates the size in bytes of points inside of the sensor_msgs/PointCloud2 message. 

The message definition looks like this
```
# This message holds a collection of N-dimensional points, which may
# contain additional information such as normals, intensity, etc. The
# point data is stored as a binary blob, its layout described by the
# contents of the "fields" array.

# The point cloud data may be organized 2d (image-like) or 1d
# (unordered). Point clouds organized as 2d images may be produced by
# camera depth sensors such as stereo or time-of-flight.

# Time of sensor data acquisition, and the coordinate frame ID (for 3d
# points).
Header header

# 2D structure of the point cloud. If the cloud is unordered, height is
# 1 and width is the length of the point cloud.
uint32 height
uint32 width

# Describes the channels and their layout in the binary data blob.
PointField[] fields

bool    is_bigendian # Is this data bigendian?
uint32  point_step   # Length of a point in bytes
uint32  row_step     # Length of a row in bytes
uint8[] data         # Actual point data, size is (row_step*height)

bool is_dense        # True if there are no invalid points
```

In the original logic the row_step was divided by the width to compute the size of a point in bytes. This only works in the 1d  storage case (which is the most common). However, it seems the velodyne driver (installed from apt) used in carma-platform does not set this field and it remains zero. Since the point_step field represents the actual desired data and works in both the 1d and 2d storage cases it serves as a much better source for the information and is set by the velodyne driver used in carma-platform. 
<!--- Describe your changes in detail -->

## Related Issue
This PR is a partial resolution for https://github.com/usdot-fhwa-stol/carma-platform/issues/1496 
The topic mismatch fix will be a carma-platform PR
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Working object detection in Elise release
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Tested on Blue Lexus at TFHRC
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.