### PR TITLE
Increase hardcoded acceleration limit for simulation

### DIFF
--- a/common/hardcoded_params/include/hardcoded_params/control_limits/control_limits.h
+++ b/common/hardcoded_params/include/hardcoded_params/control_limits/control_limits.h
@@ -21,9 +21,19 @@ namespace hardcoded_params
 namespace control_limits
 {
 /**
- * The maximum allowable longitudinal velocity of the vehicle in m/s 
+ * The maximum allowable longitudinal velocity of the vehicle in m/s
  */
 constexpr double MAX_LONGITUDINAL_VELOCITY_MPS = 35.7632;
 constexpr double MAX_LONGITUDINAL_ACCEL_MPS2 = 3.5;
+
+/**
+* The maximum allowable simulation parameters
+* At the time of writing this, platform uses CARLA 0.9.10 as the vehicle's physics simulator.
+* CARLA's this version uses below hardcoded value for its vehicles (so even if increasing this value,
+* actual simulation won't support larger values unless forked and compiled)
+* https://github.com/carla-simulator/ros-bridge/blob/0.9.10.1/carla_ackermann_control/src/carla_ackermann_control/carla_control_physics.py#L254
+*/
+constexpr double MAX_SIMULATION_LONGITUDINAL_ACCEL_MPS2 = 8.0;
+
 }
 }  // namespace hardcoded_params

--- a/common/hardcoded_params/include/hardcoded_params/control_limits/control_limits.h
+++ b/common/hardcoded_params/include/hardcoded_params/control_limits/control_limits.h
@@ -29,7 +29,7 @@ constexpr double MAX_LONGITUDINAL_ACCEL_MPS2 = 3.5;
 /**
 * The maximum allowable simulation parameters
 * At the time of writing this, platform uses CARLA 0.9.10 as the vehicle's physics simulator.
-* CARLA's this version uses below hardcoded value for its vehicles (so even if increasing this value,
+* CARLA 0.9.10 uses below hardcoded value for its vehicles (so even if increasing this value,
 * actual simulation won't support larger values unless forked and compiled)
 * https://github.com/carla-simulator/ros-bridge/blob/0.9.10.1/carla_ackermann_control/src/carla_ackermann_control/carla_control_physics.py#L254
 */

--- a/core_planning/twist_filter/include/accel_limiter.hpp
+++ b/core_planning/twist_filter/include/accel_limiter.hpp
@@ -8,10 +8,12 @@
 namespace twist_filter{
 
 constexpr double MAX_LONGITUDINAL_ACCEL_HARDCODED_LIMIT_M_S_2 = hardcoded_params::control_limits::MAX_LONGITUDINAL_ACCEL_MPS2;
+constexpr double MAX_SIMULATION_LONGITUDINAL_ACCEL_HARDCODED_LIMIT_M_S_2 = hardcoded_params::control_limits::MAX_SIMULATION_LONGITUDINAL_ACCEL_MPS2;
+
 
 class LongitudinalAccelLimiter
 {
-    public: 
+    public:
         /**
          * Default constructor, not recommended for use.
          */
@@ -24,7 +26,7 @@ class LongitudinalAccelLimiter
 
         /**
          * \brief Constructor for LongitudinalAccelLimiter
-         * 
+         *
          * \param accel_limit The acceleration limit that should be enforced, in
          * units of m/s/s
          */
@@ -32,13 +34,13 @@ class LongitudinalAccelLimiter
             _accel_limit(accel_limit),
             _initialized(false),
             _prev_v(0.0),
-            _prev_t(0.0) {};  
+            _prev_t(0.0) {};
 
         /**
          * Limit the longitudinal acceleration found in the input ControlCommandStamped
-         * 
+         *
          * \param msg The message to be evaluated
-         * \return A copy of the message with the longitudinal accel limited 
+         * \return A copy of the message with the longitudinal accel limited
          * based on params or hardcoded limit
          */
         autoware_msgs::msg::ControlCommandStamped
@@ -46,9 +48,9 @@ class LongitudinalAccelLimiter
 
                 /**
          * Limit the longitudinal acceleration found in the input TwistStamped
-         * 
+         *
          * \param msg The message to be evaluated
-         * \return A copy of the message with the longitudinal accel limited 
+         * \return A copy of the message with the longitudinal accel limited
          * based on params or hardcoded limit
          */
         geometry_msgs::msg::TwistStamped
@@ -58,7 +60,7 @@ class LongitudinalAccelLimiter
         double _accel_limit;
         bool _initialized;
         double _prev_v;
-        rclcpp::Time _prev_t; 
+        rclcpp::Time _prev_t;
 };
 
 }

