### PR TITLE
Signalized Intersection Manager support

### DIFF
--- a/common/lanelet2_extension/docs/RegulatoryElements.md
+++ b/common/lanelet2_extension/docs/RegulatoryElements.md
@@ -314,14 +314,15 @@ To support multiple types of participants a new attribute should be added for ea
 Represents a virtual traffic signal with known fixed signal phases. It is virtual because it corresponds to single signal group ID provided by a SAE J2735 SPaT message.
 Normally the traffic signal timing information is provided by SAE J2735 SPaT messages although alternative data sources can be supported.
 
-A CarmaTrafficSignal is created from a stop_line (LineString3d) and a list of exit_lanelets (Lanelet). stop_line is where the vehicle should stop and wait before crossing and exit_lanelets represent which direction the vehicle can go based on this traffic signal.
+A CarmaTrafficSignal is created from a stop_line (LineString3d) and a list of control_start and control_end lanelets. stop_line is where the vehicle should stop and wait before crossing and control_end represent which direction the vehicle can go based on this traffic signal from lanelets in control_start.
 
 ### Parameters
 
 | **Role** | **Possible Type** | **description**                |
 |-------------|--------------|----------------------------------|
 | **ref_line**    | **LineString3d**    | The linestring which define the geometry of this stop line. |
-| **exit_lanelet**    | **Lanelet**    | A lanelet representing the direction this traffic signal controls |
+| **control_start**    **Lanelet**    | A lanelet representing the start of this traffic signal's control |
+| **control_end**    | **Lanelet**    | A lanelet representing the end of this traffic signal's control |
 
 ### Custom Attributes
 
@@ -357,7 +358,7 @@ Currently when the object is created, it doesn't have any default values for the
 </relation>
 
 <!-- Virtual Linestring for Stop Line >
-<way id="1349" visible="false" version="1">
+<way id="1399" visible="false" version="1">
   <nd ref="1339" />
   <nd ref="1342" />
   <tag k="subtype" v="-" />
@@ -366,8 +367,9 @@ Currently when the object is created, it doesn't have any default values for the
 
 <!-- Regulatory Carma Traffic Signal -->
 <relation id='45221' visible='true' version='1'>
-  <member type="way" ref="1349" role="ref_line" /> <!-- Horizontal linestring representing the stop line -->
-  <member type='relation' ref="1350" role='exit_lanelet' />
+  <member type="way" ref="1399" role="ref_line" /> <!-- Horizontal linestring representing the stop line -->
+  <member type='relation' ref="1349" role='control_start' />
+  <member type='relation' ref="1350" role='control_end' />
   <tag k='subtype' v='carma_traffic_signal' />
   <tag k='type' v='regulatory_element' />
 </relation>

--- a/common/lanelet2_extension/include/lanelet2_extension/regulatory_elements/CarmaTrafficSignal.h
+++ b/common/lanelet2_extension/include/lanelet2_extension/regulatory_elements/CarmaTrafficSignal.h
@@ -51,6 +51,12 @@ enum class CarmaTrafficSignalState {
   CAUTION_CONFLICTING_TRAFFIC=9
 };
 
