### PR TITLE
Feature/wm intersection

### DIFF
--- a/common/autoware_lanelet2_ros_interface/include/autoware_lanelet2_ros_interface/utility/internal/query.tpp
+++ b/common/autoware_lanelet2_ros_interface/include/autoware_lanelet2_ros_interface/utility/internal/query.tpp
@@ -15,6 +15,7 @@
  */
 
 #pragma once
+#include <lanelet2_extension/logging/logger.h>
 
 // NOTE: This file is not meant to be included directly. Include query.h instead
 namespace lanelet
@@ -63,19 +64,21 @@ struct RecurseVisitor : public RuleParameterVisitor {
 };
 
 // Helper visitor class for finding existing elements with same id in the map and assigning input to it
-struct OverwriteParameterVisitor : public lanelet::internal::TrueMutableParameterVisitor {
+struct OverwriteParameterVisitor : public lanelet::internal::ParameterEditorVisitor {
   explicit OverwriteParameterVisitor (lanelet::LaneletMapPtr ll_Map) : ll_Map_(ll_Map) {}
   void operator() (Point3d& p) override { overwriteWithMatchingId(p, ll_Map_);} 
   void operator() (LineString3d& ls) override { overwriteWithMatchingId(ls, ll_Map_);}
   void operator() (Polygon3d& poly) override { overwriteWithMatchingId(poly, ll_Map_);}
   void operator() (WeakLanelet& llt) override { 
     if (llt.expired()) {  // NOLINT
+      LOG_WARN_STREAM("OverwriteParameterVisitor detected that this weakLanelet has expired! Returning...");
       return;
     }
     overwriteWithMatchingId(llt, ll_Map_);
   }
   void operator() (WeakArea& area) override { 
     if (area.expired()) {  // NOLINT
+      LOG_WARN_STREAM("OverwriteParameterVisitor detected that this weakArea has expired! Returning...");
       return;
     }
     overwriteWithMatchingId(area, ll_Map_);

--- a/common/autoware_lanelet2_ros_interface/include/autoware_lanelet2_ros_interface/utility/internal/query.tpp
+++ b/common/autoware_lanelet2_ros_interface/include/autoware_lanelet2_ros_interface/utility/internal/query.tpp
@@ -63,8 +63,8 @@ struct RecurseVisitor : public RuleParameterVisitor {
 };
 
 // Helper visitor class for finding existing elements with same id in the map and assigning input to it
-struct ResolveMemoryVisitor : public lanelet::internal::TrueMutableParameterVisitor {
-  explicit ResolveMemoryVisitor (lanelet::LaneletMapPtr ll_Map) : ll_Map_(ll_Map) {}
+struct OverwriteParameterVisitor : public lanelet::internal::TrueMutableParameterVisitor {
+  explicit OverwriteParameterVisitor (lanelet::LaneletMapPtr ll_Map) : ll_Map_(ll_Map) {}
   void operator() (Point3d& p) override { overwriteWithMatchingId(p, ll_Map_);} 
   void operator() (LineString3d& ls) override { overwriteWithMatchingId(ls, ll_Map_);}
   void operator() (Polygon3d& poly) override { overwriteWithMatchingId(poly, ll_Map_);}

--- a/common/autoware_lanelet2_ros_interface/lib/query.cpp
+++ b/common/autoware_lanelet2_ros_interface/lib/query.cpp
@@ -32,6 +32,14 @@ namespace lanelet
 namespace utils
 {
 
+void resolveMemory (WeakLanelet& prim, const lanelet::LaneletMapPtr ll_Map)
+{
+  if (ll_Map->laneletLayer.exists(prim.lock().id()))
+  {
+    prim = ll_Map->laneletLayer.get(prim.lock().id());
+  }
+}
+
 // Point
 void recurse (const lanelet::ConstPoint3d& prim, const lanelet::LaneletMapPtr ll_Map, query::direction check_dir, query::References& rfs)
 {

--- a/common/autoware_lanelet2_ros_interface/lib/query.cpp
+++ b/common/autoware_lanelet2_ros_interface/lib/query.cpp
@@ -32,11 +32,39 @@ namespace lanelet
 namespace utils
 {
 
-void resolveMemory (WeakLanelet& prim, const lanelet::LaneletMapPtr ll_Map)
+void overwriteWithMatchingId (WeakLanelet& prim, const lanelet::LaneletMapPtr ll_Map)
 {
   if (ll_Map->laneletLayer.exists(prim.lock().id()))
   {
     prim = ll_Map->laneletLayer.get(prim.lock().id());
+  }
+}
+void overwriteWithMatchingId (WeakArea& prim, const lanelet::LaneletMapPtr ll_Map)
+{
+  if (ll_Map->areaLayer.exists(prim.lock().id()))
+  {
+    prim = ll_Map->areaLayer.get(prim.lock().id());
+  }
+}
+void overwriteWithMatchingId (Point3d& prim, const lanelet::LaneletMapPtr ll_Map)
+{
+  if (ll_Map->pointLayer.exists(prim.id()))
+  {
+    prim = ll_Map->pointLayer.get(prim.id());
+  }
+}
+void overwriteWithMatchingId (LineString3d& prim, const lanelet::LaneletMapPtr ll_Map)
+{
+  if (ll_Map->lineStringLayer.exists(prim.id()))
+  {
+    prim = ll_Map->lineStringLayer.get(prim.id());
+  }
+}
+void overwriteWithMatchingId (Polygon3d& prim, const lanelet::LaneletMapPtr ll_Map)
+{
+  if (ll_Map->polygonLayer.exists(prim.id()))
+  {
+    prim = ll_Map->polygonLayer.get(prim.id());
   }
 }
 

--- a/common/autoware_lanelet2_ros_interface/lib/query.cpp
+++ b/common/autoware_lanelet2_ros_interface/lib/query.cpp
@@ -34,16 +34,24 @@ namespace utils
 
 void overwriteWithMatchingId (WeakLanelet& prim, const lanelet::LaneletMapPtr ll_Map)
 {
-  if (ll_Map->laneletLayer.exists(prim.lock().id()))
+  if (auto prim_ptr = prim.lock() && ll_Map->laneletLayer.exists(prim_ptr->id()))
   {
     prim = ll_Map->laneletLayer.get(prim.lock().id());
+  }
+  else 
+  {
+    LOG_WARN_STREAM("Could not acquire weak pointer lock for weakLanelet or primitive did not exist in the map");
   }
 }
 void overwriteWithMatchingId (WeakArea& prim, const lanelet::LaneletMapPtr ll_Map)
 {
-  if (ll_Map->areaLayer.exists(prim.lock().id()))
+  if (auto prim_ptr = prim.lock() && ll_Map->areaLayer.exists(prim_ptr->id()))
   {
     prim = ll_Map->areaLayer.get(prim.lock().id());
+  }
+  else 
+  {
+    LOG_WARN_STREAM("Could not acquire weak pointer lock for weakArea or primitive did not exist in the map");
   }
 }
 void overwriteWithMatchingId (Point3d& prim, const lanelet::LaneletMapPtr ll_Map)

--- a/common/autoware_lanelet2_ros_interface/lib/query.cpp
+++ b/common/autoware_lanelet2_ros_interface/lib/query.cpp
@@ -34,24 +34,40 @@ namespace utils
 
 void overwriteWithMatchingId (WeakLanelet& prim, const lanelet::LaneletMapPtr ll_Map)
 {
-  if (auto prim_ptr = prim.lock() && ll_Map->laneletLayer.exists(prim_ptr->id()))
+  if (prim.expired())
   {
-    prim = ll_Map->laneletLayer.get(prim.lock().id());
+    LOG_WARN_STREAM("Could not acquire weak pointer lock for weakLanelet");
+    return;
+  }
+    
+  auto prim_locked = prim.lock();
+ 
+  if (ll_Map->laneletLayer.exists(prim_locked.id()))
+  {
+    prim = ll_Map->laneletLayer.get(prim_locked.id());
   }
   else 
   {
-    LOG_WARN_STREAM("Could not acquire weak pointer lock for weakLanelet or primitive did not exist in the map");
+    LOG_WARN_STREAM("Lanelet primitive did not exist in the map");
   }
 }
 void overwriteWithMatchingId (WeakArea& prim, const lanelet::LaneletMapPtr ll_Map)
 {
-  if (auto prim_ptr = prim.lock() && ll_Map->areaLayer.exists(prim_ptr->id()))
+  if (prim.expired())
   {
-    prim = ll_Map->areaLayer.get(prim.lock().id());
+    LOG_WARN_STREAM("Could not acquire weak pointer lock for weakArea");
+    return;
+  }
+    
+  auto prim_locked = prim.lock();
+ 
+  if (ll_Map->areaLayer.exists(prim_locked.id()))
+  {
+    prim = ll_Map->areaLayer.get(prim_locked.id());
   }
   else 
   {
-    LOG_WARN_STREAM("Could not acquire weak pointer lock for weakArea or primitive did not exist in the map");
+    LOG_WARN_STREAM("Area primitive did not exist in the map");
   }
 }
 void overwriteWithMatchingId (Point3d& prim, const lanelet::LaneletMapPtr ll_Map)

--- a/common/lanelet2_extension/include/lanelet2_extension/regulatory_elements/CarmaTrafficSignal.h
+++ b/common/lanelet2_extension/include/lanelet2_extension/regulatory_elements/CarmaTrafficSignal.h
@@ -142,7 +142,9 @@ public:
    * @brief prefictState assumes sorted, fixed time, so guaranteed to give you one final state
    *
    * @param time_stamp boost::posix_time::ptime of the event happening
-   * @return std::pair of signal state and its end time at the input time 
+   * @return std::pair of signal state and its end time at the input time
+   *         optional will empty if no timestamps are recorded yet
+   * @throw  InvalidInputError if timestamps recorded somehow did not have full cycle
    */
   boost::optional<std::pair<boost::posix_time::ptime, CarmaTrafficSignalState>> predictState(boost::posix_time::ptime time_stamp);
   
@@ -155,9 +157,10 @@ public:
   /**
    * @brief Return the stop_lines related to the specified entry lanelet
    * @param llt entry_lanelet 
-   * @return optional stop line linestring
+   * @return optional stop line linestring. 
+   *         Empty optional if no stopline, or no entry lanelets, or if specified entry lanelet is not recorded. 
    */
-  Optional<ConstLineString3d> getStopLine(const ConstLanelet& llt) const;
+  Optional<ConstLineString3d> getConstStopLine(const ConstLanelet& llt);
   Optional<LineString3d> getStopLine(const ConstLanelet& llt);
 
   explicit CarmaTrafficSignal(const lanelet::RegulatoryElementDataPtr& data);

--- a/common/lanelet2_extension/include/lanelet2_extension/regulatory_elements/CarmaTrafficSignal.h
+++ b/common/lanelet2_extension/include/lanelet2_extension/regulatory_elements/CarmaTrafficSignal.h
@@ -139,8 +139,9 @@ public:
    * @brief prefictState assumes sorted, fixed time, so guaranteed to give you one final state
    *
    * @param time_stamp boost::posix_time::ptime of the event happening
+   * @return std::pair of signal state and its end time at the input time 
    */
-  boost::optional<CarmaTrafficSignalState> predictState(boost::posix_time::ptime time_stamp);
+  boost::optional<std::pair<boost::posix_time::ptime, CarmaTrafficSignalState>> predictState(boost::posix_time::ptime time_stamp);
   
   /**
    * @brief Return the stop_lines related to the entry lanelets in order if exists.

--- a/common/lanelet2_extension/include/lanelet2_extension/regulatory_elements/CarmaTrafficSignal.h
+++ b/common/lanelet2_extension/include/lanelet2_extension/regulatory_elements/CarmaTrafficSignal.h
@@ -114,6 +114,9 @@ public:
   int revision_ = 0; //indicates when was this last modified
   boost::posix_time::time_duration fixed_cycle_duration;
   std::vector<std::pair<boost::posix_time::ptime, CarmaTrafficSignalState>> recorded_time_stamps;
+  std::unordered_map<CarmaTrafficSignalState, boost::posix_time::time_duration> signal_durations;
+
+
   /**
    * @brief setStates function sorts states automatically
    *
@@ -148,6 +151,14 @@ public:
    */
   ConstLineStrings3d stopLine() const;
   LineStrings3d stopLine();
+
+  /**
+   * @brief Return the stop_lines related to the specified entry lanelet
+   * @param llt entry_lanelet 
+   * @return optional stop line linestring
+   */
+  Optional<ConstLineString3d> getStopLine(const ConstLanelet& llt) const;
+  Optional<LineString3d> getStopLine(const ConstLanelet& llt);
 
   explicit CarmaTrafficSignal(const lanelet::RegulatoryElementDataPtr& data);
   /**

--- a/common/lanelet2_extension/lib/CarmaTrafficSignal.cpp
+++ b/common/lanelet2_extension/lib/CarmaTrafficSignal.cpp
@@ -60,40 +60,34 @@ LineStrings3d CarmaTrafficSignal::stopLine()
   return getParameters<LineString3d>(RoleName::RefLine);
 }
 
-Optional<ConstLineString3d> CarmaTrafficSignal::getStopLine(const ConstLanelet& llt) const 
-{
-  auto sl = stopLine();
-  if (sl.empty()) {
-    return {};
-  }
-  auto llts = getControlStartLanelets();
-  auto it = std::find(llts.begin(), llts.end(), llt);
-  if (llts.empty())
-  {
-    return {};
-  }
-  if (it == llts.end()) {
-    return {};
-  }
-  return sl.at(size_t(std::distance(llts.begin(), it)));
-}
-
 Optional<LineString3d> CarmaTrafficSignal::getStopLine(const ConstLanelet& llt) 
 {
   auto sl = stopLine();
   if (sl.empty()) {
-    return {};
+    return boost::none;
   }
   lanelet::ConstLanelets llts = getControlStartLanelets();
   if (llts.empty())
   {
-    return {};
+    return boost::none;
   }
   auto it = std::find(llts.begin(), llts.end(), llt);
   if (it == llts.end()) {
-    return {};
+    return boost::none;
   }
   return sl.at(size_t(std::distance(llts.begin(), it)));
+}
+
+Optional<ConstLineString3d> CarmaTrafficSignal::getConstStopLine(const ConstLanelet& llt) 
+{
+  Optional<LineString3d> mutable_stop_line = getStopLine(llt);
+  
+  if (!mutable_stop_line)
+    return boost::none;
+
+  ConstLineString3d const_stop_line = mutable_stop_line.get();
+  
+  return const_stop_line;
 }
 
 CarmaTrafficSignal::CarmaTrafficSignal(const lanelet::RegulatoryElementDataPtr& data) : RegulatoryElement(data)

--- a/common/lanelet2_extension/lib/CarmaTrafficSignal.cpp
+++ b/common/lanelet2_extension/lib/CarmaTrafficSignal.cpp
@@ -66,21 +66,15 @@ Optional<ConstLineString3d> CarmaTrafficSignal::getStopLine(const ConstLanelet& 
   if (sl.empty()) {
     return {};
   }
-  std::cerr << "inside stop line!\n";
   auto llts = getControlStartLanelets();
-  std::cerr << "inside stop line! llts.size(): " << llts.size() << "\n";
   auto it = std::find(llts.begin(), llts.end(), llt);
-  std::cerr << "inside stop line 1!\n";
   if (llts.empty())
   {
-    std::cerr << "StartLanelest are zero!!!!!!1\n";
     return {};
   }
   if (it == llts.end()) {
-    std::cerr << "Returnning sadly\n";
     return {};
   }
-  std::cerr << "inside stop line 2!\n";
   return sl.at(size_t(std::distance(llts.begin(), it)));
 }
 
@@ -90,21 +84,15 @@ Optional<LineString3d> CarmaTrafficSignal::getStopLine(const ConstLanelet& llt)
   if (sl.empty()) {
     return {};
   }
-  std::cerr << "inside stop line!\n";
   lanelet::ConstLanelets llts = getControlStartLanelets();
-  std::cerr << "inside stop line! llts.size(): " << llts.size() << "\n";
   if (llts.empty())
   {
-    std::cerr << "StartLanelest are zero!!!!!!1\n";
     return {};
   }
   auto it = std::find(llts.begin(), llts.end(), llt);
-  std::cerr << "inside stop line 1!\n";
   if (it == llts.end()) {
-    std::cerr << "Returnning sadly\n";
     return {};
   }
-  std::cerr << "inside stop line 2!\n";
   return sl.at(size_t(std::distance(llts.begin(), it)));
 }
 
@@ -115,11 +103,6 @@ std::unique_ptr<lanelet::RegulatoryElementData> CarmaTrafficSignal::buildData(Id
 {
   // Add parameters
   RuleParameterMap rules;
-  std::cerr << "INSIDE BUILDDATA for TRAFFIC LIGHT\n";
-  for (auto llt: entry_lanelets)
-  {
-    std::cerr << "llt.d(): " << llt.id() << "\n";
-  }
   rules[lanelet::CarmaTrafficSignalRoleNameString::ControlStart].insert(rules[lanelet::CarmaTrafficSignalRoleNameString::ControlStart].end(), entry_lanelets.begin(),
                                                 entry_lanelets.end());
   rules[lanelet::CarmaTrafficSignalRoleNameString::ControlEnd].insert(rules[lanelet::CarmaTrafficSignalRoleNameString::ControlEnd].end(), exit_lanelets.begin(),
@@ -177,17 +160,12 @@ boost::optional<std::pair<boost::posix_time::ptime, CarmaTrafficSignalState>> Ca
 
 lanelet::ConstLanelets CarmaTrafficSignal::getControlStartLanelets() const
 {
-  std::cerr<<"Printing parameters:\n";
-  for (auto iter = parameters().begin(); iter != parameters().end(); iter++)
-  {
-    std::cerr<<"Printing parameter[i]" << iter->first <<"\n";
-  } 
-  return getParameters<ConstLanelet>("control_start");
+  return getParameters<ConstLanelet>(CarmaTrafficSignalRoleNameString::ControlStart);
 } 
 
 lanelet::ConstLanelets CarmaTrafficSignal::getControlEndLanelets() const
 {
-  return getParameters<ConstLanelet>("control_end");
+  return getParameters<ConstLanelet>(CarmaTrafficSignalRoleNameString::ControlEnd);
 }
 
 void CarmaTrafficSignal::setStates(std::vector<std::pair<boost::posix_time::ptime, CarmaTrafficSignalState>> input_time_steps, int revision)

--- a/common/lanelet2_extension/lib/CarmaTrafficSignal.cpp
+++ b/common/lanelet2_extension/lib/CarmaTrafficSignal.cpp
@@ -215,7 +215,6 @@ double toSec(const boost::posix_time::time_duration& duration) {
 }
 
 double toSec(const boost::posix_time::ptime& time) {
-  // TODO clean up this comment boost::posix_time::time_duration duration = t - boost::posix_time::from_time_t(0);
   return toSec(time - boost::posix_time::from_time_t(0));
 }
 

--- a/common/lanelet2_extension/test/src/CarmaTrafficSignalTest.cpp
+++ b/common/lanelet2_extension/test/src/CarmaTrafficSignalTest.cpp
@@ -48,11 +48,37 @@ TEST(CarmaTrafficSignalTest, CarmaTrafficSignal)
   auto ll_1 = carma_wm::getLanelet(left_1, right_1, lanelet::AttributeValueString::SolidDashed,lanelet::AttributeValueString::Dashed);
   auto ll_2 = carma_wm::getLanelet(left_1, right_1, lanelet::AttributeValueString::SolidDashed,lanelet::AttributeValueString::Dashed);
   
-  lanelet::Id traffic_light_id = utils::getId();
-  LineString3d virtual_stop_line(traffic_light_id, {pl2, pr2});
+  lanelet::Id stop_line_id = utils::getId();
+  LineString3d virtual_stop_line(stop_line_id, {pl2, pr2});
+  lanelet::Id stop_line_id1= utils::getId();
+  LineString3d virtual_stop_line1(stop_line_id1, {pl2, pr2});
   // Creat passing control line for solid dashed line
-  std::shared_ptr<CarmaTrafficSignal> traffic_light(new CarmaTrafficSignal(CarmaTrafficSignal::buildData(lanelet::utils::getId(), { virtual_stop_line }, {ll_1, ll_2}, {ll_2})));
+  std::shared_ptr<CarmaTrafficSignal> traffic_light(new CarmaTrafficSignal(CarmaTrafficSignal::buildData(lanelet::utils::getId(), { virtual_stop_line,  virtual_stop_line1}, {ll_1, ll_2}, {ll_2})));
   ll_1.addRegulatoryElement(traffic_light);
+
+  auto entry_lanelets = traffic_light->getControlStartLanelets();
+
+  lanelet::RegulatoryElementPtr regem = traffic_light;
+  auto factory_pcl = lanelet::RegulatoryElementFactory::create(regem->attribute(lanelet::AttributeName::Subtype).value(),
+                                                            std::const_pointer_cast<lanelet::RegulatoryElementData>(regem->constData()));
+
+  lanelet::CarmaTrafficSignalPtr ctl = std::dynamic_pointer_cast<lanelet::CarmaTrafficSignal>(factory_pcl);
+
+  std::cerr << "Tryign to print the entry stuff" << std::endl;
+  for (auto l : ctl->getControlStartLanelets())
+  {
+    std::cerr << "entry lanelet: " << l.id() << "\n";
+  }
+
+  for (auto l : entry_lanelets)
+  {
+    std::cerr << "lanelet: " << l.id() << "\n";
+  }
+  
+  ASSERT_EQ(2,entry_lanelets.size());
+
+  auto sl = traffic_light->getStopLine(ll_2);
+  ASSERT_EQ(stop_line_id1,sl.get().id());
 
   std::vector<std::pair<boost::posix_time::ptime, CarmaTrafficSignalState>> input_time_steps;
 

--- a/common/lanelet2_extension/test/src/CarmaTrafficSignalTest.cpp
+++ b/common/lanelet2_extension/test/src/CarmaTrafficSignalTest.cpp
@@ -63,17 +63,6 @@ TEST(CarmaTrafficSignalTest, CarmaTrafficSignal)
                                                             std::const_pointer_cast<lanelet::RegulatoryElementData>(regem->constData()));
 
   lanelet::CarmaTrafficSignalPtr ctl = std::dynamic_pointer_cast<lanelet::CarmaTrafficSignal>(factory_pcl);
-
-  std::cerr << "Tryign to print the entry stuff" << std::endl;
-  for (auto l : ctl->getControlStartLanelets())
-  {
-    std::cerr << "entry lanelet: " << l.id() << "\n";
-  }
-
-  for (auto l : entry_lanelets)
-  {
-    std::cerr << "lanelet: " << l.id() << "\n";
-  }
   
   ASSERT_EQ(2,entry_lanelets.size());
 

--- a/common/lanelet2_extension/test/src/CarmaTrafficSignalTest.cpp
+++ b/common/lanelet2_extension/test/src/CarmaTrafficSignalTest.cpp
@@ -72,8 +72,8 @@ TEST(CarmaTrafficSignalTest, CarmaTrafficSignal)
   ASSERT_EQ(time::durationFromSec(5),traffic_light->fixed_cycle_duration);
   ASSERT_EQ(0,traffic_light->revision_);
 
-  ASSERT_EQ(static_cast<lanelet::CarmaTrafficSignalState>(1),traffic_light->predictState(time::timeFromSec(1.5)).get());
-  ASSERT_EQ(static_cast<lanelet::CarmaTrafficSignalState>(0),traffic_light->predictState(time::timeFromSec(1)).get());
+  ASSERT_EQ(static_cast<lanelet::CarmaTrafficSignalState>(1),traffic_light->predictState(time::timeFromSec(1.5)).get().second);
+  ASSERT_EQ(static_cast<lanelet::CarmaTrafficSignalState>(0),traffic_light->predictState(time::timeFromSec(1)).get().second);
   ASSERT_EQ(traffic_light->getControlStartLanelets().size(), 2);
   ASSERT_EQ(traffic_light->getControlStartLanelets().back().id(), ll_2.id());
   

--- a/lanelet2/lanelet2_core/include/lanelet2_core/primitives/Lanelet.h
+++ b/lanelet2/lanelet2_core/include/lanelet2_core/primitives/Lanelet.h
@@ -11,7 +11,6 @@
 #include "lanelet2_core/primitives/LineString.h"
 #include "lanelet2_core/primitives/Primitive.h"
 #include "lanelet2_core/utility/Optional.h"
-#include <iostream>
 
 namespace lanelet {
 enum class LaneletType { OneWay, Bidirectional };
@@ -323,7 +322,6 @@ class ConstWeakLanelet {
   ConstWeakLanelet() = default;
   ConstWeakLanelet(const ConstLanelet& llet)  // NOLINT
       : laneletData_{llet.constData()}, inverted_{llet.inverted()} {}
-  ~ConstWeakLanelet() {/*std::cerr << "Deleting: " << lock().id() << "\n";*/}
   /**
    * @brief Obtains the original ConstLanelet.
    * @throws NullptrError if the managed lanelet expired.
@@ -332,11 +330,9 @@ class ConstWeakLanelet {
 
   //! tests whether the WeakLanelet is still valid
   bool expired() const noexcept { return laneletData_.expired(); }
-
-  std::weak_ptr<const LaneletData> laneletData_;  // NOLINT
   
  protected:
-  
+  std::weak_ptr<const LaneletData> laneletData_;  // NOLINT
   bool inverted_{false};                          // NOLINT
 };
 

--- a/lanelet2/lanelet2_core/include/lanelet2_core/primitives/Lanelet.h
+++ b/lanelet2/lanelet2_core/include/lanelet2_core/primitives/Lanelet.h
@@ -11,6 +11,7 @@
 #include "lanelet2_core/primitives/LineString.h"
 #include "lanelet2_core/primitives/Primitive.h"
 #include "lanelet2_core/utility/Optional.h"
+#include <iostream>
 
 namespace lanelet {
 enum class LaneletType { OneWay, Bidirectional };
@@ -322,7 +323,7 @@ class ConstWeakLanelet {
   ConstWeakLanelet() = default;
   ConstWeakLanelet(const ConstLanelet& llet)  // NOLINT
       : laneletData_{llet.constData()}, inverted_{llet.inverted()} {}
-
+  ~ConstWeakLanelet() {/*std::cerr << "Deleting: " << lock().id() << "\n";*/}
   /**
    * @brief Obtains the original ConstLanelet.
    * @throws NullptrError if the managed lanelet expired.
@@ -332,8 +333,10 @@ class ConstWeakLanelet {
   //! tests whether the WeakLanelet is still valid
   bool expired() const noexcept { return laneletData_.expired(); }
 
- protected:
   std::weak_ptr<const LaneletData> laneletData_;  // NOLINT
+  
+ protected:
+  
   bool inverted_{false};                          // NOLINT
 };
 

--- a/lanelet2/lanelet2_core/include/lanelet2_core/primitives/RegulatoryElement.h
+++ b/lanelet2/lanelet2_core/include/lanelet2_core/primitives/RegulatoryElement.h
@@ -171,14 +171,14 @@ class MutableParameterVisitor : public boost::static_visitor<void> {  // NOLINT
  * parameter of a regulatory element 
  * @see RegulatoryElement::applyVisitor
  */
-class TrueMutableParameterVisitor : public boost::static_visitor<void> {  // NOLINT
+class ParameterEditorVisitor : public boost::static_visitor<void> {  // NOLINT
  public:
   virtual void operator()(Point3d /*unused*/&) = 0;
   virtual void operator()(LineString3d& /*unused*/) = 0;
   virtual void operator()(Polygon3d& /*unused*/) = 0;
   virtual void operator()(WeakLanelet& /*unused*/) = 0;
   virtual void operator()(WeakArea& /*unused*/) = 0;
-  virtual ~TrueMutableParameterVisitor() = default;
+  virtual ~ParameterEditorVisitor() = default;
   std::string role;  //!< applyVisitor will set the current role here
 };
 }  // namespace internal
@@ -252,7 +252,7 @@ class RegulatoryElement  // NOLINT
 
   //! applies a visitor to every parameter in the regulatory element
   void applyVisitor(RuleParameterVisitor& visitor) const;
-  void applyVisitor(lanelet::internal::TrueMutableParameterVisitor& visitor);
+  void applyVisitor(lanelet::internal::ParameterEditorVisitor& visitor);
 
 
  protected:

--- a/lanelet2/lanelet2_core/include/lanelet2_core/primitives/RegulatoryElement.h
+++ b/lanelet2/lanelet2_core/include/lanelet2_core/primitives/RegulatoryElement.h
@@ -166,6 +166,16 @@ class MutableParameterVisitor : public boost::static_visitor<void> {  // NOLINT
   virtual ~MutableParameterVisitor() = default;
   std::string role;  //!< applyVisitor will set the current role here
 };
+class MisheelMutableParameterVisitor : public boost::static_visitor<void> {  // NOLINT
+ public:
+  virtual void operator()(Point3d /*unused*/&) = 0;
+  virtual void operator()(LineString3d& /*unused*/) = 0;
+  virtual void operator()(Polygon3d& /*unused*/) = 0;
+  virtual void operator()(WeakLanelet& /*unused*/) = 0;
+  virtual void operator()(WeakArea& /*unused*/) = 0;
+  virtual ~MisheelMutableParameterVisitor() = default;
+  std::string role;  //!< applyVisitor will set the current role here
+};
 }  // namespace internal
 
 //! @brief A general rule or limitation for a lanelet (abstract base class)
@@ -237,6 +247,8 @@ class RegulatoryElement  // NOLINT
 
   //! applies a visitor to every parameter in the regulatory element
   void applyVisitor(RuleParameterVisitor& visitor) const;
+  void applyVisitor(lanelet::internal::MisheelMutableParameterVisitor& visitor);
+
 
  protected:
   const_iterator begin() const { return constData()->parameters.begin(); }

--- a/lanelet2/lanelet2_core/include/lanelet2_core/primitives/RegulatoryElement.h
+++ b/lanelet2/lanelet2_core/include/lanelet2_core/primitives/RegulatoryElement.h
@@ -166,14 +166,19 @@ class MutableParameterVisitor : public boost::static_visitor<void> {  // NOLINT
   virtual ~MutableParameterVisitor() = default;
   std::string role;  //!< applyVisitor will set the current role here
 };
-class MisheelMutableParameterVisitor : public boost::static_visitor<void> {  // NOLINT
+/**
+ * @brief You can inherit from this visitor to perform an operation on and alter each
+ * parameter of a regulatory element 
+ * @see RegulatoryElement::applyVisitor
+ */
+class TrueMutableParameterVisitor : public boost::static_visitor<void> {  // NOLINT
  public:
   virtual void operator()(Point3d /*unused*/&) = 0;
   virtual void operator()(LineString3d& /*unused*/) = 0;
   virtual void operator()(Polygon3d& /*unused*/) = 0;
   virtual void operator()(WeakLanelet& /*unused*/) = 0;
   virtual void operator()(WeakArea& /*unused*/) = 0;
-  virtual ~MisheelMutableParameterVisitor() = default;
+  virtual ~TrueMutableParameterVisitor() = default;
   std::string role;  //!< applyVisitor will set the current role here
 };
 }  // namespace internal
@@ -247,7 +252,7 @@ class RegulatoryElement  // NOLINT
 
   //! applies a visitor to every parameter in the regulatory element
   void applyVisitor(RuleParameterVisitor& visitor) const;
-  void applyVisitor(lanelet::internal::MisheelMutableParameterVisitor& visitor);
+  void applyVisitor(lanelet::internal::TrueMutableParameterVisitor& visitor);
 
 
  protected:

--- a/lanelet2/lanelet2_core/src/RegulatoryElement.cpp
+++ b/lanelet2/lanelet2_core/src/RegulatoryElement.cpp
@@ -153,7 +153,7 @@ void RegulatoryElement::applyVisitor(RuleParameterVisitor& visitor) const {
   }
 }
 
-void RegulatoryElement::applyVisitor(lanelet::internal::MisheelMutableParameterVisitor& visitor) {
+void RegulatoryElement::applyVisitor(lanelet::internal::TrueMutableParameterVisitor& visitor) {
   for (auto& elems : parameters()) {
     visitor.role = elems.first;
     for (auto& elem : elems.second) {

--- a/lanelet2/lanelet2_core/src/RegulatoryElement.cpp
+++ b/lanelet2/lanelet2_core/src/RegulatoryElement.cpp
@@ -152,7 +152,7 @@ void RegulatoryElement::applyVisitor(RuleParameterVisitor& visitor) const {
   }
 }
 
-void RegulatoryElement::applyVisitor(lanelet::internal::TrueMutableParameterVisitor& visitor) {
+void RegulatoryElement::applyVisitor(lanelet::internal::ParameterEditorVisitor& visitor) {
   for (auto& elems : parameters()) {
     visitor.role = elems.first;
     for (auto& elem : elems.second) {

--- a/lanelet2/lanelet2_core/src/RegulatoryElement.cpp
+++ b/lanelet2/lanelet2_core/src/RegulatoryElement.cpp
@@ -119,7 +119,6 @@ RegulatoryElementPtr RegulatoryElementFactory::create(std::string ruleName, cons
   auto& inst = RegulatoryElementFactory::instance();
   auto it = inst.registry_.find(ruleName);
   if (it != inst.registry_.end()) {
-    std::cerr << "!!!!!!! We found a place with rulename: " << ruleName << "\n";
     return it->second(data);
   }
   throw InvalidInputError("No regulatory element found that implements rule " + ruleName);

--- a/lanelet2/lanelet2_core/src/RegulatoryElement.cpp
+++ b/lanelet2/lanelet2_core/src/RegulatoryElement.cpp
@@ -119,6 +119,7 @@ RegulatoryElementPtr RegulatoryElementFactory::create(std::string ruleName, cons
   auto& inst = RegulatoryElementFactory::instance();
   auto it = inst.registry_.find(ruleName);
   if (it != inst.registry_.end()) {
+    std::cerr << "!!!!!!! We found a place with rulename: " << ruleName << "\n";
     return it->second(data);
   }
   throw InvalidInputError("No regulatory element found that implements rule " + ruleName);
@@ -147,6 +148,15 @@ void RegulatoryElement::applyVisitor(RuleParameterVisitor& visitor) const {
   for (const auto& elems : parameters()) {
     visitor.role = elems.first;
     for (const auto& elem : elems.second) {
+      boost::apply_visitor(visitor, elem);
+    }
+  }
+}
+
+void RegulatoryElement::applyVisitor(lanelet::internal::MisheelMutableParameterVisitor& visitor) {
+  for (auto& elems : parameters()) {
+    visitor.role = elems.first;
+    for (auto& elem : elems.second) {
       boost::apply_visitor(visitor, elem);
     }
   }

--- a/lanelet2/lanelet2_io/include/lanelet2_io/io_handlers/Serialize.h
+++ b/lanelet2/lanelet2_io/include/lanelet2_io/io_handlers/Serialize.h
@@ -62,9 +62,7 @@ void save(Archive& ar, const lanelet::AttributeMap& p, unsigned int /*version*/)
 
 template <typename Archive>
 void load(Archive& ar, lanelet::RuleParameterMap& p, unsigned int /*version*/) {
-  std::cerr<<"calling parameter\n";
   boost::serialization::load_map_collection(ar, p);
-
 }
 
 template <typename Archive>
@@ -121,6 +119,7 @@ void save(Archive& ar, const lanelet::Lanelet& l, unsigned int /*version*/) {
 template <typename Archive>
 void load(Archive& ar, lanelet::Lanelet& l, unsigned int /*version*/) {
   std::shared_ptr<lanelet::LaneletData> ptr;
+  
   bool inv = false;
   ar >> inv >> ptr;
   l = lanelet::Lanelet(ptr, inv);
@@ -146,31 +145,14 @@ void save(Archive& ar, const lanelet::WeakLanelet& l, unsigned int /*version*/) 
     throw lanelet::LaneletError("Can not serialize expired weak pointer!");
   }
   auto sp = l.lock();
-  std::cerr << "Still has it : " << sp.id() << "\n";
   ar& sp;
 }
 template <typename Archive>
 void load(Archive& ar, lanelet::WeakLanelet& l, unsigned int /*version*/) {
   lanelet::Lanelet lanelet;
-  //lanelet::Lanelet lanelet1;
 
-  std::cerr << "OMG WE ARE AT HERe, weaklenelt\n";
   ar& lanelet;
-  //lanelet1 = lanelet;
   l = lanelet;
-  
-  if (l.expired())
-  {
-    std::cerr << "inside, deserialization, we lost ot\n";
-  }
-  else
-  {
-    std::cerr << " still has it " << l.lock().id() << "\n";
-    std::cerr << "weak count" << l.laneletData_.use_count() << "\n";
-    //auto copy = l.laneletData_;
-    std::cerr << "weak count" << l.laneletData_.use_count() << "\n";
-
-  }
 }
 
 //! linestring + data

--- a/lanelet2/lanelet2_io/include/lanelet2_io/io_handlers/Serialize.h
+++ b/lanelet2/lanelet2_io/include/lanelet2_io/io_handlers/Serialize.h
@@ -62,7 +62,9 @@ void save(Archive& ar, const lanelet::AttributeMap& p, unsigned int /*version*/)
 
 template <typename Archive>
 void load(Archive& ar, lanelet::RuleParameterMap& p, unsigned int /*version*/) {
+  std::cerr<<"calling parameter\n";
   boost::serialization::load_map_collection(ar, p);
+
 }
 
 template <typename Archive>
@@ -144,13 +146,31 @@ void save(Archive& ar, const lanelet::WeakLanelet& l, unsigned int /*version*/) 
     throw lanelet::LaneletError("Can not serialize expired weak pointer!");
   }
   auto sp = l.lock();
+  std::cerr << "Still has it : " << sp.id() << "\n";
   ar& sp;
 }
 template <typename Archive>
 void load(Archive& ar, lanelet::WeakLanelet& l, unsigned int /*version*/) {
   lanelet::Lanelet lanelet;
+  //lanelet::Lanelet lanelet1;
+
+  std::cerr << "OMG WE ARE AT HERe, weaklenelt\n";
   ar& lanelet;
+  //lanelet1 = lanelet;
   l = lanelet;
+  
+  if (l.expired())
+  {
+    std::cerr << "inside, deserialization, we lost ot\n";
+  }
+  else
+  {
+    std::cerr << " still has it " << l.lock().id() << "\n";
+    std::cerr << "weak count" << l.laneletData_.use_count() << "\n";
+    //auto copy = l.laneletData_;
+    std::cerr << "weak count" << l.laneletData_.use_count() << "\n";
+
+  }
 }
 
 //! linestring + data


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
Supports PR: https://github.com/usdot-fhwa-stol/carma-platform/pull/1586/
Major changes:
- CarmaTrafficSignal can return stop_line of a specific entry_lanelet. This is because single signal_group can control multiple lanes and even opposite directions. 
- CarmaTrafficSignal's predictState also returns the end_time of current state. This will prove useful for user's to know when the signal will change. Also it is used to shift and modify the timers when new cycle info is received through SPAT.
- OverwriteParameterVisitor and overwriteWithMatchingId. These functions are used to overwrite the parameter of regulatoryElement. it is used to match the memory address of received parameter to the on the already exists in the map with same id.


## Related Issue
https://github.com/usdot-fhwa-stol/carma-platform/issues/1587
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
This is to supprot TSMO Use Case 2.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Local integration tested with real world MAP message. 
At the time of this PR, faulty MAP msg converter is blocking full vehicle integration test.
https://github.com/usdot-fhwa-stol/carma-platform/issues/1588
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have added any new packages to the sonar-scanner.properties file
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.