### PR TITLE
Rename TrafficLight to TrafficSignal

### DIFF
--- a/common/lanelet2_extension/CMakeLists.txt
+++ b/common/lanelet2_extension/CMakeLists.txt
@@ -85,7 +85,7 @@ add_library( lanelet2_extension_lib
   lib/local_frame_projector.cpp
   lib/mgrs_projector.cpp
   lib/CarmaUSTrafficRules.cpp
-  lib/CarmaTrafficLight.cpp
+  lib/CarmaTrafficSignal.cpp
   lib/PassingControlLine.cpp
   lib/StopRule.cpp
   lib/DigitalSpeedLimit.cpp
@@ -131,7 +131,7 @@ if(CATKIN_ENABLE_TESTING)
   test/src/CarmaUSTrafficRulesTest.cpp
   test/src/MapLoadingTest.cpp
   test/src/test_local_projector.cpp
-  test/src/CarmaTrafficTest.cpp
+  test/src/CarmaTrafficSignalTest.cpp
   WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/test # Add test directory as working directory for unit tests
  )
 

--- a/common/lanelet2_extension/include/lanelet2_extension/regulatory_elements/CarmaTrafficSignal.h
+++ b/common/lanelet2_extension/include/lanelet2_extension/regulatory_elements/CarmaTrafficSignal.h
@@ -38,7 +38,7 @@ namespace lanelet
  * CAUTION_CONFLICTING_TRAFFIC : Yellow Flashing
  *
  */