--- a/core_planning/twist_filter/include/twist_filter.hpp
+++ b/core_planning/twist_filter/include/twist_filter.hpp
@@ -19,7 +19,7 @@
  * Modifications:
  * - Added limiting for longitudinal velocity per CARMA specifications. Refactored
  *   namespacing and header as needed to support unit testing.
- *   - Kyle Rush 
+ *   - Kyle Rush
  *   - 9/11/2020
  * - Refactored for ros2
  *    - 11/16/2022
@@ -75,12 +75,12 @@ private:
     carma_ros2_utils::PubPtr<std_msgs::msg::Float32> ctrl_lacc_limit_debug_pub_, ctrl_ljerk_limit_debug_pub_;
     carma_ros2_utils::PubPtr<std_msgs::msg::Float32> twist_lacc_result_pub_, twist_ljerk_result_pub_;
     carma_ros2_utils::PubPtr<std_msgs::msg::Float32> ctrl_lacc_result_pub_, ctrl_ljerk_result_pub_;
-    
+
     //subscribers
     carma_ros2_utils::SubPtr<geometry_msgs::msg::TwistStamped> twist_sub_;
     carma_ros2_utils::SubPtr<autoware_msgs::msg::ControlCommandStamped> ctrl_sub_;
     carma_ros2_utils::SubPtr<autoware_config_msgs::msg::ConfigTwistFilter> config_sub_;
-    
+
     //ros params
     double wheel_base_;
     double longitudinal_velocity_limit_;

--- a/core_planning/twist_filter/src/twist_filter.cpp
+++ b/core_planning/twist_filter/src/twist_filter.cpp
@@ -65,11 +65,11 @@ carma_ros2_utils::CallbackReturn TwistFilter::handle_on_configure(const rclcpp_l
   if (use_sim_time)
   {
     hardcoded_acceleration_limit = MAX_SIMULATION_LONGITUDINAL_ACCEL_HARDCODED_LIMIT_M_S_2;
-    RCLCPP_INFO_STREAM(rclcpp::get_logger("logger"), "Simulation mode detected. Accounting hardcoded limit longitudinal acceleration limit used: " << hardcoded_acceleration_limit);
+    RCLCPP_INFO_STREAM(get_logger(), "Simulation mode detected. Accounting for hardcoded limit, longitudinal acceleration limit used: " << hardcoded_acceleration_limit);
   }
   else
   {
-    RCLCPP_INFO_STREAM(rclcpp::get_logger("logger"), "Accounting hardcoded limit, longitudinal acceleration limit used: " << hardcoded_acceleration_limit);
+    RCLCPP_INFO_STREAM(get_logger(), "Accounting for hardcoded limit, longitudinal acceleration limit used: " << hardcoded_acceleration_limit);
   }
 
   _lon_accel_limiter = LongitudinalAccelLimiter{


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
Increasing the hardcoded acceleration limit so that we can test more range of motion in simulation. 
<!--- Describe your changes in detail -->

## Related GitHub Issue
N/A
<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key
https://usdot-carma.atlassian.net/browse/CDAR-825
<!-- e.g. CAR-123 -->

## Motivation and Context
vru use case 1 verification testing prep
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
sim pc 1
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
