### PR TITLE
skip build for mpc_follower and qpoases vendor

### DIFF
--- a/docker/install.sh
+++ b/docker/install.sh
@@ -29,7 +29,7 @@ echo "ROS 1 Build with CUDA"
 sudo mkdir /opt/autoware.ai # Create install directory
 sudo chown carma /opt/autoware.ai # Set owner to expose permissions for build
 sudo chgrp carma /opt/autoware.ai # Set group to expose permissions for build
-AUTOWARE_COMPILE_WITH_CUDA=1 colcon build --packages-skip mpc_follower qpoases_vendor --build-base build_ros1 --install-base /opt/autoware.ai/ros/install --cmake-args -DCMAKE_BUILD_TYPE=Release -DCMAKE_LIBRARY_PATH=/usr/local/cuda/lib64/stubs -DCMAKE_CXX_FLAGS=-Wall -DCMAKE_C_FLAGS=-Wall
+AUTOWARE_COMPILE_WITH_CUDA=1 colcon build --build-base build_ros1 --install-base /opt/autoware.ai/ros/install --cmake-args -DCMAKE_BUILD_TYPE=Release -DCMAKE_LIBRARY_PATH=/usr/local/cuda/lib64/stubs -DCMAKE_CXX_FLAGS=-Wall -DCMAKE_C_FLAGS=-Wall
 
 # Get the exit code from the ROS1 build so we can skip the ROS2 build if the ROS1 build failed
 status=$?

--- a/docker/install.sh
+++ b/docker/install.sh
@@ -29,7 +29,7 @@ echo "ROS 1 Build with CUDA"
 sudo mkdir /opt/autoware.ai # Create install directory
 sudo chown carma /opt/autoware.ai # Set owner to expose permissions for build
 sudo chgrp carma /opt/autoware.ai # Set group to expose permissions for build
-AUTOWARE_COMPILE_WITH_CUDA=1 colcon build --build-base build_ros1 --install-base /opt/autoware.ai/ros/install --cmake-args -DCMAKE_BUILD_TYPE=Release -DCMAKE_LIBRARY_PATH=/usr/local/cuda/lib64/stubs -DCMAKE_CXX_FLAGS=-Wall -DCMAKE_C_FLAGS=-Wall
+AUTOWARE_COMPILE_WITH_CUDA=1 colcon build --packages-skip mpc_follower qpoases_vendor --build-base build_ros1 --install-base /opt/autoware.ai/ros/install --cmake-args -DCMAKE_BUILD_TYPE=Release -DCMAKE_LIBRARY_PATH=/usr/local/cuda/lib64/stubs -DCMAKE_CXX_FLAGS=-Wall -DCMAKE_C_FLAGS=-Wall
 
 # Get the exit code from the ROS1 build so we can skip the ROS2 build if the ROS1 build failed
 status=$?


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
This pr allows autoware docker build to skip the build for qpoases_vendor and mpc_follower. The checkout for qpoases_vendor seems to be unstable and often results in errors while building the autoware image.

It is assumed that skipping the build for mpc_follower is not going to cause any functional changes to the carma system, since the controller being used is pure_pursuit.
## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Docker image successfully built after this change.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.