-enum class CarmaTrafficLightState {
+enum class CarmaTrafficSignalState {
   UNAVAILABLE=0,
   DARK=1,
   STOP_THEN_PROCEED=2,
@@ -88,9 +88,9 @@ namespace time {
 }
 
 /**
- * \brief Stream operator for CarmaTrafficLightState enum.
+ * \brief Stream operator for CarmaTrafficSignalState enum.
  */
-std::ostream& operator<<(std::ostream& os, CarmaTrafficLightState s);
+std::ostream& operator<<(std::ostream& os, CarmaTrafficSignalState s);
 
 /**
  * @brief: Class representing a known timing traffic light.
@@ -100,20 +100,20 @@ std::ostream& operator<<(std::ostream& os, CarmaTrafficLightState s);
  * @ingroup Primitives
  */
 
-class CarmaTrafficLight : public lanelet::RegulatoryElement
+class CarmaTrafficSignal : public lanelet::RegulatoryElement
 {
 public:
   static constexpr char RuleName[] = "carma_traffic_light";
   int revision_ = 0; //indicates when was this last modified
   boost::posix_time::time_duration fixed_cycle_duration;
-  std::vector<std::pair<boost::posix_time::ptime, CarmaTrafficLightState>> recorded_time_stamps;
+  std::vector<std::pair<boost::posix_time::ptime, CarmaTrafficSignalState>> recorded_time_stamps;
   /**
    * @brief setStates function sorts states automatically
    *
    * @param data The data to initialize this regulation with
    * NOTE: to extract full cycle, first and last state should match in input_time_steps
    */
-  void setStates(std::vector<std::pair<boost::posix_time::ptime, CarmaTrafficLightState>> input_time_steps, int revision);
+  void setStates(std::vector<std::pair<boost::posix_time::ptime, CarmaTrafficSignalState>> input_time_steps, int revision);
 
   /**
    * @brief getControlledLanelets function returns lanelets this element controls
@@ -125,11 +125,11 @@ public:
    *
    * @param time_stamp boost::posix_time::ptime of the event happening
    */
-  boost::optional<CarmaTrafficLightState> predictState(boost::posix_time::ptime time_stamp);
+  boost::optional<CarmaTrafficSignalState> predictState(boost::posix_time::ptime time_stamp);
   ConstLineStrings3d stopLine() const;
   LineStrings3d stopLine();
 
-  explicit CarmaTrafficLight(const lanelet::RegulatoryElementDataPtr& data);
+  explicit CarmaTrafficSignal(const lanelet::RegulatoryElementDataPtr& data);
   /**
    * @brief: Creating one is not directly usable unless setStates is called Static helper function that creates a stop line data object based on the provided inputs
    *
@@ -145,13 +145,13 @@ public:
 private:
   // the following lines are required so that lanelet2 can create this object
   // when loading a map with this regulatory element
-  friend class lanelet::RegisterRegulatoryElement<CarmaTrafficLight>;
+  friend class lanelet::RegisterRegulatoryElement<CarmaTrafficSignal>;
 };
 
 
 // Convenience Ptr Declarations
-using CarmaTrafficLightPtr = std::shared_ptr<CarmaTrafficLight>;
-using CarmaTrafficLightConstPtr = std::shared_ptr<const CarmaTrafficLight>;
+using CarmaTrafficSignalPtr = std::shared_ptr<CarmaTrafficSignal>;
+using CarmaTrafficSignalConstPtr = std::shared_ptr<const CarmaTrafficSignal>;
 
 }  // namespace lanelet
 

--- a/common/lanelet2_extension/lib/CarmaTrafficSignal.cpp
+++ b/common/lanelet2_extension/lib/CarmaTrafficSignal.cpp
@@ -15,7 +15,7 @@
  */
 
 #include <ostream>
-#include <lanelet2_extension/regulatory_elements/CarmaTrafficLight.h>
+#include <lanelet2_extension/regulatory_elements/CarmaTrafficSignal.h>
 #include <lanelet2_extension/logging/logger.h>
 #include "RegulatoryHelpers.h"
 
@@ -26,45 +26,45 @@ using namespace lanelet::time;
 
 // C++ 14 vs 17 parameter export
 #if __cplusplus < 201703L
-constexpr char CarmaTrafficLight::RuleName[];  // instantiate string in cpp file
+constexpr char CarmaTrafficSignal::RuleName[];  // instantiate string in cpp file
 #endif
 
-std::ostream& operator<<(std::ostream& os, CarmaTrafficLightState s)
+std::ostream& operator<<(std::ostream& os, CarmaTrafficSignalState s)
 {
   switch (s)
   {  // clang-format off
-    case CarmaTrafficLightState::UNAVAILABLE   : os << "CarmaTrafficLightState::UNAVAILABLE"; break;
-    case CarmaTrafficLightState::DARK: os << "CarmaTrafficLightState::DARK"; break;
-    case CarmaTrafficLightState::STOP_THEN_PROCEED : os << "CarmaTrafficLightState::STOP_THEN_PROCEED"; break;
-    case CarmaTrafficLightState::STOP_AND_REMAIN  : os << "CarmaTrafficLightState::STOP_AND_REMAIN"; break;
-    case CarmaTrafficLightState::PRE_MOVEMENT  : os << "CarmaTrafficLightState::PRE_MOVEMENT"; break;
-    case CarmaTrafficLightState::PERMISSIVE_MOVEMENT_ALLOWED  : os << "CarmaTrafficLightState::PERMISSIVE_MOVEMENT_ALLOWED"; break;
-    case CarmaTrafficLightState::PROTECTED_MOVEMENT_ALLOWED  : os << "CarmaTrafficLightState::PROTECTED_MOVEMENT_ALLOWED"; break;
-    case CarmaTrafficLightState::PERMISSIVE_CLEARANCE  : os << "CarmaTrafficLightState::PERMISSIVE_CLEARANCE"; break;
-    case CarmaTrafficLightState::PROTECTED_CLEARANCE  : os << "CarmaTrafficLightState::PROTECTED_CLEARANCE"; break;
-    case CarmaTrafficLightState::CAUTION_CONFLICTING_TRAFFIC  : os << "CarmaTrafficLightState::CAUTION_CONFLICTING_TRAFFIC"; break;
+    case CarmaTrafficSignalState::UNAVAILABLE   : os << "CarmaTrafficSignalState::UNAVAILABLE"; break;
+    case CarmaTrafficSignalState::DARK: os << "CarmaTrafficSignalState::DARK"; break;
+    case CarmaTrafficSignalState::STOP_THEN_PROCEED : os << "CarmaTrafficSignalState::STOP_THEN_PROCEED"; break;
+    case CarmaTrafficSignalState::STOP_AND_REMAIN  : os << "CarmaTrafficSignalState::STOP_AND_REMAIN"; break;
+    case CarmaTrafficSignalState::PRE_MOVEMENT  : os << "CarmaTrafficSignalState::PRE_MOVEMENT"; break;
+    case CarmaTrafficSignalState::PERMISSIVE_MOVEMENT_ALLOWED  : os << "CarmaTrafficSignalState::PERMISSIVE_MOVEMENT_ALLOWED"; break;
+    case CarmaTrafficSignalState::PROTECTED_MOVEMENT_ALLOWED  : os << "CarmaTrafficSignalState::PROTECTED_MOVEMENT_ALLOWED"; break;
+    case CarmaTrafficSignalState::PERMISSIVE_CLEARANCE  : os << "CarmaTrafficSignalState::PERMISSIVE_CLEARANCE"; break;
+    case CarmaTrafficSignalState::PROTECTED_CLEARANCE  : os << "CarmaTrafficSignalState::PROTECTED_CLEARANCE"; break;
+    case CarmaTrafficSignalState::CAUTION_CONFLICTING_TRAFFIC  : os << "CarmaTrafficSignalState::CAUTION_CONFLICTING_TRAFFIC"; break;
     default: os.setstate(std::ios_base::failbit);
   }  // clang-format on
   return os;
 }
 
-ConstLineStrings3d CarmaTrafficLight::stopLine() const
+ConstLineStrings3d CarmaTrafficSignal::stopLine() const
 {
   return getParameters<ConstLineString3d>(RoleName::RefLine);
 }
 
-LineStrings3d CarmaTrafficLight::stopLine()
+LineStrings3d CarmaTrafficSignal::stopLine()
 {
   return getParameters<LineString3d>(RoleName::RefLine);
 }
 
-CarmaTrafficLight::CarmaTrafficLight(const lanelet::RegulatoryElementDataPtr& data) : RegulatoryElement(data)
+CarmaTrafficSignal::CarmaTrafficSignal(const lanelet::RegulatoryElementDataPtr& data) : RegulatoryElement(data)
 {}
 
-std::unique_ptr<lanelet::RegulatoryElementData> CarmaTrafficLight::buildData(Id id, LineString3d stop_line, Lanelets lanelets)
+std::unique_ptr<lanelet::RegulatoryElementData> CarmaTrafficSignal::buildData(Id id, LineString3d stop_line, Lanelets lanelets)
 {
 
-  if (stop_line.empty()) throw lanelet::InvalidInputError("Empty linestring was passed into CarmaTrafficLight buildData function");
+  if (stop_line.empty()) throw lanelet::InvalidInputError("Empty linestring was passed into CarmaTrafficSignal buildData function");
   // Add parameters
   RuleParameterMap rules;
   rules[lanelet::RoleNameString::Refers].insert(rules[lanelet::RoleNameString::Refers].end(), lanelets.begin(),
@@ -80,11 +80,11 @@ std::unique_ptr<lanelet::RegulatoryElementData> CarmaTrafficLight::buildData(Id 
   return std::make_unique<RegulatoryElementData>(id, rules, attribute_map);
 }
 
-boost::optional<CarmaTrafficLightState> CarmaTrafficLight::predictState(boost::posix_time::ptime time_stamp)
+boost::optional<CarmaTrafficSignalState> CarmaTrafficSignal::predictState(boost::posix_time::ptime time_stamp)
 {
   if (recorded_time_stamps.empty())
   {
-    LOG_WARN_STREAM("CarmaTrafficLight doesn't have any recorded states of traffic lights");
+    LOG_WARN_STREAM("CarmaTrafficSignal doesn't have any recorded states of traffic lights");
     return boost::none;
   }
   if (recorded_time_stamps.size() == 1) // if only 1 timestamp recorded, this signal doesn't change
@@ -117,16 +117,16 @@ boost::optional<CarmaTrafficLightState> CarmaTrafficLight::predictState(boost::p
   throw lanelet::InvalidInputError("Reached unreachable code block. Implies duplicate phase is not provided. Unable to determine fixed cycle duration");
 }
 
-lanelet::ConstLanelets CarmaTrafficLight::getControlledLanelets() const
+lanelet::ConstLanelets CarmaTrafficSignal::getControlledLanelets() const
 {
   return getParameters<lanelet::ConstLanelet>(RoleName::Refers);
 } 
 
-void CarmaTrafficLight::setStates(std::vector<std::pair<boost::posix_time::ptime, CarmaTrafficLightState>> input_time_steps, int revision)
+void CarmaTrafficSignal::setStates(std::vector<std::pair<boost::posix_time::ptime, CarmaTrafficSignalState>> input_time_steps, int revision)
 {
   if (input_time_steps.empty())
   {
-    LOG_ERROR_STREAM("Given states for the CarmaTrafficLight Id: " << id() << " is empty. Returning...");
+    LOG_ERROR_STREAM("Given states for the CarmaTrafficSignal Id: " << id() << " is empty. Returning...");
     return;
   }
 
@@ -183,7 +183,7 @@ boost::posix_time::time_duration durationFromSec(double sec) {
 namespace
 {
 // this object actually does the registration work for us
-lanelet::RegisterRegulatoryElement<lanelet::CarmaTrafficLight> reg;
+lanelet::RegisterRegulatoryElement<lanelet::CarmaTrafficSignal> reg;
 }  // namespace
 
 }  // namespace lanelet

--- a/common/lanelet2_extension/test/src/CarmaTrafficSignalTest.cpp
+++ b/common/lanelet2_extension/test/src/CarmaTrafficSignalTest.cpp
@@ -21,7 +21,7 @@
 #include <lanelet2_traffic_rules/TrafficRulesFactory.h>
 #include <lanelet2_core/Attribute.h>
 #include "TestHelpers.h"
-#include <lanelet2_extension/regulatory_elements/CarmaTrafficLight.h>
+#include <lanelet2_extension/regulatory_elements/CarmaTrafficSignal.h>
 
 using ::testing::_;
 using ::testing::A;
@@ -33,7 +33,7 @@ using ::testing::ReturnArg;
 namespace lanelet
 {
 
-TEST(CarmaTrafficLightTest, CarmaTrafficLight)
+TEST(CarmaTrafficSignalTest, CarmaTrafficSignal)
 {
   auto pl1 = carma_wm::getPoint(0, 0, 0);
   auto pl2 = carma_wm::getPoint(0, 1, 0);
@@ -51,20 +51,20 @@ TEST(CarmaTrafficLightTest, CarmaTrafficLight)
   lanelet::Id traffic_light_id = utils::getId();
   LineString3d virtual_stop_line(traffic_light_id, {pl2, pr2});
   // Creat passing control line for solid dashed line
-  std::shared_ptr<CarmaTrafficLight> traffic_light(new CarmaTrafficLight(CarmaTrafficLight::buildData(lanelet::utils::getId(), { virtual_stop_line }, {ll_1, ll_2})));
+  std::shared_ptr<CarmaTrafficSignal> traffic_light(new CarmaTrafficSignal(CarmaTrafficSignal::buildData(lanelet::utils::getId(), { virtual_stop_line }, {ll_1, ll_2})));
   ll_1.addRegulatoryElement(traffic_light);
 
-  std::vector<std::pair<boost::posix_time::ptime, CarmaTrafficLightState>> input_time_steps;
+  std::vector<std::pair<boost::posix_time::ptime, CarmaTrafficSignalState>> input_time_steps;
 
-  input_time_steps.push_back(std::make_pair(time::timeFromSec(1001),static_cast<lanelet::CarmaTrafficLightState>(0)));
-  input_time_steps.push_back(std::make_pair(time::timeFromSec(1002),static_cast<lanelet::CarmaTrafficLightState>(1)));
-  input_time_steps.push_back(std::make_pair(time::timeFromSec(1003),static_cast<lanelet::CarmaTrafficLightState>(2)));
-  input_time_steps.push_back(std::make_pair(time::timeFromSec(1004),static_cast<lanelet::CarmaTrafficLightState>(3)));
-  input_time_steps.push_back(std::make_pair(time::timeFromSec(1005),static_cast<lanelet::CarmaTrafficLightState>(4)));
+  input_time_steps.push_back(std::make_pair(time::timeFromSec(1001),static_cast<lanelet::CarmaTrafficSignalState>(0)));
+  input_time_steps.push_back(std::make_pair(time::timeFromSec(1002),static_cast<lanelet::CarmaTrafficSignalState>(1)));
+  input_time_steps.push_back(std::make_pair(time::timeFromSec(1003),static_cast<lanelet::CarmaTrafficSignalState>(2)));
+  input_time_steps.push_back(std::make_pair(time::timeFromSec(1004),static_cast<lanelet::CarmaTrafficSignalState>(3)));
+  input_time_steps.push_back(std::make_pair(time::timeFromSec(1005),static_cast<lanelet::CarmaTrafficSignalState>(4)));
 
   EXPECT_THROW(traffic_light->setStates(input_time_steps,0), lanelet::InvalidInputError);
 
-  input_time_steps.push_back(std::make_pair(time::timeFromSec(1006),static_cast<lanelet::CarmaTrafficLightState>(0)));
+  input_time_steps.push_back(std::make_pair(time::timeFromSec(1006),static_cast<lanelet::CarmaTrafficSignalState>(0)));
 
   traffic_light->setStates(input_time_steps,0);
 
@@ -72,8 +72,8 @@ TEST(CarmaTrafficLightTest, CarmaTrafficLight)
   ASSERT_EQ(time::durationFromSec(5),traffic_light->fixed_cycle_duration);
   ASSERT_EQ(0,traffic_light->revision_);
 
-  ASSERT_EQ(static_cast<lanelet::CarmaTrafficLightState>(1),traffic_light->predictState(time::timeFromSec(1.5)).get());
-  ASSERT_EQ(static_cast<lanelet::CarmaTrafficLightState>(0),traffic_light->predictState(time::timeFromSec(1)).get());
+  ASSERT_EQ(static_cast<lanelet::CarmaTrafficSignalState>(1),traffic_light->predictState(time::timeFromSec(1.5)).get());
+  ASSERT_EQ(static_cast<lanelet::CarmaTrafficSignalState>(0),traffic_light->predictState(time::timeFromSec(1)).get());
   ASSERT_EQ(traffic_light->getControlledLanelets().size(), 2);
   ASSERT_EQ(traffic_light->getControlledLanelets().back().id(), ll_2.id());
   


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
Upon client's request, the CarmaTrafficLight naming should be changed to CarmaTrafficSignal for better terminology.
NOTE:
coordinate around PR https://github.com/usdot-fhwa-stol/autoware.ai/pull/182


## Related Issue
https://github.com/usdot-fhwa-stol/carma-platform/issues/1529
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
See above.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Smoke tested on lanelet2_extension, and carma_wm packages

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have added any new packages to the sonar-scanner.properties file
- [X] My change requires a change to the documentation.
- [X I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.