### PR TITLE
Refactor lanelet::time utility functionalities to be public

### DIFF
--- a/common/lanelet2_extension/CMakeLists.txt
+++ b/common/lanelet2_extension/CMakeLists.txt
@@ -62,6 +62,7 @@ set(cpp_files
   lib/SignalizedIntersection.cpp
   lib/RegionAccessRule.cpp
   lib/DirectionOfTravel.cpp
+  lib/TimeConversion.cpp
 )
 
 

--- a/common/lanelet2_extension/include/lanelet2_extension/regulatory_elements/CarmaTrafficSignal.h
+++ b/common/lanelet2_extension/include/lanelet2_extension/regulatory_elements/CarmaTrafficSignal.h
@@ -58,42 +58,6 @@ struct CarmaTrafficSignalRoleNameString
   static constexpr char ControlEnd[] = "control_end";
 };
 
-// Namespace for time representations used with this regulatory element
-namespace time {
-
-  /**
-   * \brief Converts a boost time duration into the number of posix seconds it represents
-   * 
-   * \param duration The duration to convert.
-   * \return The number of posix seconds with microsecond resolution
-   */ 
-  double toSec(const boost::posix_time::time_duration& duration);
-  
-  /**
-   * \brief Converts a boost time duration into the number of posix seconds since 1970
-   * 
-   * \param duration The duration to convert.
-   * \return The number of posix seconds since 1970 with microsecond resolution
-   */ 
-  double toSec(const boost::posix_time::ptime& time);
-
-  /**
-   * \brief Returns a boost posix time object which matches the input posix seconds since 1970 with microsecond accuracy.
-   * 
-   * \param sec The number of posix seconds since 1970. Fractional seconds are supported.
-   * \return Initialized posix time object matching the input
-   */ 
-  boost::posix_time::ptime timeFromSec(double sec);
-
-  /**
-   * \brief Returns a boost posix time object which matches the input posix seconds duration with microsecond accuracy.
-   * 
-   * \param sec The number of posix seconds the duration should reflect. Fractional seconds are supported.
-   * \return Initialized posix time duration object matching the input
-   */ 
-  boost::posix_time::time_duration durationFromSec(double sec);
-}
-
 /**
  * \brief Stream operator for CarmaTrafficSignalState enum.
  */

--- a/common/lanelet2_extension/include/lanelet2_extension/regulatory_elements/CarmaTrafficSignal.h
+++ b/common/lanelet2_extension/include/lanelet2_extension/regulatory_elements/CarmaTrafficSignal.h
@@ -19,6 +19,7 @@
 
 #include <lanelet2_core/primitives/RegulatoryElement.h>
 #include <boost/date_time/posix_time/posix_time.hpp>
+#include <lanelet2_extension/time/TimeConversion.h>
 #include <unordered_map>
 
 namespace lanelet

