### PR TITLE
fix georef

### DIFF
--- a/common/map_file_ros2/nodes/map_param_loader/map_param_loader.cpp
+++ b/common/map_file_ros2/nodes/map_param_loader/map_param_loader.cpp
@@ -23,24 +23,14 @@ namespace map_param_loader
 
   MapParamLoader::MapParamLoader(const rclcpp::NodeOptions &options) : carma_ros2_utils::CarmaLifecycleNode(options)
   {
-    
+
   }
 
   carma_ros2_utils::CallbackReturn MapParamLoader::handle_on_configure(const rclcpp_lifecycle::State &)
   {
     lanelet2_filename = declare_parameter<std::string>("file_name", lanelet2_filename);
     broadcast_earth_frame = declare_parameter<bool>("broadcast_earth_frame", broadcast_earth_frame);
-
-    // NOTE: Currently, intra-process comms must be disabled for the following two publishers that are transient_local: https://github.com/ros2/rclcpp/issues/1753
-    rclcpp::PublisherOptions intra_proc_disabled; 
-    intra_proc_disabled.use_intra_process_comm = rclcpp::IntraProcessSetting::Disable; // Disable intra-process comms for this PublisherOptions object
-
-    // Create a publisher that will send all previously published messages to late-joining subscribers ONLY If the subscriber is transient_local too
-    auto pub_qos_transient_local = rclcpp::QoS(rclcpp::KeepAll()); // A publisher with this QoS will store all messages that it has sent on the topic
-    pub_qos_transient_local.transient_local();  // A publisher with this QoS will re-send all (when KeepAll is used) messages to all late-joining subscribers 
-                                         // NOTE: The subscriber's QoS must be set to transient_local() as well for earlier messages to be resent to the later-joiner.
-
-    georef_pub_ = this->create_publisher<std_msgs::msg::String>("georeference",  pub_qos_transient_local, intra_proc_disabled);
+    georef_pub_ = this->create_publisher<std_msgs::msg::String>("georeference", 1);
 
     return CallbackReturn::SUCCESS;
   }
@@ -57,11 +47,11 @@ namespace map_param_loader
       tf2::Transform tf = getTransform(target_frame_);
 
       // Broadcast the transform
-      broadcastTransform(tf);  
+      broadcastTransform(tf);
     }
 
     timer_ = this->create_wall_timer(std::chrono::milliseconds(500), std::bind(&MapParamLoader::timer_callback, this));
-    
+
     return CallbackReturn::SUCCESS;
   }
 
@@ -78,7 +68,7 @@ namespace map_param_loader
   {
 
     lanelet::projection::LocalFrameProjector local_projector(map_frame.c_str());
-    
+
     tf2::Matrix3x3 rot_mat, id = tf2::Matrix3x3::getIdentity();
     lanelet::BasicPoint3d origin_in_map{0,0,0}, origin_in_ecef;
 
@@ -97,7 +87,7 @@ namespace map_param_loader
     // Transpose due to the way tf2::Matrix3x3 supposed to be stored.
     tf2::Vector3 v_origin_in_ecef{origin_in_ecef[0],origin_in_ecef[1],origin_in_ecef[2]};
     tf2::Transform tf(rot_mat.transpose(), v_origin_in_ecef);
-    
+
     // map_to_ecef tf
     return tf;
   }


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
Fixing the QOS of georeference. 
Merging to carma-develop, so later I can merge to develop-humble
All nodes are created with different QOS subscriptions. And sometimes the nodes can miss this important data and shut down (GNSStoMapConvertor etc.). Maybe it worked in foxy, but not in humble

to QOS mismatch, 
<!--- Describe your changes in detail -->

## Related GitHub Issue
NA
<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key
ARC-175
<!-- e.g. CAR-123 -->

## Motivation and Context
ROS2 Humble System launch. 
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Black Pacifica
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