+struct CarmaTrafficSignalRoleNameString
+{
+  static constexpr char ControlStart[] = "control_start";
+  static constexpr char ControlEnd[] = "control_end";
+};
+
 // Namespace for time representations used with this regulatory element
 namespace time {
 
@@ -104,6 +110,7 @@ class CarmaTrafficSignal : public lanelet::RegulatoryElement
 {
 public:
   static constexpr char RuleName[] = "carma_traffic_signal";
+
   int revision_ = 0; //indicates when was this last modified
   boost::posix_time::time_duration fixed_cycle_duration;
   std::vector<std::pair<boost::posix_time::ptime, CarmaTrafficSignalState>> recorded_time_stamps;
@@ -116,9 +123,15 @@ public:
   void setStates(std::vector<std::pair<boost::posix_time::ptime, CarmaTrafficSignalState>> input_time_steps, int revision);
 
   /**
-   * @brief getControlledLanelets function returns lanelets this element controls
+   * @brief getControlStartLanelets function returns lanelets where this element's control starts
    */
-  lanelet::ConstLanelets getControlledLanelets() const;
+  lanelet::ConstLanelets getControlStartLanelets() const;
+ 
+  /**
+   * @brief getControlEndLanelets function returns lanelets where this element's control ends
+   */
+  lanelet::ConstLanelets getControlEndLanelets() const;
+
 
   /**
    * @brief prefictState assumes sorted, fixed time, so guaranteed to give you one final state
@@ -135,12 +148,13 @@ public:
    *         Static helper function that creates a stop line data object based on the provided inputs
    *
    * @param id The lanelet::Id of this element
-   * @param lanelets List of lanelets this element controls.
+   * @param entry_lanelets List of lanelets where this element's control starts
+   * @param exit_lanelets List of lanelets where this element's control ends
    * @param stop_line The line string which represent the stop line of the traffic light
    *
    * @return RegulatoryElementData containing all the necessary information to construct a stop rule
    */
-  static std::unique_ptr<lanelet::RegulatoryElementData> buildData(Id id, LineString3d stop_line, Lanelets lanelets);
+  static std::unique_ptr<lanelet::RegulatoryElementData> buildData(Id id, LineString3d stop_line, Lanelets entry_lanelets, Lanelets exit_lanelets);
 
 
 private:

--- a/common/lanelet2_extension/include/lanelet2_extension/regulatory_elements/CarmaTrafficSignal.h
+++ b/common/lanelet2_extension/include/lanelet2_extension/regulatory_elements/CarmaTrafficSignal.h
@@ -124,14 +124,16 @@ public:
 
   /**
    * @brief getControlStartLanelets function returns lanelets where this element's control starts
+   * NOTE: Order of the lanelets does not correlate to the order of the control_end lanelets
    */
   lanelet::ConstLanelets getControlStartLanelets() const;
  
   /**
    * @brief getControlEndLanelets function returns lanelets where this element's control ends
+   * NOTE: Order of the lanelets does not correlate to the order of the control_start lanelets
+   * 
    */
   lanelet::ConstLanelets getControlEndLanelets() const;
-
 
   /**
    * @brief prefictState assumes sorted, fixed time, so guaranteed to give you one final state
@@ -139,6 +141,10 @@ public:
    * @param time_stamp boost::posix_time::ptime of the event happening
    */
   boost::optional<CarmaTrafficSignalState> predictState(boost::posix_time::ptime time_stamp);
+  
+  /**
+   * @brief Return the stop_lines related to the entry lanelets in order if exists.
+   */
   ConstLineStrings3d stopLine() const;
   LineStrings3d stopLine();
 
@@ -150,11 +156,11 @@ public:
    * @param id The lanelet::Id of this element
    * @param entry_lanelets List of lanelets where this element's control starts
    * @param exit_lanelets List of lanelets where this element's control ends
-   * @param stop_line The line string which represent the stop line of the traffic light
+   * @param stop_lines The line strings which represent the stop lines of the entry_lanelets (in order) controlled by the traffic light
    *
    * @return RegulatoryElementData containing all the necessary information to construct a stop rule
    */
-  static std::unique_ptr<lanelet::RegulatoryElementData> buildData(Id id, LineString3d stop_line, Lanelets entry_lanelets, Lanelets exit_lanelets);
+  static std::unique_ptr<lanelet::RegulatoryElementData> buildData(Id id, LineStrings3d stop_lines, Lanelets entry_lanelets, Lanelets exit_lanelets);
 
 
 private:

--- a/common/lanelet2_extension/lib/CarmaTrafficSignal.cpp
+++ b/common/lanelet2_extension/lib/CarmaTrafficSignal.cpp
@@ -27,6 +27,8 @@ using namespace lanelet::time;
 // C++ 14 vs 17 parameter export
 #if __cplusplus < 201703L
 constexpr char CarmaTrafficSignal::RuleName[];  // instantiate string in cpp file
+constexpr const char CarmaTrafficSignalRoleNameString::ControlStart[];
+constexpr const char CarmaTrafficSignalRoleNameString::ControlEnd[];
 #endif
 
 std::ostream& operator<<(std::ostream& os, CarmaTrafficSignalState s)
@@ -61,14 +63,16 @@ LineStrings3d CarmaTrafficSignal::stopLine()
 CarmaTrafficSignal::CarmaTrafficSignal(const lanelet::RegulatoryElementDataPtr& data) : RegulatoryElement(data)
 {}
 
-std::unique_ptr<lanelet::RegulatoryElementData> CarmaTrafficSignal::buildData(Id id, LineString3d stop_line, Lanelets lanelets)
+std::unique_ptr<lanelet::RegulatoryElementData> CarmaTrafficSignal::buildData(Id id, LineString3d stop_line, Lanelets entry_lanelets, Lanelets exit_lanelets)
 {
 
   if (stop_line.empty()) throw lanelet::InvalidInputError("Empty linestring was passed into CarmaTrafficSignal buildData function");
   // Add parameters
   RuleParameterMap rules;
-  rules[lanelet::RoleNameString::Refers].insert(rules[lanelet::RoleNameString::Refers].end(), lanelets.begin(),
-                                                lanelets.end());
+  rules[lanelet::CarmaTrafficSignalRoleNameString::ControlStart].insert(rules[lanelet::CarmaTrafficSignalRoleNameString::ControlStart].end(), entry_lanelets.begin(),
+                                                entry_lanelets.end());
+  rules[lanelet::CarmaTrafficSignalRoleNameString::ControlEnd].insert(rules[lanelet::CarmaTrafficSignalRoleNameString::ControlEnd].end(), exit_lanelets.begin(),
+                                                exit_lanelets.end());
   rules[lanelet::RoleNameString::RefLine].insert(rules[lanelet::RoleNameString::RefLine].end(), stop_line);
 
   // Add attributes
@@ -117,10 +121,15 @@ boost::optional<CarmaTrafficSignalState> CarmaTrafficSignal::predictState(boost:
   throw lanelet::InvalidInputError("Reached unreachable code block. Implies duplicate phase is not provided. Unable to determine fixed cycle duration");
 }
 
-lanelet::ConstLanelets CarmaTrafficSignal::getControlledLanelets() const
+lanelet::ConstLanelets CarmaTrafficSignal::getControlStartLanelets() const
 {
-  return getParameters<lanelet::ConstLanelet>(RoleName::Refers);
+  return getParameters<ConstLanelet>(CarmaTrafficSignalRoleNameString::ControlStart);
 } 
+
+lanelet::ConstLanelets CarmaTrafficSignal::getControlEndLanelets() const
+{
+  return getParameters<ConstLanelet>(CarmaTrafficSignalRoleNameString::ControlEnd);
+}
 
 void CarmaTrafficSignal::setStates(std::vector<std::pair<boost::posix_time::ptime, CarmaTrafficSignalState>> input_time_steps, int revision)
 {

--- a/common/lanelet2_extension/lib/CarmaTrafficSignal.cpp
+++ b/common/lanelet2_extension/lib/CarmaTrafficSignal.cpp
@@ -63,17 +63,15 @@ LineStrings3d CarmaTrafficSignal::stopLine()
 CarmaTrafficSignal::CarmaTrafficSignal(const lanelet::RegulatoryElementDataPtr& data) : RegulatoryElement(data)
 {}
 
-std::unique_ptr<lanelet::RegulatoryElementData> CarmaTrafficSignal::buildData(Id id, LineString3d stop_line, Lanelets entry_lanelets, Lanelets exit_lanelets)
+std::unique_ptr<lanelet::RegulatoryElementData> CarmaTrafficSignal::buildData(Id id, LineStrings3d stop_lines, Lanelets entry_lanelets, Lanelets exit_lanelets)
 {
-
-  if (stop_line.empty()) throw lanelet::InvalidInputError("Empty linestring was passed into CarmaTrafficSignal buildData function");
   // Add parameters
   RuleParameterMap rules;
   rules[lanelet::CarmaTrafficSignalRoleNameString::ControlStart].insert(rules[lanelet::CarmaTrafficSignalRoleNameString::ControlStart].end(), entry_lanelets.begin(),
                                                 entry_lanelets.end());
   rules[lanelet::CarmaTrafficSignalRoleNameString::ControlEnd].insert(rules[lanelet::CarmaTrafficSignalRoleNameString::ControlEnd].end(), exit_lanelets.begin(),
                                                 exit_lanelets.end());
-  rules[lanelet::RoleNameString::RefLine].insert(rules[lanelet::RoleNameString::RefLine].end(), stop_line);
+  rules[lanelet::RoleNameString::RefLine].insert(rules[lanelet::RoleNameString::RefLine].end(), stop_lines.begin(), stop_lines.end());
 
   // Add attributes
   AttributeMap attribute_map({

--- a/common/lanelet2_extension/test/src/CarmaTrafficSignalTest.cpp
+++ b/common/lanelet2_extension/test/src/CarmaTrafficSignalTest.cpp
@@ -51,7 +51,7 @@ TEST(CarmaTrafficSignalTest, CarmaTrafficSignal)
   lanelet::Id traffic_light_id = utils::getId();
   LineString3d virtual_stop_line(traffic_light_id, {pl2, pr2});
   // Creat passing control line for solid dashed line
-  std::shared_ptr<CarmaTrafficSignal> traffic_light(new CarmaTrafficSignal(CarmaTrafficSignal::buildData(lanelet::utils::getId(), { virtual_stop_line }, {ll_1, ll_2})));
+  std::shared_ptr<CarmaTrafficSignal> traffic_light(new CarmaTrafficSignal(CarmaTrafficSignal::buildData(lanelet::utils::getId(), { virtual_stop_line }, {ll_1, ll_2}, {ll_2})));
   ll_1.addRegulatoryElement(traffic_light);
 
   std::vector<std::pair<boost::posix_time::ptime, CarmaTrafficSignalState>> input_time_steps;
@@ -74,8 +74,8 @@ TEST(CarmaTrafficSignalTest, CarmaTrafficSignal)
 
   ASSERT_EQ(static_cast<lanelet::CarmaTrafficSignalState>(1),traffic_light->predictState(time::timeFromSec(1.5)).get());
   ASSERT_EQ(static_cast<lanelet::CarmaTrafficSignalState>(0),traffic_light->predictState(time::timeFromSec(1)).get());
-  ASSERT_EQ(traffic_light->getControlledLanelets().size(), 2);
-  ASSERT_EQ(traffic_light->getControlledLanelets().back().id(), ll_2.id());
+  ASSERT_EQ(traffic_light->getControlStartLanelets().size(), 2);
+  ASSERT_EQ(traffic_light->getControlStartLanelets().back().id(), ll_2.id());
   
 }
 

--- a/common/lanelet2_extension/test/src/SignalizedIntersectionTest.cpp
+++ b/common/lanelet2_extension/test/src/SignalizedIntersectionTest.cpp
@@ -163,7 +163,7 @@ TEST(SignalizedIntersectionTest, trafficSignalFunctions)
   auto pl = carma_wm::getPoint(0, 1, 0);
   auto pr = carma_wm::getPoint(1, 1, 0); 
   LineString3d virtual_stop_line(stop_line_id, {pl, pr});
-  std::shared_ptr<CarmaTrafficSignal> traffic_light(new CarmaTrafficSignal(CarmaTrafficSignal::buildData(lanelet::utils::getId(), { virtual_stop_line }, {llt})));
+  std::shared_ptr<CarmaTrafficSignal> traffic_light(new CarmaTrafficSignal(CarmaTrafficSignal::buildData(lanelet::utils::getId(), { virtual_stop_line }, {llt}, {llt})));
   llt.addRegulatoryElement(traffic_light);
 
   EXPECT_EQ(intersection->getTrafficSignals(llt).size(), 1);


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
This PR supports the PR here https://github.com/usdot-fhwa-stol/carma-platform/pull/1547
CarmaTrafficSignal now has exit lanelets describing which lanes the signal controls in an intersection.

## Related Issue
https://github.com/usdot-fhwa-stol/carma-platform/issues/1548
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
This change is to support multiple directions from a lane
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Local integration tested
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have added any new packages to the sonar-scanner.properties file
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.