--- a/common/lanelet2_extension/include/lanelet2_extension/time/TimeConversion.h
+++ b/common/lanelet2_extension/include/lanelet2_extension/time/TimeConversion.h
@@ -1,0 +1,34 @@
+#pragma once
+/*
+ * Copyright (C) 2022 LEIDOS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+#include <boost/date_time/posix_time/posix_time.hpp>
+
+namespace lanelet
+{
+
+namespace time {
+
+double toSec(const boost::posix_time::time_duration& duration);
+
+double toSec(const boost::posix_time::ptime& time);
+
+boost::posix_time::ptime timeFromSec(double sec);
+
+boost::posix_time::time_duration durationFromSec(double sec);
+
+} // namespace time
+
+}  // namespace lanelet

--- a/common/lanelet2_extension/include/lanelet2_extension/time/TimeConversion.h
+++ b/common/lanelet2_extension/include/lanelet2_extension/time/TimeConversion.h
@@ -21,9 +21,9 @@ namespace lanelet
 
 namespace time {
 
-double lanelet::time::toSec(const boost::posix_time::time_duration& duration);
+double toSec(const boost::posix_time::time_duration& duration);
 
-double lanelet::time::toSec(const boost::posix_time::ptime& time);
+double toSec(const boost::posix_time::ptime& time);
 
 boost::posix_time::ptime timeFromSec(double sec);
 

--- a/common/lanelet2_extension/include/lanelet2_extension/time/TimeConversion.h
+++ b/common/lanelet2_extension/include/lanelet2_extension/time/TimeConversion.h
@@ -21,9 +21,9 @@ namespace lanelet
 
 namespace time {
 
-double toSec(const boost::posix_time::time_duration& duration);
+double lanelet::time::toSec(const boost::posix_time::time_duration& duration);
 
-double toSec(const boost::posix_time::ptime& time);
+double lanelet::time::toSec(const boost::posix_time::ptime& time);
 
 boost::posix_time::ptime timeFromSec(double sec);
 

--- a/common/lanelet2_extension/lib/CarmaTrafficSignal.cpp
+++ b/common/lanelet2_extension/lib/CarmaTrafficSignal.cpp
@@ -18,6 +18,7 @@
 #include <lanelet2_extension/regulatory_elements/CarmaTrafficSignal.h>
 #include <lanelet2_extension/logging/logger.h>
 #include "RegulatoryHelpers.h"
+#include <lanelet2_extension/time/TimeConversion.h>
 
 namespace lanelet
 {
@@ -197,32 +198,6 @@ void CarmaTrafficSignal::setStates(std::vector<std::pair<boost::posix_time::ptim
   fixed_cycle_duration = recorded_time_stamps.back().first - recorded_time_stamps.front().first; // it is okay if size is only 1, case is handled in predictState
   revision_ = revision;
 }
-
-
-namespace time {
-
-double toSec(const boost::posix_time::time_duration& duration) {
-  if (duration.is_special()) {
-    throw std::invalid_argument("Cannot convert special duration to seconds");
-  }
-  return duration.total_microseconds() / 1000000.0;
-}
-
-double toSec(const boost::posix_time::ptime& time) {
-  return toSec(time - boost::posix_time::from_time_t(0));
-}
-
-boost::posix_time::ptime timeFromSec(double sec) {
-  return boost::posix_time::from_time_t(0) + boost::posix_time::microseconds(static_cast<long>(sec * 1000000L));
-}
-
-boost::posix_time::time_duration durationFromSec(double sec) {
-  return boost::posix_time::microseconds(static_cast<long>(sec * 1000000L));
-}
-
-} // namespace time
-
-
 
 namespace
 {

--- a/common/lanelet2_extension/lib/CarmaTrafficSignal.cpp
+++ b/common/lanelet2_extension/lib/CarmaTrafficSignal.cpp
@@ -18,7 +18,6 @@
 #include <lanelet2_extension/regulatory_elements/CarmaTrafficSignal.h>
 #include <lanelet2_extension/logging/logger.h>
 #include "RegulatoryHelpers.h"
-#include <lanelet2_extension/time/TimeConversion.h>
 
 namespace lanelet
 {

--- a/common/lanelet2_extension/lib/CarmaTrafficSignal.cpp
+++ b/common/lanelet2_extension/lib/CarmaTrafficSignal.cpp
@@ -130,8 +130,8 @@ boost::optional<std::pair<boost::posix_time::ptime, CarmaTrafficSignalState>> Ca
   boost::posix_time::time_duration accumulated_offset_duration;
   double offset_duration_dir = recorded_time_stamps.front().first > time_stamp ? -1.0 : 1.0; // -1 if past, +1 if time_stamp is in future
 
-  int num_of_cycles = std::abs(toSec(recorded_time_stamps.front().first - time_stamp) / toSec(fixed_cycle_duration));
-  accumulated_offset_duration = durationFromSec( num_of_cycles * toSec(fixed_cycle_duration));
+  int num_of_cycles = std::abs(lanelet::time::toSec(recorded_time_stamps.front().first - time_stamp) / lanelet::time::toSec(fixed_cycle_duration));
+  accumulated_offset_duration = durationFromSec( num_of_cycles * lanelet::time::toSec(fixed_cycle_duration));
   
   if (offset_duration_dir < 0) 
   {
@@ -143,8 +143,8 @@ boost::optional<std::pair<boost::posix_time::ptime, CarmaTrafficSignalState>> Ca
   // iterate through states in the cycle to get the signal
   for (size_t i = 0; i < recorded_time_stamps.size(); i++)
   {
-    double end_time = toSec(recorded_time_stamps[i].first) + offset_duration_dir * toSec(accumulated_offset_duration);
-    if (end_time >= toSec(time_stamp))
+    double end_time = lanelet::time::toSec(recorded_time_stamps[i].first) + offset_duration_dir * lanelet::time::toSec(accumulated_offset_duration);
+    if (end_time >= lanelet::time::toSec(time_stamp))
     { 
       return std::pair<boost::posix_time::ptime, CarmaTrafficSignalState>(timeFromSec(end_time), recorded_time_stamps[i].second);
     }

--- a/common/lanelet2_extension/lib/TimeConversion.cpp
+++ b/common/lanelet2_extension/lib/TimeConversion.cpp
@@ -22,15 +22,15 @@ namespace lanelet
 
 namespace time {
 
-double lanelet::time::toSec(const boost::posix_time::time_duration& duration) {
+double toSec(const boost::posix_time::time_duration& duration) {
   if (duration.is_special()) {
     throw std::invalid_argument("Cannot convert special duration to seconds");
   }
   return duration.total_microseconds() / 1000000.0;
 }
 
-double lanelet::time::toSec(const boost::posix_time::ptime& time) {
-  return lanelet::time::toSec(time - boost::posix_time::from_time_t(0));
+double toSec(const boost::posix_time::ptime& time) {
+  return toSec(time - boost::posix_time::from_time_t(0));
 }
 
 boost::posix_time::ptime timeFromSec(double sec) {

--- a/common/lanelet2_extension/lib/TimeConversion.cpp
+++ b/common/lanelet2_extension/lib/TimeConversion.cpp
@@ -22,15 +22,15 @@ namespace lanelet
 
 namespace time {
 
-double toSec(const boost::posix_time::time_duration& duration) {
+double lanelet::time::toSec(const boost::posix_time::time_duration& duration) {
   if (duration.is_special()) {
     throw std::invalid_argument("Cannot convert special duration to seconds");
   }
   return duration.total_microseconds() / 1000000.0;
 }
 
-double toSec(const boost::posix_time::ptime& time) {
-  return toSec(time - boost::posix_time::from_time_t(0));
+double lanelet::time::toSec(const boost::posix_time::ptime& time) {
+  return lanelet::time::toSec(time - boost::posix_time::from_time_t(0));
 }
 
 boost::posix_time::ptime timeFromSec(double sec) {

--- a/common/lanelet2_extension/lib/TimeConversion.cpp
+++ b/common/lanelet2_extension/lib/TimeConversion.cpp
@@ -1,0 +1,46 @@
+
+/*
+ * Copyright (C) 2022 LEIDOS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+#include <boost/date_time/posix_time/posix_time.hpp>
+#include <lanelet2_extension/time/TimeConversion.h>
+
+namespace lanelet
+{
+
+namespace time {
+
+double toSec(const boost::posix_time::time_duration& duration) {
+  if (duration.is_special()) {
+    throw std::invalid_argument("Cannot convert special duration to seconds");
+  }
+  return duration.total_microseconds() / 1000000.0;
+}
+
+double toSec(const boost::posix_time::ptime& time) {
+  return toSec(time - boost::posix_time::from_time_t(0));
+}
+
+boost::posix_time::ptime timeFromSec(double sec) {
+  return boost::posix_time::from_time_t(0) + boost::posix_time::microseconds(static_cast<long>(sec * 1000000L));
+}
+
+boost::posix_time::time_duration durationFromSec(double sec) {
+  return boost::posix_time::microseconds(static_cast<long>(sec * 1000000L));
+}
+
+} // namespace time
+
+}  // namespace lanelet


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
Supports this PR https://github.com/usdot-fhwa-stol/carma-platform/pull/1792
Simply refactoring utility time conversion code to be usable on other places.

## Related Issue
https://github.com/usdot-fhwa-stol/carma-platform/pull/1792
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
See above
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Unit tested
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have added any new packages to the sonar-scanner.properties file
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.